### PR TITLE
Fixed small bug in metadata piping

### DIFF
--- a/eq-author-api/repositories/QuestionPageRepository.js
+++ b/eq-author-api/repositories/QuestionPageRepository.js
@@ -81,7 +81,7 @@ module.exports.getPipingAnswersForQuestionPage = id =>
 
 module.exports.getPipingMetadataForQuestionPage = id =>
   knex("Metadata")
-    .select()
+    .select("Metadata.*")
     .join("Questionnaires", "Metadata.questionnaireId", "Questionnaires.id")
     .join("SectionsView", "SectionsView.questionnaireId", "Questionnaires.id")
     .join("PagesView", "PagesView.sectionId", "SectionsView.id")

--- a/eq-author-api/repositories/QuestionPageRepository.test.js
+++ b/eq-author-api/repositories/QuestionPageRepository.test.js
@@ -20,6 +20,8 @@ const {
   TEXT: METADATA_TEXT
 } = require("../constants/metadataTypes");
 
+const { getName } = require("../utils/getName");
+
 describe("QuestionPageRepository", () => {
   beforeAll(() => db.migrate.latest());
   afterAll(() => db.destroy());
@@ -158,8 +160,8 @@ describe("QuestionPageRepository", () => {
     beforeEach(async () => {
       questionnaire = await buildTestQuestionnaire({
         metadata: [
-          { key: "metadata_date", type: METADATA_DATE },
-          { key: "metadata_text", type: METADATA_TEXT }
+          { key: "metadata_date", alias: "metadata date", type: METADATA_DATE },
+          { key: "metadata_text", alias: "metadata text", type: METADATA_TEXT }
         ],
         sections: [
           {
@@ -188,6 +190,9 @@ describe("QuestionPageRepository", () => {
           key: "metadata_date"
         })
       ]);
+
+      expect(getName(metadata[0], "Metadata")).toEqual("metadata text");
+      expect(getName(metadata[1], "Metadata")).toEqual("metadata date");
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
There was a small bug in the piping of metadata due to the query requesting too many fields meaning that the get name function got confused and would end up returning a pointer to the current field in the content picker rather than the individual piece of metadata. 

### How to review 
Change makes sense, new assertions pass and the piping of metadata now works as expected.
