### PR TITLE
Fix slow connection removing section title

### DIFF
--- a/eq-author/src/components/IntroEditor/index.js
+++ b/eq-author/src/components/IntroEditor/index.js
@@ -9,7 +9,6 @@ import { raiseToast } from "redux/toast/actions";
 
 import MainCanvas from "components/MainCanvas";
 import IconButtonDelete from "components/IconButtonDelete";
-import withEntityEditor from "components/withEntityEditor";
 import Button from "components/Button";
 import IconText from "components/IconText";
 import AddPage from "components/QuestionnaireDesignPage/icon-add-page.svg?inline";
@@ -20,7 +19,6 @@ import { TransitionGroup } from "react-transition-group";
 
 import { colors, radius } from "constants/theme";
 
-import sectionFragment from "graphql/fragments/section.graphql";
 import withDeleteSectionIntro from "containers/enhancers/withDeleteSectionIntro";
 
 const StyledMainCanvas = styled(MainCanvas)`
@@ -145,6 +143,4 @@ const wrappedSectionIntro = flowRight(
   withDeleteSectionIntro
 )(UnwrappedIntroEditor);
 
-export default withEntityEditor("section", sectionFragment)(
-  wrappedSectionIntro
-);
+export default wrappedSectionIntro;

--- a/eq-author/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/eq-author/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -61,6 +61,16 @@ exports[`SectionEditor should render 1`] = `
       value="Section 1"
     />
   </SectionEditor__Padding>
+  <Connect(Apollo(UnwrappedIntroEditor))
+    onChange={[MockFunction]}
+    onUpdate={[MockFunction]}
+    section={
+      Object {
+        "id": "section-1",
+        "title": "Section 1",
+      }
+    }
+  />
 </SectionEditor__SectionCanvas>
 `;
 
@@ -125,5 +135,15 @@ exports[`SectionEditor should render 2`] = `
       value="Section 2"
     />
   </SectionEditor__Padding>
+  <Connect(Apollo(UnwrappedIntroEditor))
+    onChange={[MockFunction]}
+    onUpdate={[MockFunction]}
+    section={
+      Object {
+        "id": "section-2",
+        "title": "Section 2",
+      }
+    }
+  />
 </SectionEditor__SectionCanvas>
 `;

--- a/eq-author/src/components/SectionEditor/index.js
+++ b/eq-author/src/components/SectionEditor/index.js
@@ -12,6 +12,7 @@ import WrappingInput from "components/WrappingInput";
 import MoveSectionModal from "components/MoveSectionModal";
 import MoveSectionQuery from "components/MoveSectionModal/MoveSectionQuery";
 import CharacterCounter from "components/CharacterCounter";
+import IntroEditor from "components/IntroEditor";
 
 import { colors, radius } from "constants/theme";
 
@@ -143,11 +144,15 @@ export class UnwrappedSectionEditor extends React.Component {
             testSelector="txt-section-title"
           />
         </Padding>
+        <IntroEditor
+          onUpdate={onUpdate}
+          section={section}
+          onChange={onChange}
+        />
       </SectionCanvas>
     );
   }
 }
-
 UnwrappedSectionEditor.fragments = {
   Section: sectionFragment
 };

--- a/eq-author/src/components/SectionRoute/index.js
+++ b/eq-author/src/components/SectionRoute/index.js
@@ -16,7 +16,6 @@ import Button from "components/Button";
 import IconText from "components/IconText";
 import EditorLayout from "components/EditorLayout";
 import DuplicateButton from "components/DuplicateButton";
-import IntroEditor from "components/IntroEditor";
 
 import withDeleteSection from "containers/enhancers/withDeleteSection";
 import withUpdateSection from "containers/enhancers/withUpdateSection";
@@ -163,12 +162,6 @@ export class UnwrappedSectionRoute extends React.Component {
           onMoveSectionDialog={this.handleMoveSection}
           {...this.props}
         />
-        {data.section && (
-          <IntroEditor
-            onUpdate={this.props.onUpdateSection}
-            section={data.section}
-          />
-        )}
       </Titled>
     );
   }


### PR DESCRIPTION
### What is the context of this PR?
When using Author on a slower connection there is a race condition with the section introduction where adding section title and then adding a section introduction would remove the section title. This is to remove the second entity editor on the page so that the section introduction is controlled by the section one

### How to review 
- Run tests
- Throttle connection to slow 3g
- Create a new section
- Add a section title
- Add a section introduction
- Make sure section title doesn't disappear
- Make sure all other parts of the section introduction still work (delete, undo delete, etc)
