### PR TITLE
Fixed confirmation title bug

### DIFF
--- a/eq-author/src/components/QuestionConfirmationRoute/Editor.js
+++ b/eq-author/src/components/QuestionConfirmationRoute/Editor.js
@@ -48,6 +48,7 @@ export class UnwrappedEditor extends React.Component {
       <Wrapper>
         <RichTextEditor
           id="confirmation-title"
+          name="title"
           label="Confirmation question"
           value={title}
           onUpdate={this.handleRichTextUpdate}

--- a/eq-author/src/components/QuestionConfirmationRoute/__snapshots__/Editor.test.js.snap
+++ b/eq-author/src/components/QuestionConfirmationRoute/__snapshots__/Editor.test.js.snap
@@ -14,6 +14,7 @@ exports[`Editor Editor Component should autoFocus the title when there is not on
     id="confirmation-title"
     label="Confirmation question"
     multiline={false}
+    name="title"
     onUpdate={[Function]}
     placeholder=""
     size="large"
@@ -65,6 +66,7 @@ exports[`Editor Editor Component should render 1`] = `
     id="confirmation-title"
     label="Confirmation question"
     multiline={false}
+    name="title"
     onUpdate={[Function]}
     placeholder=""
     size="large"

--- a/eq-author/src/components/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/components/QuestionPageEditor/MetaEditor.js
@@ -95,7 +95,8 @@ export class StatelessMetaEditor extends React.Component {
           </Alias>
         </Padding>
         <RichTextEditor
-          id="title"
+          id="question-title"
+          name="title"
           label="Question"
           value={page.title}
           onUpdate={handleUpdate}
@@ -107,7 +108,8 @@ export class StatelessMetaEditor extends React.Component {
         />
 
         <RichTextEditor
-          id="description"
+          id="question-description"
+          name="description"
           label="Question description (optional)…"
           value={page.description}
           onUpdate={handleUpdate}
@@ -119,7 +121,8 @@ export class StatelessMetaEditor extends React.Component {
         />
 
         <GuidanceEditor
-          id="guidance"
+          id="question-guidance"
+          name="guidance"
           label="Include and exclude guidance"
           value={page.guidance}
           onUpdate={handleUpdate}

--- a/eq-author/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/eq-author/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -37,10 +37,11 @@ exports[`MetaEditor should render 1`] = `
       }
     }
     fetchAnswers={[Function]}
-    id="title"
+    id="question-title"
     label="Question"
     metadata={Array []}
     multiline={false}
+    name="title"
     onUpdate={[Function]}
     placeholder=""
     size="large"
@@ -57,10 +58,11 @@ exports[`MetaEditor should render 1`] = `
       }
     }
     fetchAnswers={[Function]}
-    id="description"
+    id="question-description"
     label="Question description (optional)…"
     metadata={Array []}
     multiline={true}
+    name="description"
     onUpdate={[Function]}
     placeholder=""
     testSelector="txt-question-description"
@@ -76,10 +78,11 @@ exports[`MetaEditor should render 1`] = `
       }
     }
     fetchAnswers={[Function]}
-    id="guidance"
+    id="question-guidance"
     label="Include and exclude guidance"
     metadata={Array []}
     multiline={true}
+    name="guidance"
     onUpdate={[Function]}
     testSelector="txt-question-guidance"
     value="Page guidance"

--- a/eq-author/src/components/RichTextEditor/RichTextEditor.story.js
+++ b/eq-author/src/components/RichTextEditor/RichTextEditor.story.js
@@ -73,6 +73,7 @@ const props = {
   label: "Enter some text",
   placeholder: "Enter some text...",
   id: "richtext",
+  name: "richtext",
   sectionId: "1",
   client
 };

--- a/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
@@ -34,7 +34,8 @@ describe("components/RichTextEditor", function() {
     props = {
       onUpdate: jest.fn(),
       label: "I am a label",
-      id: "test"
+      id: "test",
+      name: "test-name"
     };
     editorInstance = {
       focus: jest.fn()
@@ -115,7 +116,7 @@ describe("components/RichTextEditor", function() {
   it("should call onUpdate with raw editor state onBlur", () => {
     wrapper.find("[data-test='rte-field']").simulate("blur");
     expect(props.onUpdate).toHaveBeenCalledWith({
-      name: "test",
+      name: "test-name",
       value: "<p></p>"
     });
   });

--- a/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -115,6 +115,7 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
           }
         }
         isActiveControl={[Function]}
+        name="test-name"
         onPiping={[Function]}
         onToggle={[Function]}
         onUpdate={[MockFunction]}
@@ -402,6 +403,7 @@ exports[`components/RichTextEditor should render 1`] = `
           }
         }
         isActiveControl={[Function]}
+        name="test-name"
         onPiping={[Function]}
         onToggle={[Function]}
         onUpdate={[MockFunction]}
@@ -740,6 +742,7 @@ exports[`components/RichTextEditor should render existing content 1`] = `
           }
         }
         isActiveControl={[Function]}
+        name="test-name"
         onPiping={[Function]}
         onToggle={[Function]}
         onUpdate={[MockFunction]}

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -130,7 +130,7 @@ class RichTextEditor extends React.Component {
     onUpdate: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    name: PropTypes.string,
+    name: PropTypes.string.isRequired,
     className: PropTypes.string,
     multiline: PropTypes.bool,
     size: PropTypes.oneOf(Object.keys(sizes)),
@@ -339,7 +339,7 @@ class RichTextEditor extends React.Component {
 
   handleBlur = () => {
     this.props.onUpdate({
-      name: this.props.name ? this.props.name : this.props.id,
+      name: this.props.name,
       value: this.getHTML()
     });
 

--- a/eq-author/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/eq-author/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -50,9 +50,10 @@ exports[`SectionEditor should render 1`] = `
           "emphasis": true,
         }
       }
-      id="title"
+      id="section-title"
       label="Title"
       multiline={false}
+      name="title"
       onUpdate={[Function]}
       placeholder=""
       size="large"
@@ -113,9 +114,10 @@ exports[`SectionEditor should render 2`] = `
           "emphasis": true,
         }
       }
-      id="title"
+      id="section-title"
       label="Title"
       multiline={false}
+      name="title"
       onUpdate={[Function]}
       placeholder=""
       size="large"

--- a/eq-author/src/components/SectionEditor/index.js
+++ b/eq-author/src/components/SectionEditor/index.js
@@ -133,7 +133,8 @@ export class UnwrappedSectionEditor extends React.Component {
         </Padding>
         <Padding>
           <RichTextEditor
-            id="title"
+            id="section-title"
+            name="title"
             label="Title"
             value={section.title}
             onUpdate={handleUpdate}


### PR DESCRIPTION
### What is the context of this PR?
Small bug where the id of a field didn't match the field name of the graphql query i.e rather than sending title:"foo" to the mutation it was instead sending confirmation-title:"foo" meaning that title was null. 

This is a quick fix for this issue but was wondering if instead we needed to me a bit more though and add a required proptype to the RTE of `graphqlFieldName` this might mean we could use less generic ids as well as I think there are a few places where we have different RTE's with an id of "title".

### How to review 
Not sure how to test for this as the cypress test will all pass due to just asserting that the stuff held in the inputs state is correct and they dont make sure that stuff has been stored in the db. Any ideas?
