### PR TITLE
Implemented automatic piping of checkbox answers

### DIFF
--- a/eq-publisher/src/constants/answerTypes.js
+++ b/eq-publisher/src/constants/answerTypes.js
@@ -1,0 +1,19 @@
+const CHECKBOX = "Checkbox";
+const RADIO = "Radio";
+const TEXTFIELD = "TextField";
+const TEXTAREA = "TextArea";
+const CURRENCY = "Currency";
+const NUMBER = "Number";
+const DATE = "Date";
+const DATE_RANGE = "DateRange";
+
+module.exports = {
+  CHECKBOX,
+  RADIO,
+  TEXTFIELD,
+  TEXTAREA,
+  CURRENCY,
+  NUMBER,
+  DATE,
+  DATE_RANGE
+};

--- a/eq-publisher/src/eq_schema/Group.test.js
+++ b/eq-publisher/src/eq_schema/Group.test.js
@@ -511,5 +511,48 @@ describe("Group", () => {
         expectedRunnerRouting
       );
     });
+
+    it("pipes in checkbox values from the previous questions", () => {
+      const ctx = ctxGenerator(null);
+
+      ctx.questionnaireJson.sections[0].pages[0].answers[0] = {
+        id: "6",
+        type: "Checkbox",
+        label: "Test",
+        description: "",
+        guidance: "",
+        options: [
+          {
+            id: "Foo",
+            label: "Foo"
+          },
+          {
+            id: "Bar",
+            label: "Bar"
+          },
+          {
+            id: "Baz",
+            label: "Baz"
+          }
+        ],
+        properties: {
+          required: false
+        }
+      };
+
+      const resultantJson = new Group(
+        ctx.questionnaireJson.sections[0].id,
+        ctx.questionnaireJson.sections[0].title,
+        ctx.questionnaireJson.sections[0].pages,
+        { introductionEnabled: false },
+        ctx
+      );
+
+      expect(resultantJson.blocks[1].questions[0].description).toEqual(
+        `{{ answers['answer${
+          ctx.questionnaireJson.sections[0].pages[0].answers[0].id
+        }']|format_unordered_list }}`
+      );
+    });
   });
 });

--- a/eq-publisher/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
+++ b/eq-publisher/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
@@ -1,4 +1,5 @@
 const Block = require("../../Block");
+const { CHECKBOX, RADIO } = require("../../../constants/answerTypes");
 
 const buildAuthorConfirmationQuestion = (
   page,
@@ -8,7 +9,7 @@ const buildAuthorConfirmationQuestion = (
 ) => {
   const confirmationAnswerObject = {
     id: `confirmation-answer-for-${page.id}`,
-    type: "Radio",
+    type: RADIO,
     properties: {
       required: true
     },
@@ -66,6 +67,10 @@ const buildAuthorConfirmationQuestion = (
   const confirmationQuestionObject = {
     id: `confirmation-page-for-${page.id}`,
     title: page.confirmation.title,
+    description:
+      page.answers[0].type === CHECKBOX
+        ? `{{ answers['answer${page.answers[0].id}']|format_unordered_list }}`
+        : null,
     pageType: "ConfirmationQuestion",
     routingRuleSet,
     answers: [confirmationAnswerObject]


### PR DESCRIPTION
### What is the context of this PR?
One of the requirements for confirmation questions was that all checkbox answers would be automatically piped into the confirmation description, however this was missed off the original PR. this PR rectifys that and causes all checkbox answers to be automatically piped.

### How to review 
Tests pass and Publisher output is now correct.
