### PR TITLE
Dont strip html from introductions when piping

### DIFF
--- a/eq-publisher/src/eq_schema/Block.js
+++ b/eq-publisher/src/eq_schema/Block.js
@@ -1,7 +1,10 @@
 const Question = require("./Question");
 const RoutingRule = require("./RoutingRule");
 const RoutingDestination = require("./RoutingDestination");
-const { getInnerHTMLWithPiping } = require("../utils/HTMLUtils");
+const {
+  getInnerHTMLWithPiping,
+  unescapePiping
+} = require("../utils/HTMLUtils");
 const convertPipes = require("../utils/convertPipes");
 const { get, isNil, remove, isEmpty } = require("lodash");
 const { flow, getOr, last, map, some } = require("lodash/fp");
@@ -16,10 +19,16 @@ const getLastPage = flow(
   last
 );
 
-const processPipedText = ctx =>
+const processPipedTitle = ctx =>
   flow(
     convertPipes(ctx),
     getInnerHTMLWithPiping
+  );
+
+const processPipedText = ctx =>
+  flow(
+    convertPipes(ctx),
+    unescapePiping
   );
 
 const isLastPageInSection = (page, ctx) =>
@@ -58,7 +67,7 @@ class Block {
     return {
       type: "Interstitial",
       id: `group${groupId}-introduction`,
-      title: processPipedText(ctx)(introductionTitle) || "",
+      title: processPipedTitle(ctx)(introductionTitle) || "",
       description: processPipedText(ctx)(introductionContent) || ""
     };
   }

--- a/eq-publisher/src/eq_schema/Block.test.js
+++ b/eq-publisher/src/eq_schema/Block.test.js
@@ -89,13 +89,21 @@ describe("Block", () => {
   });
 
   describe("piping", () => {
-    const createPipe = ({
+    const createPipeInText = ({
       id = 123,
       type = "TextField",
       text = "foo",
       pipeType = "answers"
     } = {}) =>
       `<span data-piped="${pipeType}" data-id="${id}" data-type="${type}">${text}</span>`;
+
+    const createPipeInHtml = ({
+      id = 123,
+      type = "TextField",
+      text = "foo",
+      pipeType = "answers"
+    } = {}) =>
+      `<strong><span data-piped="${pipeType}" data-id="${id}" data-type="${type}">${text}</span></strong><ul><li>Some Value</li></ul>`;
 
     const createContext = (
       metadata = [{ id: "123", type: "Text", key: "my_metadata" }]
@@ -108,7 +116,23 @@ describe("Block", () => {
     it("should handle piped values in title", () => {
       // noinspection JSAnnotator
       let introduction = {
-        introductionTitle: createPipe(),
+        introductionTitle: createPipeInText(),
+        introductionContent: ""
+      };
+
+      const introBlock = Block.buildIntroBlock(
+        introduction,
+        0,
+        createContext()
+      );
+
+      expect(introBlock.title).toEqual("{{ answers['answer123'] }}");
+    });
+
+    it("should handle piped values in title while stripping html", () => {
+      // noinspection JSAnnotator
+      let introduction = {
+        introductionTitle: createPipeInHtml(),
         introductionContent: ""
       };
 
@@ -125,7 +149,7 @@ describe("Block", () => {
       // noinspection JSAnnotator
       let introduction = {
         introductionTitle: "",
-        introductionContent: createPipe()
+        introductionContent: createPipeInHtml()
       };
 
       const introBlock = Block.buildIntroBlock(
@@ -134,7 +158,9 @@ describe("Block", () => {
         createContext()
       );
 
-      expect(introBlock.description).toEqual("{{ answers['answer123'] }}");
+      expect(introBlock.description).toEqual(
+        "<strong>{{ answers['answer123'] }}</strong><ul><li>Some Value</li></ul>"
+      );
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Publisher was stripping some of the HTML out of the description when published.

This PR limits that change to just inserting the piped values.

### How to review 
Add a formatted section introduction and see that the formatting and piping still work
