### PR TITLE
Fix indentation of branch in yaml config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ deploy:
 
 branches:
   only:
-  - master
+    - master


### PR DESCRIPTION
### What is the context of this PR?
Since #36 was merged the master branch has stopped building on Travis.
I think this may be due to incorrect indentation within the travis Yaml file.
This PR aims to correct.

### How to review 
YAML looks correct.
