### PR TITLE
Add earliest and latest date validation to date range answers

### DIFF
--- a/eq-author-api/migrations/20181203185722_add_date_validation_to_date_range_answers.js
+++ b/eq-author-api/migrations/20181203185722_add_date_validation_to_date_range_answers.js
@@ -1,0 +1,46 @@
+const { noop } = require("lodash");
+const { DATE_RANGE } = require("../constants/answerTypes");
+
+exports.up = async function(knex, Promise) {
+  const answersWithId = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where({ type: DATE_RANGE });
+
+  const ids = answersWithId.map(({ id }) => id);
+
+  await knex("Validation_AnswerRules")
+    .whereIn("answerId", ids)
+    .del();
+
+  const inserts = ids.map(id =>
+    knex("Validation_AnswerRules").insert([
+      {
+        answerId: id,
+        validationType: "earliestDate",
+        config: {
+          offset: {
+            value: 0,
+            unit: "Days"
+          },
+          relativePosition: "Before"
+        }
+      },
+      {
+        answerId: id,
+        validationType: "latestDate",
+        config: {
+          offset: {
+            value: 0,
+            unit: "Days"
+          },
+          relativePosition: "After"
+        }
+      }
+    ])
+  );
+
+  return Promise.all(inserts);
+};
+
+exports.down = noop;

--- a/eq-author-api/repositories/strategies/validationStrategy.js
+++ b/eq-author-api/repositories/strategies/validationStrategy.js
@@ -20,7 +20,7 @@ const createDefaultValidationsForAnswer = async ({ id, type }, trx) => {
       answerId: id,
       validationType,
       config: defaultValidationRuleConfigs[validationType],
-      entityType: defaultValidationEntityTypes[validationType].entityType
+      entityType: defaultValidationEntityTypes({type})[validationType].entityType
     });
   });
   await Promise.all(promises);

--- a/eq-author-api/schema/resolvers.js
+++ b/eq-author-api/schema/resolvers.js
@@ -393,6 +393,8 @@ const Resolvers = {
       ctx.repositories.Answer.splitComposites(answer),
     page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.getById(answer.questionPageId),
+    validation: answer =>
+      ["date"].includes(getValidationEntity(answer.type)) ? answer : null,
     displayName: answer => getName(answer, "CompositeAnswer")
   },
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -143,6 +143,7 @@ type CompositeAnswer implements Answer {
   page: QuestionPage
   childAnswers: [BasicAnswer]!
   properties: JSON
+  validation: ValidationType
 }
 
 type Option {

--- a/eq-author-api/tests/utils/graphql.js
+++ b/eq-author-api/tests/utils/graphql.js
@@ -584,10 +584,10 @@ const updateAnswerMutation = `
 mutation UpdateAnswer($input: UpdateAnswerInput!) {
   updateAnswer(input: $input) {
     id,
-    description,
-    guidance,
-    qCode,
-    label,
+    description
+    guidance
+    qCode
+    label
     type
     ...on CompositeAnswer{
       childAnswers{
@@ -610,51 +610,89 @@ mutation MoveSection($input: MoveSectionInput!) {
 
 const getAnswerValidations = `
   query QuestionPage($id: ID!) {
-    answer(id: $id){
-     id
-     ...on BasicAnswer {
-       validation{
-         ...on NumberValidation{
-           minValue{
-             id
-             enabled
-             inclusive
-             custom
-           }
-           maxValue{
-            id
-            enabled
-            inclusive
-            custom
-            entityType
-          }
-         }
-         ...on DateValidation {
-           earliestDate {
-             id
-             enabled
-             custom
-             offset {
-               value
-               unit
-             }
-             relativePosition
-           }
-           latestDate {
-             id
-             enabled
-             custom
-             offset {
-               value
-               unit
-             }
-             relativePosition
-           }
-         }
-       }
-     }
-   }
+  answer(id: $id) {
+    id
+    ...CompositeAnswer
+    ...BasicAnswer
   }
+}
+
+fragment CompositeAnswer on CompositeAnswer {
+  validation {
+    ... on DateValidation {
+      earliestDate {
+        ...EarliestDateValidationRule
+      }
+      latestDate {
+        ...LatestDateValidationRule
+      }
+    }
+  }
+  childAnswers {
+    id
+    label
+  }
+}
+
+fragment BasicAnswer on BasicAnswer {
+  validation {
+    ... on NumberValidation {
+      minValue {
+        ...MinValueValidationRule
+      }
+      maxValue {
+        ...MaxValueValidationRule
+      }
+    }
+    ... on DateValidation {
+      earliestDate {
+        ...EarliestDateValidationRule
+      }
+      latestDate {
+        ...LatestDateValidationRule
+      }
+    }
+  }
+}
+
+fragment MinValueValidationRule on MinValueValidationRule {
+  id
+  enabled
+  custom
+  inclusive
+}
+
+fragment MaxValueValidationRule on MaxValueValidationRule {
+  id
+  enabled
+  custom
+  inclusive
+  entityType
+}
+
+fragment EarliestDateValidationRule on EarliestDateValidationRule {
+  id
+  enabled
+  entityType
+  custom
+  offset {
+    value
+    unit
+  }
+  relativePosition
+}
+
+fragment LatestDateValidationRule on LatestDateValidationRule {
+  id
+  enabled
+  entityType
+  custom
+  offset {
+    value
+    unit
+  }
+  relativePosition
+}
 `;
 
 const toggleAnswerValidation = `

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -1,13 +1,14 @@
 const { CUSTOM, NOW } = require("../constants/validationEntityTypes");
+const { DATE } = require("../constants/answerTypes");
 
 const answerTypeMap = {
   number: ["Currency", "Number"],
-  date: ["Date"]
+  date: ["Date", "DateRange"]
 };
 
 const validationRuleMap = {
   number: ["minValue", "maxValue"],
-  date: ["earliestDate", "latestDate"]
+  date: ["earliestDate", "latestDate"],
 };
 
 const defaultValidationRuleConfigs = {
@@ -33,7 +34,7 @@ const defaultValidationRuleConfigs = {
   }
 };
 
-const defaultValidationEntityTypes = {
+const defaultValidationEntityTypes = ({type}) => ({
   minValue: {
     entityType: CUSTOM
   },
@@ -41,12 +42,12 @@ const defaultValidationEntityTypes = {
     entityType: CUSTOM
   },
   earliestDate: {
-    entityType: NOW
+    entityType: type === DATE ? NOW : CUSTOM
   },
   latestDate: {
-    entityType: NOW
+    entityType:  type === DATE ? NOW : CUSTOM
   }
-};
+});
 
 Object.assign(module.exports, {
   answerTypeMap,

--- a/eq-author/cypress/integration/authenticated/validation_spec.js
+++ b/eq-author/cypress/integration/authenticated/validation_spec.js
@@ -1,5 +1,10 @@
 /* eslint-disable  camelcase */
-import { CURRENCY, DATE, NUMBER } from "../../../src/constants/answer-types";
+import {
+  CURRENCY,
+  DATE,
+  DATE_RANGE,
+  NUMBER
+} from "../../../src/constants/answer-types";
 
 import {
   addAnswerType,
@@ -405,6 +410,137 @@ describe("Answer Validation", () => {
       it("should update metadata", () => {
         toggleCheckboxOn("@latestDateToggle");
         setMetadata("@latestDate", METADATA_KEY);
+      });
+
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+  });
+
+  describe("Date Range", () => {
+    describe("Earliest date", () => {
+      beforeEach(() => {
+        addAnswerType(DATE_RANGE);
+        cy.get(testId("date-answer-label"))
+          .eq(0)
+          .type("Validation Answer 1");
+        cy.get(testId("date-answer-label"))
+          .eq(1)
+          .type("Validation Answer 2");
+        cy.get(testId("sidebar-button-earliest-date")).as("earliestDate");
+        cy.get("@earliestDate").click();
+        cy.get(testId("validation-view-toggle")).within(() => {
+          cy.get('[role="switch"]').as("earliestDateToggle");
+        });
+      });
+
+      it("should exist in the side bar", () => {
+        cy.get("@earliestDate").should("be.visible");
+      });
+
+      it("should show the date validation modal", () => {
+        cy.get(testId("sidebar-title")).contains("Date Range validation");
+      });
+
+      it("can be toggled on", () => {
+        cy.get(testId("earliest-date-validation")).contains(
+          "Earliest date is disabled"
+        );
+
+        toggleCheckboxOn("@earliestDateToggle");
+
+        cy.get(testId("earliest-date-validation")).should(
+          "not.contain",
+          "Earliest date is disabled"
+        );
+      });
+
+      it("should update the offset value", () => {
+        toggleCheckboxOn("@earliestDateToggle");
+        cy.get('[name="offset.value"]')
+          .type("{backspace}5")
+          .blur()
+          .should("have.value", "5");
+      });
+
+      it("should update the offset unit", () => {
+        toggleCheckboxOn("@earliestDateToggle");
+
+        cy.get('[name="offset.unit"]')
+          .select("Months")
+          .blur()
+          .should("have.value", "Months");
+      });
+
+      it("should update the custom value", () => {
+        toggleCheckboxOn("@earliestDateToggle");
+
+        cy.get('[type="date"]')
+          .type("1985-09-14")
+          .blur()
+          .should("have.value", "1985-09-14");
+      });
+
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+
+    describe("Latest date", () => {
+      beforeEach(() => {
+        addAnswerType(DATE_RANGE);
+        cy.get(testId("date-answer-label"))
+          .eq(0)
+          .type("Validation Answer 1");
+        cy.get(testId("date-answer-label"))
+          .eq(1)
+          .type("Validation Answer 2");
+        cy.get(testId("sidebar-button-latest-date")).as("latestDate");
+        cy.get("@latestDate").click();
+        cy.get(testId("validation-view-toggle")).within(() => {
+          cy.get('[role="switch"]').as("latestDateToggle");
+        });
+      });
+
+      it("should exist in the side bar", () => {
+        cy.get(testId("sidebar-button-latest-date")).should("be.visible");
+      });
+
+      it("should show the date validation modal", () => {
+        cy.get(testId("sidebar-title")).contains("Date Range validation");
+      });
+
+      it("can be toggled on", () => {
+        toggleCheckboxOn("@latestDateToggle");
+        cy.get(testId("latest-date-validation")).should(
+          "not.contain",
+          "Latest date is disabled"
+        );
+      });
+
+      it("should update the offset value", () => {
+        toggleCheckboxOn("@latestDateToggle");
+        cy.get('[name="offset.value"]')
+          .type("{backspace}5")
+          .blur()
+          .should("have.value", "5");
+      });
+
+      it("should update the offset unit", () => {
+        toggleCheckboxOn("@latestDateToggle");
+        cy.get('[name="offset.unit"]')
+          .select("Months")
+          .blur()
+          .should("have.value", "Months");
+      });
+
+      it("should update the custom value", () => {
+        toggleCheckboxOn("@latestDateToggle");
+        cy.get('[type="date"]')
+          .type("1985-09-14")
+          .blur()
+          .should("have.value", "1985-09-14");
       });
 
       afterEach(() => {

--- a/eq-author/src/components/Answers/DateRange/index.js
+++ b/eq-author/src/components/Answers/DateRange/index.js
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-
+import gql from "graphql-tag";
 import styled from "styled-components";
 
 import Date from "components/Answers/Date";
-import gql from "graphql-tag";
+
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
+import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -36,6 +38,16 @@ DateRange.fragments = {
     fragment DateRange on Answer {
       id
       ... on CompositeAnswer {
+        validation {
+          ... on DateValidation {
+            earliestDate {
+              ...EarliestDateValidationRule
+            }
+            latestDate {
+              ...LatestDateValidationRule
+            }
+          }
+        }
         childAnswers {
           id
           label
@@ -43,6 +55,8 @@ DateRange.fragments = {
       }
     }
     ${Date.fragments.Date}
+    ${EarliestDateValidationRule}
+    ${LatestDateValidationRule}
   `
 };
 

--- a/eq-author/src/components/Validation/AnswerValidation.js
+++ b/eq-author/src/components/Validation/AnswerValidation.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { kebabCase, get } from "lodash";
+import { kebabCase, get, startCase } from "lodash";
 import styled from "styled-components";
 import CustomPropTypes from "custom-prop-types";
 import PropTypes from "prop-types";
@@ -16,7 +16,7 @@ import { EarliestDate, LatestDate } from "components/Validation/Date";
 import ValidationContext from "components/Validation/ValidationContext";
 import DatePreview from "components/Validation/Date/DatePreview";
 
-import { CURRENCY, DATE, NUMBER } from "constants/answer-types";
+import { CURRENCY, DATE, DATE_RANGE, NUMBER } from "constants/answer-types";
 import { colors } from "constants/theme";
 
 const Container = styled.div`
@@ -45,14 +45,14 @@ const validationTypes = [
     id: "earliestDate",
     title: "Earliest Date",
     render: () => <EarliestDate />,
-    types: [DATE],
+    types: [DATE, DATE_RANGE],
     preview: DatePreview
   },
   {
     id: "latestDate",
     title: "Latest Date",
     render: () => <LatestDate />,
-    types: [DATE],
+    types: [DATE, DATE_RANGE],
     preview: DatePreview
   }
 ];
@@ -60,7 +60,7 @@ const validationTypes = [
 const getValidationsForType = type =>
   validationTypes.filter(({ types }) => types.includes(type));
 
-const validations = [NUMBER, CURRENCY, DATE].reduce(
+const validations = [NUMBER, CURRENCY, DATE, DATE_RANGE].reduce(
   (hash, type) => ({
     ...hash,
     [type]: getValidationsForType(type)
@@ -97,9 +97,7 @@ export class UnconnectedAnswerValidation extends React.Component {
 
   render() {
     const { answer } = this.props;
-
     const validValidationTypes = validations[answer.type] || [];
-
     if (validValidationTypes.length === 0) {
       return null;
     }
@@ -128,7 +126,7 @@ export class UnconnectedAnswerValidation extends React.Component {
             id={this.modalId}
             onClose={this.handleModalClose}
             navItems={validValidationTypes}
-            title={`${answer.type} validation`}
+            title={`${startCase(answer.type)} validation`}
             isOpen={this.state.modalIsOpen}
           />
         </ValidationContext.Provider>

--- a/eq-author/src/components/Validation/Date/DateValidation.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.js
@@ -15,6 +15,7 @@ import Path from "components/Validation/path.svg?inline";
 import PathEnd from "components/Validation/path-end.svg?inline";
 
 import * as entityTypes from "constants/validation-entity-types";
+import { DATE, DATE_RANGE } from "constants/answer-types";
 
 const UNITS = ["Days", "Months", "Years"];
 const RELATIVE_POSITIONS = ["Before", "After"];
@@ -51,10 +52,18 @@ const StartDateText = styled.div`
   padding-top: 0.4em;
 `;
 
+const CustomInput = styled.div`
+  margin-top: 6em;
+`;
+
 const START_COL_SIZE = 3;
 const END_COL_SIZE = 12 - START_COL_SIZE;
 
-const getUnits = format => {
+const getUnits = ({ format, type }) => {
+  if (type === DATE_RANGE) {
+    return UNITS;
+  }
+
   if (format === "dd/mm/yyyy") {
     return UNITS;
   }
@@ -125,14 +134,15 @@ class DateValidation extends React.Component {
     const {
       date: { offset, relativePosition, entityType },
       answer: {
-        properties: { format }
+        properties: { format },
+        type
       },
       displayName,
       onChange,
       onUpdate
     } = this.props;
 
-    const availableUnits = getUnits(format);
+    const availableUnits = getUnits({ format, type });
     const offsetUnitIsInvalid = !availableUnits.includes(offset.unit);
 
     return (
@@ -184,30 +194,38 @@ class DateValidation extends React.Component {
         </Grid>
         <Grid>
           <AlignedColumn cols={START_COL_SIZE}>
-            <RelativePositionSelect
-              name="relativePosition"
-              value={relativePosition}
-              onChange={onChange}
-              onBlur={onUpdate}
-              data-test="relative-position-select"
-            >
-              {RELATIVE_POSITIONS.map(position => (
-                <option key={position} value={position}>
-                  {position}
-                </option>
-              ))}
-            </RelativePositionSelect>
+            {type === DATE && (
+              <RelativePositionSelect
+                name="relativePosition"
+                value={relativePosition}
+                onChange={onChange}
+                onBlur={onUpdate}
+                data-test="relative-position-select"
+              >
+                {RELATIVE_POSITIONS.map(position => (
+                  <option key={position} value={position}>
+                    {position}
+                  </option>
+                ))}
+              </RelativePositionSelect>
+            )}
+            {type === DATE_RANGE && (
+              <EmphasisedText>{relativePosition}</EmphasisedText>
+            )}
             <PathEnd />
           </AlignedColumn>
           <Column cols={9}>
-            <ValidationPills
-              entityType={entityType}
-              onEntityTypeChange={this.handleEntityTypeChange}
-              PreviousAnswer={this.PreviousAnswer}
-              Metadata={this.Metadata}
-              Custom={this.Custom}
-              Now={this.Now}
-            />
+            {type === DATE && (
+              <ValidationPills
+                entityType={entityType}
+                onEntityTypeChange={this.handleEntityTypeChange}
+                PreviousAnswer={this.PreviousAnswer}
+                Metadata={this.Metadata}
+                Custom={this.Custom}
+                Now={this.Now}
+              />
+            )}
+            {type === DATE_RANGE && <CustomInput>{this.Custom()}</CustomInput>}
           </Column>
         </Grid>
       </div>
@@ -257,7 +275,7 @@ DateValidation.propTypes = {
   answer: PropTypes.shape({
     id: PropTypes.string.required,
     properties: PropTypes.shape({
-      format: PropTypes.string.isRequired
+      format: PropTypes.string
     }).isRequired
   }).isRequired,
   onToggleValidationRule: PropTypes.func.isRequired,

--- a/eq-author/src/components/Validation/Date/DateValidation.test.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.test.js
@@ -1,8 +1,9 @@
-import { ValidationPills } from "components/Validation/ValidationPills";
-import { CUSTOM, PREVIOUS_ANSWER } from "constants/validation-entity-types";
 import React from "react";
 import { shallow } from "enzyme";
 import { Number } from "components/Forms";
+import { ValidationPills } from "components/Validation/ValidationPills";
+import { DATE, DATE_RANGE } from "constants/answer-types";
+import { CUSTOM, PREVIOUS_ANSWER } from "constants/validation-entity-types";
 
 import DateValidation from "./DateValidation";
 
@@ -15,7 +16,8 @@ describe("Date Validation", () => {
         id: "1",
         properties: {
           format: "dd/mm/yyyy"
-        }
+        },
+        type: DATE
       },
       date: {
         id: "123",
@@ -45,6 +47,15 @@ describe("Date Validation", () => {
 
   it("should render the form input with the values when enabled", () => {
     const wrapper = shallow(<DateValidation {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render custom input for date range type answer", () => {
+    const answer = {
+      ...props.answer,
+      type: DATE_RANGE
+    };
+    const wrapper = shallow(<DateValidation {...props} answer={answer} />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -165,6 +176,16 @@ describe("Date Validation", () => {
       properties: {
         format: "yyyy"
       }
+    };
+    const wrapper = shallow(<DateValidation {...props} answer={answer} />);
+    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
+    expect(updateUnitField).toMatchSnapshot();
+  });
+
+  it("should render all units for date range answers", () => {
+    const answer = {
+      properties: {},
+      type: DATE_RANGE
     };
     const wrapper = shallow(<DateValidation {...props} answer={answer} />);
     const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');

--- a/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
@@ -47,6 +47,151 @@ exports[`Date Validation should render a please select for offset unit when the 
 </withChangeHandler(Select__SimpleSelect)>
 `;
 
+exports[`Date Validation should render all units for date range answers 1`] = `
+<withChangeHandler(Select__SimpleSelect)
+  data-test="offset-unit-select"
+  name="offset.unit"
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  value="Months"
+>
+  <option
+    key="Days"
+    value="Days"
+  >
+    Days
+  </option>
+  <option
+    key="Months"
+    value="Months"
+  >
+    Months
+  </option>
+  <option
+    key="Years"
+    value="Years"
+  >
+    Years
+  </option>
+</withChangeHandler(Select__SimpleSelect)>
+`;
+
+exports[`Date Validation should render custom input for date range type answer 1`] = `
+<ValidationView
+  data-test="example-test-id"
+  enabled={true}
+  onToggleChange={[Function]}
+>
+  <div>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <DateValidation__AlignedColumn
+        cols={3}
+      >
+        <DateValidation__EmphasisedText>
+          Some date
+           is
+        </DateValidation__EmphasisedText>
+      </DateValidation__AlignedColumn>
+      <Column
+        cols={9}
+      >
+        <Grid
+          align="top"
+          fillHeight={true}
+        >
+          <Column
+            cols={2}
+          >
+            <Number
+              default={0}
+              id="offset-value"
+              max={99999}
+              min={0}
+              name="offset.value"
+              onBlur={[MockFunction]}
+              onChange={[MockFunction]}
+              step={1}
+              value={5}
+            />
+          </Column>
+          <Column
+            cols={4}
+          >
+            <withChangeHandler(Select__SimpleSelect)
+              data-test="offset-unit-select"
+              name="offset.unit"
+              onBlur={[MockFunction]}
+              onChange={[MockFunction]}
+              value="Months"
+            >
+              <option
+                key="Days"
+                value="Days"
+              >
+                Days
+              </option>
+              <option
+                key="Months"
+                value="Months"
+              >
+                Months
+              </option>
+              <option
+                key="Years"
+                value="Years"
+              >
+                Years
+              </option>
+            </withChangeHandler(Select__SimpleSelect)>
+          </Column>
+        </Grid>
+      </Column>
+    </Grid>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <Column
+        cols={3}
+      >
+        <DateValidation__ConnectedPath />
+      </Column>
+    </Grid>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <DateValidation__AlignedColumn
+        cols={3}
+      >
+        <DateValidation__EmphasisedText>
+          Before
+        </DateValidation__EmphasisedText>
+        <Component />
+      </DateValidation__AlignedColumn>
+      <Column
+        cols={9}
+      >
+        <DateValidation__CustomInput>
+          <DateValidation__DateInput
+            max="9999-12-30"
+            min="1000-01-01"
+            name="customDate"
+            onBlur={[MockFunction]}
+            onChange={[MockFunction]}
+            type="date"
+            value="2018-01-01"
+          />
+        </DateValidation__CustomInput>
+      </Column>
+    </Grid>
+  </div>
+</ValidationView>
+`;
+
 exports[`Date Validation should render disabled message when not enabled 1`] = `
 <ValidationView
   data-test="example-test-id"

--- a/eq-author/src/graphql/createAnswer.graphql
+++ b/eq-author/src/graphql/createAnswer.graphql
@@ -48,6 +48,16 @@ mutation createAnswer($input: CreateAnswerInput!) {
       childAnswers {
         ...Answer
       }
+      validation {
+        ... on DateValidation {
+          earliestDate {
+            ...EarliestDateValidationRule
+          }
+          latestDate {
+            ...LatestDateValidationRule
+          }
+        }
+      }
     }
   }
 }

--- a/eq-publisher/src/api/queries.js
+++ b/eq-publisher/src/api/queries.js
@@ -7,69 +7,99 @@ exports.getQuestionnaire = `
     guidance
     properties
     qCode
-    ...on BasicAnswer{
-      validation{
-        ...on NumberValidation{
-          minValue{
-            id
-            inclusive
-            enabled
-            custom
-          }
-          maxValue{
-            id
-            inclusive
-            enabled
-            custom
-            entityType
-            previousAnswer {
-              id
-            }
-          }
+    ...BasicAnswer
+    ...CompositeAnswer
+  }
+  
+  fragment CompositeAnswer on CompositeAnswer {
+    validation {
+      ... on DateValidation {
+        earliestDate {
+          ...EarliestDateValidationRule
         }
-        ...on DateValidation{
-          earliestDate{
-            id
-            enabled
-            custom
-            offset {
-              value
-              unit
-            }
-            relativePosition
-            entityType
-            previousAnswer {
-              id
-            }
-            metadata {
-              key
-            }
-          }
-          latestDate{
-            id
-            enabled
-            custom
-            offset {
-              value
-              unit
-            }
-            relativePosition
-            entityType
-            previousAnswer {
-              id
-            }
-            metadata {
-              key
-            }
-          }
+        latestDate {
+          ...LatestDateValidationRule
         }
       }
     }
-    ...on CompositeAnswer{
-      childAnswers{
-        id
-        label
+    childAnswers {
+      id
+      label
+    }
+  }
+  
+  fragment BasicAnswer on BasicAnswer {
+    validation {
+      ... on NumberValidation {
+        minValue {
+          ...MinValueValidationRule
+        }
+        maxValue {
+          ...MaxValueValidationRule
+        }
       }
+      ... on DateValidation {
+        earliestDate {
+          ...EarliestDateValidationRule
+        }
+        latestDate {
+          ...LatestDateValidationRule
+        }
+      }
+    }
+  }
+  
+  fragment MinValueValidationRule on MinValueValidationRule {
+    id
+    enabled
+    custom
+    inclusive
+  }
+  
+  fragment MaxValueValidationRule on MaxValueValidationRule {
+    id
+    enabled
+    custom
+    inclusive
+    entityType
+    previousAnswer {
+      id
+    }
+  }
+  
+  fragment EarliestDateValidationRule on EarliestDateValidationRule {
+    id
+    enabled
+    entityType
+    custom
+    offset {
+      value
+      unit
+    }
+    relativePosition
+    previousAnswer {
+      id
+    }
+    metadata {
+      key
+    }
+  }
+  
+  fragment LatestDateValidationRule on LatestDateValidationRule {
+    id
+    enabled
+    entityType
+    custom
+    offset {
+      value
+      unit
+    }
+    relativePosition
+    previousAnswer {
+      id
+    }
+    metadata {
+      key
     }
   }
 

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -17,8 +17,8 @@ class Answer {
         this.buildNumberValidation(maxValue, "max_value");
       } else if (answer.type === "Date") {
         const { earliestDate, latestDate } = answer.validation;
-        this.buildDateValidation(earliestDate, "minimum");
-        this.buildDateValidation(latestDate, "maximum");
+        this.minimum = Answer.buildDateValidation(earliestDate);
+        this.maximum = Answer.buildDateValidation(latestDate);
       }
     }
 
@@ -75,7 +75,7 @@ class Answer {
       return;
     }
 
-    const comparator = this.buildComparator(validationRule);
+    const comparator = Answer.buildComparator(validationRule);
 
     if (isNil(comparator)) {
       return;
@@ -87,7 +87,7 @@ class Answer {
     };
   }
 
-  buildComparator(validationRule) {
+  static buildComparator(validationRule) {
     const {
       entityType = "Custom",
       custom,
@@ -119,13 +119,13 @@ class Answer {
     return;
   }
 
-  buildDateValidation(validationRule, validationType) {
+  static buildDateValidation(validationRule) {
     const { enabled } = validationRule;
     if (!enabled) {
       return;
     }
 
-    const comparator = this.buildComparator(validationRule);
+    const comparator = Answer.buildComparator(validationRule);
 
     if (isNil(comparator)) {
       return;
@@ -136,14 +136,12 @@ class Answer {
     const offsetValue = offset.value * multiplier;
     const offsetUnit = offset.unit.toLowerCase();
 
-    Object.assign(this, {
-      [validationType]: {
-        ...comparator,
-        offset_by: {
-          [offsetUnit]: offsetValue
-        }
+    return {
+      ...comparator,
+      offset_by: {
+        [offsetUnit]: offsetValue
       }
-    });
+    };
   }
 
   static buildOption({ label, description }) {

--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -47,6 +47,12 @@ class Question {
     if (dateRange) {
       this.type = "DateRange";
       this.answers = this.buildDateRangeAnswers(dateRange);
+
+      const { earliestDate, latestDate } = dateRange.validation;
+      if (earliestDate.enabled || latestDate.enabled) {
+        this.answers[0].minimum = Answer.buildDateValidation(earliestDate);
+        this.answers[1].maximum = Answer.buildDateValidation(latestDate);
+      }
     } else if (mutuallyExclusive) {
       this.type = "MutuallyExclusive";
       this.mandatory = get("properties.required", mutuallyExclusive);

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -66,6 +66,32 @@ describe("Question", () => {
   });
 
   describe("DateRange", () => {
+    let validation = {};
+    beforeEach(() => {
+      validation = {
+        earliestDate: {
+          id: "1",
+          enabled: true,
+          custom: "2017-02-17",
+          offset: {
+            value: 4,
+            unit: "Days"
+          },
+          relativePosition: "Before"
+        },
+        latestDate: {
+          id: "2",
+          enabled: true,
+          custom: "2018-02-17",
+          offset: {
+            value: 10,
+            unit: "Years"
+          },
+          relativePosition: "After"
+        }
+      };
+    });
+
     it("should convert Author DateRange to Runner-compatible format", () => {
       const answers = [
         {
@@ -73,6 +99,7 @@ describe("Question", () => {
           id: "1",
           label: "Period from",
           properties: { required: true },
+          validation,
           childAnswers: [
             { id: "1from", label: "Period from" },
             { id: "1to", label: "Period to" }
@@ -106,6 +133,7 @@ describe("Question", () => {
           type: "DateRange",
           id: "1",
           properties: { required: true },
+          validation,
           childAnswers: [
             { id: "1from", label: "Period from" },
             { id: "1to", label: "Period to" }
@@ -128,6 +156,7 @@ describe("Question", () => {
           type: "Checkbox",
           id: "1",
           properties: { required: true },
+          validation,
           options: [
             {
               id: "1",
@@ -165,6 +194,7 @@ describe("Question", () => {
           type: "Checkbox",
           id: "1",
           properties: { required: true },
+          validation,
           options: [
             {
               id: "1",
@@ -181,6 +211,45 @@ describe("Question", () => {
           type: "Checkbox"
         })
       ]);
+    });
+
+    it("should create date validation", () => {
+      const answers = [
+        {
+          type: "DateRange",
+          id: "1",
+          properties: { required: true },
+          validation,
+          childAnswers: [
+            { id: "1from", label: "Period from" },
+            { id: "1to", label: "Period to" }
+          ]
+        }
+      ];
+      const question = new Question(createQuestionJSON({ answers }));
+
+      expect(question.answers[0]).toEqual(
+        expect.objectContaining({
+          minimum: {
+            value: "2017-02-17",
+            // eslint-disable-next-line camelcase
+            offset_by: {
+              days: -4
+            }
+          }
+        })
+      );
+      expect(question.answers[1]).toEqual(
+        expect.objectContaining({
+          maximum: {
+            value: "2018-02-17",
+            // eslint-disable-next-line camelcase
+            offset_by: {
+              years: 10
+            }
+          }
+        })
+      );
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Adds validation to date range answers to limit earliest and latest dates `eq-survey-runner` users can enter. 

### How to review 
- Run tests 
- Ensure validation works as expected on `eq-survey-runner`