### PR TITLE
Bug - 738 - Do not show errors for optional fields description and guidance

### DIFF
--- a/eq-author/src/components/PreviewPageRoute/index.js
+++ b/eq-author/src/components/PreviewPageRoute/index.js
@@ -86,18 +86,14 @@ export const UnwrappedPreviewPageRoute = ({ loading, data }) => {
           )}
         </PageTitle>
 
-        {rteIsEmpty(description) ? (
-          <Error large>Missing description</Error>
-        ) : (
+        {!rteIsEmpty(description) && (
           <Description
             data-test="description"
             dangerouslySetInnerHTML={{ __html: description }}
           />
         )}
 
-        {rteIsEmpty(guidance) ? (
-          <Error large>Missing guidance</Error>
-        ) : (
+        {!rteIsEmpty(guidance) && (
           <Guidance data-test="guidance">
             <Panel dangerouslySetInnerHTML={{ __html: guidance }} />
           </Guidance>


### PR DESCRIPTION
### What is the context of this PR?
Remove errors shown for optional description and guidance on question preview.

### How to review 
1. Add a question
1. View preview and ensure there are no errors shown for missing guidance and description.
