### PR TITLE
732 -Question confirmation piping

### DIFF
--- a/eq-author-api/repositories/QuestionConfirmationRepository.js
+++ b/eq-author-api/repositories/QuestionConfirmationRepository.js
@@ -1,6 +1,10 @@
 const { head, pick } = require("lodash/fp");
 
 const QuestionConfirmation = require("../db/QuestionConfirmation");
+const { PIPING_ANSWER_TYPES } = require("../constants/pipingAnswerTypes");
+
+const QuestionPageRepostory = require("./QuestionPageRepository");
+const PreviousAnswerStrategy = require("./strategies/previousAnswersStrategy");
 
 const USER_MODIFIABLE_FIELDS = [
   "title",
@@ -45,12 +49,28 @@ module.exports = knex => {
       .restore(id)
       .then(head);
 
+  const getPipingAnswers = async id => {
+    const { pageId } = await findById(id);
+    return PreviousAnswerStrategy(knex).getPreviousAnswersForPage({
+      id: pageId,
+      includeSelf: true,
+      answerTypes: PIPING_ANSWER_TYPES
+    });
+  };
+
+  const getPipingMetadata = async id => {
+    const { pageId } = await findById(id);
+    return QuestionPageRepostory(knex).getPipingMetadataForQuestionPage(pageId);
+  };
+
   return {
     findById,
     findByPageId,
     create,
     update,
     delete: remove,
-    restore
+    restore,
+    getPipingAnswers,
+    getPipingMetadata
   };
 };

--- a/eq-author-api/repositories/strategies/duplicateStrategy/piping.js
+++ b/eq-author-api/repositories/strategies/duplicateStrategy/piping.js
@@ -10,6 +10,11 @@ const PIPING_LOCATIONS = [
     entityName: "sections",
     table: "Sections",
     fields: ["introductionTitle", "introductionContent"]
+  },
+  {
+    entityName: "questionConfirmations",
+    table: "QuestionConfirmations",
+    fields: ["title"]
   }
 ];
 

--- a/eq-author-api/repositories/strategies/duplicateStrategy/piping.test.js
+++ b/eq-author-api/repositories/strategies/duplicateStrategy/piping.test.js
@@ -141,6 +141,41 @@ describe("Update piping", () => {
     });
   });
 
+  it("should update piping for Question Confirmation titles", async () => {
+    const references = {
+      questionConfirmations: {
+        "1": "new1"
+      },
+      answers: {
+        a1: "newA1"
+      },
+      metadata: {
+        m1: "newM1"
+      }
+    };
+    trx.andWhere = async func => {
+      func(builder);
+      return [
+        {
+          id: "new1",
+          title:
+            'title <span data-piped="answers" data-id="a1" data-type="TextField">{{Answer 1}}</span>'
+        }
+      ];
+    };
+
+    await updatePiping(trx, references);
+
+    expect(trx.table).toHaveBeenCalledWith("QuestionConfirmations");
+    expect(trx.update).toHaveBeenCalledWith({
+      title:
+        'title <span data-piped="answers" data-id="newA1" data-type="TextField">{{Answer 1}}</span>'
+    });
+    expect(trx.where).toHaveBeenCalledWith({
+      id: "new1"
+    });
+  });
+
   it("should do nothing if there are no changed entities that could have piping", async () => {
     const references = {
       answers: {

--- a/eq-author-api/schema/resolvers.js
+++ b/eq-author-api/schema/resolvers.js
@@ -573,7 +573,11 @@ const Resolvers = {
     negative: ({ negativeLabel, negativeDescription }) => ({
       label: negativeLabel,
       description: negativeDescription
-    })
+    }),
+    availablePipingAnswers: ({ id }, args, ctx) =>
+      ctx.repositories.QuestionConfirmation.getPipingAnswers(id),
+    availablePipingMetadata: ({ id }, args, ctx) =>
+      ctx.repositories.QuestionConfirmation.getPipingMetadata(id)
   },
 
   Date: GraphQLDate,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -87,6 +87,8 @@ type QuestionConfirmation {
   page: QuestionPage!
   positive: ConfirmationOption!
   negative: ConfirmationOption!
+  availablePipingAnswers: [Answer!]!
+  availablePipingMetadata: [Metadata!]!
 }
 
 interface Answer {

--- a/eq-author-api/tests/schema/queries/questionConfirmation.test.js
+++ b/eq-author-api/tests/schema/queries/questionConfirmation.test.js
@@ -30,7 +30,13 @@ describe("QuestionConfirmation", () => {
           negativeLabel: "nl",
           negativeDescription: "nd",
           pageId: "1"
-        })
+        }),
+        getPipingAnswers: jest
+          .fn()
+          .mockResolvedValue([{ id: 1, label: "Answer" }]),
+        getPipingMetadata: jest
+          .fn()
+          .mockResolvedValue([{ id: 2, alias: "Metadata" }])
       }
     };
   });
@@ -48,6 +54,14 @@ describe("QuestionConfirmation", () => {
           negative {
             description
           }
+          availablePipingAnswers {
+            id
+            label
+          }
+          availablePipingMetadata {
+            id
+            alias
+          }
         }
       }
     `;
@@ -63,7 +77,9 @@ describe("QuestionConfirmation", () => {
         },
         negative: {
           description: "nd"
-        }
+        },
+        availablePipingAnswers: [{ id: "1", label: "Answer" }],
+        availablePipingMetadata: [{ id: "2", alias: "Metadata" }]
       }
     });
     expect(repositories.QuestionConfirmation.findById).toHaveBeenCalledWith(

--- a/eq-author/cypress/integration/authenticated/piping_spec.js
+++ b/eq-author/cypress/integration/authenticated/piping_spec.js
@@ -7,6 +7,7 @@ import {
   selectFirstAnswerFromContentPicker,
   selectFirstMetadataContentPicker
 } from "../../utils";
+import { questionConfirmation } from "../../builders";
 
 const ANSWER = "Number Answer";
 const METADATA = "example_metadata";
@@ -27,6 +28,12 @@ const clickLastPage = () =>
   cy
     .get(testId("nav-page-link"))
     .last()
+    .click({ force: true }); //Metadata modal transition is sometimes too slow
+
+const clickFirstPage = () =>
+  cy
+    .get(testId("nav-page-link"))
+    .first()
     .click({ force: true }); //Metadata modal transition is sometimes too slow
 
 const addSectionIntro = () => cy.get(testId("btn-add-intro")).click();
@@ -83,6 +90,16 @@ describe("Piping", () => {
         );
       });
     });
+    describe("Question Confirmation", () => {
+      beforeEach(() => {
+        clickFirstPage();
+        questionConfirmation.add();
+      });
+
+      it("Can pipe answer on page into title", () => {
+        canPipePreviousAnswer({ selector: "txt-confirmation-title" });
+      });
+    });
     describe("Section Introduction", () => {
       beforeEach(() => {
         clickLastSection();
@@ -113,6 +130,16 @@ describe("Piping", () => {
       });
       it("Can pipe metadata into page guidance", () => {
         canPipeMetadata({ selector: "txt-question-guidance" });
+      });
+    });
+    describe("Question Confirmation", () => {
+      beforeEach(() => {
+        clickLastPage();
+        questionConfirmation.add();
+      });
+
+      it("Can pipe metadata into title", () => {
+        canPipeMetadata({ selector: "txt-confirmation-title" });
       });
     });
     describe("Section Introduction", () => {

--- a/eq-author/src/components/QuestionConfirmationRoute/Editor.js
+++ b/eq-author/src/components/QuestionConfirmationRoute/Editor.js
@@ -52,7 +52,7 @@ export class UnwrappedEditor extends React.Component {
           label="Confirmation question"
           value={title}
           onUpdate={this.handleRichTextUpdate}
-          controls={{ bold: true, emphasis: true }}
+          controls={{ bold: true, emphasis: true, piping: true }}
           size="large"
           testSelector="txt-confirmation-title"
           data-test="title-input"

--- a/eq-author/src/components/QuestionConfirmationRoute/__snapshots__/Editor.test.js.snap
+++ b/eq-author/src/components/QuestionConfirmationRoute/__snapshots__/Editor.test.js.snap
@@ -8,6 +8,7 @@ exports[`Editor Editor Component should autoFocus the title when there is not on
       Object {
         "bold": true,
         "emphasis": true,
+        "piping": true,
       }
     }
     data-test="title-input"
@@ -60,6 +61,7 @@ exports[`Editor Editor Component should render 1`] = `
       Object {
         "bold": true,
         "emphasis": true,
+        "piping": true,
       }
     }
     data-test="title-input"

--- a/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.test.js
+++ b/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.test.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Query } from "react-apollo";
+
+import AvailablePipingContentQuery, {
+  GET_PIPING_CONTENT_PAGE,
+  GET_PIPING_CONTENT_SECTION,
+  GET_PIPING_CONTENT_QUESTION_CONFIRMATION
+} from "./AvailablePipingContentQuery";
+
+describe("Available Piping Content Query", () => {
+  const sectionId = "1";
+  const pageId = "2";
+  const confirmationId = "3";
+
+  it("should make a query for section data when on a section page", () => {
+    const wrapper = shallow(
+      <AvailablePipingContentQuery sectionId={sectionId}>
+        {() => {}}
+      </AvailablePipingContentQuery>
+    );
+    expect(wrapper.find(Query).props()).toMatchObject({
+      variables: { id: sectionId },
+      query: GET_PIPING_CONTENT_SECTION
+    });
+  });
+
+  it("should make a query for page data when on a question page", () => {
+    const wrapper = shallow(
+      <AvailablePipingContentQuery sectionId={sectionId} pageId={pageId}>
+        {() => {}}
+      </AvailablePipingContentQuery>
+    );
+    expect(wrapper.find(Query).props()).toMatchObject({
+      variables: { id: pageId },
+      query: GET_PIPING_CONTENT_PAGE
+    });
+  });
+
+  it("should make a query for confirmation data when on a question confirmation page", () => {
+    const wrapper = shallow(
+      <AvailablePipingContentQuery
+        sectionId={sectionId}
+        pageId={pageId}
+        confirmationId={confirmationId}
+      >
+        {() => {}}
+      </AvailablePipingContentQuery>
+    );
+    expect(wrapper.find(Query).props()).toMatchObject({
+      variables: { id: confirmationId },
+      query: GET_PIPING_CONTENT_QUESTION_CONFIRMATION
+    });
+  });
+});

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withRouter } from "react-router-dom";
 import styled from "styled-components";
-import { get, isUndefined } from "lodash";
 
 import ContentPickerModal from "components/ContentPickerModal";
 import AvailablePipingContentQuery from "components/RichTextEditor/AvailablePipingContentQuery";
@@ -103,17 +102,29 @@ export class Menu extends React.Component {
   }
 }
 
-const PipingMenu = props => (
+const calculateEntityName = ({ pageId, confirmationId }) => {
+  if (confirmationId) {
+    return "questionConfirmation";
+  }
+  if (pageId) {
+    return "questionPage";
+  }
+  return "section";
+};
+
+export const UnwrappedPipingMenu = props => (
   <AvailablePipingContentQuery
-    id={props.match.params.pageId || props.match.params.sectionId}
-    sectionContent={isUndefined(props.match.params.pageId)}
+    pageId={props.match.params.pageId}
+    sectionId={props.match.params.sectionId}
+    confirmationId={props.match.params.confirmationId}
   >
-    {({ data, ...innerProps }) => {
-      const root = `${props.match.params.pageId ? "questionPage" : "section"}`;
+    {({ data = {}, ...innerProps }) => {
+      const entityName = calculateEntityName(props.match.params);
+      const entity = data[entityName] || {};
       return (
         <Menu
-          answerData={shapeTree(get(data, `${root}.availablePipingAnswers`))}
-          metadataData={get(data, `${root}.availablePipingMetadata`)}
+          answerData={shapeTree(entity.availablePipingAnswers)}
+          metadataData={entity.availablePipingMetadata}
           {...props}
           {...innerProps}
         />
@@ -122,9 +133,9 @@ const PipingMenu = props => (
   </AvailablePipingContentQuery>
 );
 
-PipingMenu.propTypes = {
+UnwrappedPipingMenu.propTypes = {
   match: CustomPropTypes.match,
   disabled: PropTypes.bool
 };
 
-export default withRouter(PipingMenu);
+export default withRouter(UnwrappedPipingMenu);

--- a/eq-author/src/components/RichTextEditor/PipingMenu.test.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.test.js
@@ -1,16 +1,16 @@
 import React from "react";
-import {
-  Menu as PipingMenu,
-  MenuButton as PipingMenuButton
-} from "./PipingMenu";
 import { shallow } from "enzyme";
+
+import AvailablePipingContentQuery from "components/RichTextEditor/AvailablePipingContentQuery";
+
+import { Menu, MenuButton, UnwrappedPipingMenu } from "./PipingMenu";
 
 describe("PipingMenu", () => {
   let handleItemChosen, answerData, metadataData;
 
   const render = (props = {}) => {
     return shallow(
-      <PipingMenu
+      <Menu
         match={createMatch("1", "1", "1")}
         onItemChosen={handleItemChosen}
         answerData={answerData}
@@ -86,14 +86,14 @@ describe("PipingMenu", () => {
     const wrapper = render({
       disabled: true
     });
-    expect(wrapper.find(PipingMenuButton).prop("disabled")).toBe(true);
+    expect(wrapper.find(MenuButton).prop("disabled")).toBe(true);
   });
 
   it("should render as disabled when loading", () => {
     const wrapper = render({
       loading: true
     });
-    expect(wrapper.find(PipingMenuButton).prop("disabled")).toBe(true);
+    expect(wrapper.find(MenuButton).prop("disabled")).toBe(true);
   });
 
   it("should render as disabled when there is no answerData and metadataData", () => {
@@ -101,7 +101,7 @@ describe("PipingMenu", () => {
       answerData: null,
       metadataData: null
     });
-    expect(wrapper.find(PipingMenuButton).prop("disabled")).toBe(true);
+    expect(wrapper.find(MenuButton).prop("disabled")).toBe(true);
   });
 
   it("should open the picker when clicked", () => {
@@ -129,5 +129,94 @@ describe("PipingMenu", () => {
     wrapper.find("[data-test='piping-button']").simulate("click");
     wrapper.find("[data-test='picker']").simulate("close");
     expect(wrapper.find("[data-test='picker']").prop("isOpen")).toBe(false);
+  });
+
+  it("should pick the data depending on the page location", () => {
+    const entities = [
+      {
+        name: "questionConfirmation",
+        params: {
+          questionnaireId: "4",
+          sectionId: "3",
+          pageId: "2",
+          confirmationId: "1"
+        }
+      },
+      {
+        name: "questionPage",
+        params: {
+          questionnaireId: "4",
+          sectionId: "3",
+          pageId: "2"
+        }
+      },
+      {
+        name: "section",
+        params: {
+          questionnaireId: "4",
+          sectionId: "3"
+        }
+      }
+    ];
+
+    entities.forEach(({ name, params }) => {
+      const match = {
+        params
+      };
+      const wrapper = shallow(<UnwrappedPipingMenu match={match} />);
+      const data = {
+        [name]: {
+          availablePipingAnswers: [
+            {
+              id: "1",
+              displayName: "Answer 1",
+              page: {
+                id: "1",
+                displayName: "Page 1",
+                section: {
+                  id: "1",
+                  displayName: "Section 1"
+                }
+              }
+            }
+          ],
+          availablePipingMetadata: [
+            {
+              id: "1",
+              alias: "Metadata"
+            }
+          ]
+        }
+      };
+
+      const result = wrapper.find(AvailablePipingContentQuery).prop("children")(
+        {
+          data,
+          onItemChosen: jest.fn()
+        }
+      );
+
+      expect(result.props).toMatchObject({
+        answerData: [
+          {
+            id: "1",
+            displayName: "Section 1",
+            pages: [
+              {
+                id: "1",
+                displayName: "Page 1",
+                answers: [{ id: "1", displayName: "Answer 1" }]
+              }
+            ]
+          }
+        ],
+        metadataData: [
+          {
+            id: "1",
+            alias: "Metadata"
+          }
+        ]
+      });
+    });
   });
 });

--- a/eq-author/src/components/RichTextEditor/__snapshots__/Toolbar.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/Toolbar.test.js.snap
@@ -58,7 +58,7 @@ exports[`components/RichTextEditor/Toolbar should render as visible 1`] = `
           <Component />
         </ToolbarButton>
         <Toolbar__Separator />
-        <withRouter(PipingMenu)
+        <withRouter(UnwrappedPipingMenu)
           disabled={true}
           onItemChosen={[MockFunction]}
         />


### PR DESCRIPTION
### What is the context of this PR?
Initial question confirmation piping. This is reliant on #53 

### How to review 
1. Ensure you can view a survey with piped data in the question confirmation
1. The correct answers are pickable (this is not true as it does not allow those on from the current page)

### Dependencies
- [x] - #53 - Need the method `getPreviousAnswersForPage`
