### PR TITLE
Disable API code coverage by default

### DIFF
--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -8,6 +8,7 @@
     "start:dev": "yarn waitForPostgres && yarn knex -- migrate:latest && nodemon --inspect=0.0.0.0:5858",
     "lint": "eslint .",
     "test": "NODE_ENV=test ./scripts/test.sh",
+    "test:coverage": "yarn test --coverage",
     "test:breakingChanges": "node scripts/checkForBreakingChanges.js",
     "knex": "knex --knexfile config/knexfile.js --cwd .",
     "precommit": "lint-staged",
@@ -52,7 +53,6 @@
   "jest": {
     "testEnvironment": "node",
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.js",
       "!config/**/*",

--- a/eq-author-api/scripts/ci.sh
+++ b/eq-author-api/scripts/ci.sh
@@ -3,7 +3,7 @@ set -e
 
 yarn install --frozen-lockfile
 yarn lint --max-warnings=0
-yarn test
+yarn test:coverage
 bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION
 yarn test:breakingChanges
 


### PR DESCRIPTION
### What is the context of this PR?
This has to be manually disabled when running with watch as it is not
useful for most testing scenarios.

### How to review 
1. Ensure `yarn test` does not output any coverage info
2. Ensure `yarn test:coverage` provides coverage output
3. Ensure CI still collects coverage info
