### PR TITLE
Update webpack version range

### DIFF
--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -110,7 +110,7 @@
     "terser-webpack-plugin": "^1.1.0",
     "url-loader": "1.1.1",
     "wait-on": "^2.0.2",
-    "webpack": "4.19.1",
+    "webpack": "^4.19.1",
     "webpack-dev-server": "3.1.9",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "^3.6.2"

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -13959,7 +13959,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.19.1:
+webpack@^4.19.1:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.19.1.tgz#096674bc3b573f8756c762754366e5b333d6576f"
   integrity sha512-j7Q/5QqZRqIFXJvC0E59ipLV5Hf6lAnS3ezC3I4HMUybwEDikQBVad5d+IpPtmaQPQArvgUZLXIN6lWijHBn4g==


### PR DESCRIPTION
### What is the context of this PR?
Test greenkeeper will update lock files for in-range packages

### How to review 
- Tests pass
- See if https://github.com/ONSdigital/eq-author-app/pull/68 has its lock file updated after this branch is merged