### PR TITLE
Bug - Unable to pipe dates

### DIFF
--- a/eq-author-api/constants/pipingAnswerTypes.js
+++ b/eq-author-api/constants/pipingAnswerTypes.js
@@ -1,3 +1,9 @@
-const { TEXTFIELD, NUMBER, CURRENCY, DATE_RANGE } = require("./answerTypes");
+const type = require("./answerTypes");
 
-module.exports.PIPING_ANSWER_TYPES = [TEXTFIELD, NUMBER, CURRENCY, DATE_RANGE];
+module.exports.PIPING_ANSWER_TYPES = [
+  type.TEXTFIELD,
+  type.NUMBER,
+  type.CURRENCY,
+  type.DATE,
+  type.DATE_RANGE
+];

--- a/eq-author-api/repositories/QuestionConfirmationRepository.test.js
+++ b/eq-author-api/repositories/QuestionConfirmationRepository.test.js
@@ -30,8 +30,16 @@ describe("QuestionConfirmationRepository", () => {
             {
               answers: [
                 {
-                  label: "Previous Answer",
+                  label: "Previous Currency Answer",
                   type: answerTypes.CURRENCY
+                },
+                {
+                  label: "Previous Date Answer",
+                  type: answerTypes.DATE
+                },
+                {
+                  label: "Previous Date Range Answer",
+                  type: answerTypes.DATE_RANGE
                 }
               ]
             },
@@ -241,7 +249,9 @@ describe("QuestionConfirmationRepository", () => {
         confirmation.id
       );
       expect(pipingAnswers).toEqual([
-        expect.objectContaining({ label: "Previous Answer" }),
+        expect.objectContaining({ label: "Previous Currency Answer" }),
+        expect.objectContaining({ label: "Previous Date Answer" }),
+        expect.objectContaining({ label: "Previous Date Range Answer" }),
         expect.objectContaining({ label: "Answer" })
       ]);
     });

--- a/eq-author-api/repositories/QuestionPageRepository.js
+++ b/eq-author-api/repositories/QuestionPageRepository.js
@@ -81,7 +81,8 @@ module.exports = knex => {
       .join("SectionsView", "SectionsView.questionnaireId", "Questionnaires.id")
       .join("PagesView", "PagesView.sectionId", "SectionsView.id")
       .where("PagesView.id", id)
-      .andWhere("Metadata.isDeleted", false);
+      .andWhere("Metadata.isDeleted", false)
+      .orderBy("Metadata.id", "asc");
 
   const getRoutingQuestionsForQuestionPage = id =>
     getPreviousQuestionsForPage({

--- a/eq-author-api/repositories/QuestionPageRepository.test.js
+++ b/eq-author-api/repositories/QuestionPageRepository.test.js
@@ -140,16 +140,22 @@ describe("QuestionPageRepository", () => {
 
       expect(pipingAnswers).toEqual([
         expect.objectContaining({
-          label: "Answer 1.1.7"
+          label: "Answer 1.1.1"
         }),
         expect.objectContaining({
-          label: "Answer 1.1.6"
+          label: "Answer 1.1.2"
         }),
         expect.objectContaining({
           label: "Answer 1.1.5"
         }),
         expect.objectContaining({
-          label: "Answer 1.1.2"
+          label: "Answer 1.1.6"
+        }),
+        expect.objectContaining({
+          label: "Answer 1.1.7"
+        }),
+        expect.objectContaining({
+          label: "Answer 1.2.1"
         }),
         expect.objectContaining({
           label: "Answer 1.2.2"
@@ -187,15 +193,15 @@ describe("QuestionPageRepository", () => {
 
       expect(metadata).toEqual([
         expect.objectContaining({
-          key: "metadata_text"
+          key: "metadata_date"
         }),
         expect.objectContaining({
-          key: "metadata_date"
+          key: "metadata_text"
         })
       ]);
 
-      expect(getName(metadata[0], "Metadata")).toEqual("metadata text");
-      expect(getName(metadata[1], "Metadata")).toEqual("metadata date");
+      expect(getName(metadata[0], "Metadata")).toEqual("metadata date");
+      expect(getName(metadata[1], "Metadata")).toEqual("metadata text");
     });
   });
 

--- a/eq-author-api/repositories/SectionRepository.js
+++ b/eq-author-api/repositories/SectionRepository.js
@@ -140,14 +140,14 @@ module.exports = knex => {
     });
   };
 
-  const getPipingAnswersForSection = id =>
-    getById(id).then(({ position: sectionPosition, questionnaireId }) =>
-      getPreviousAnswersForSection({
-        answerTypes: PIPING_ANSWER_TYPES,
-        sectionPosition,
-        questionnaireId
-      })
-    );
+  const getPipingAnswersForSection = async id => {
+    const { position: sectionPosition, questionnaireId } = await getById(id);
+    return getPreviousAnswersForSection({
+      answerTypes: PIPING_ANSWER_TYPES,
+      sectionPosition,
+      questionnaireId
+    });
+  };
 
   const getPipingMetadataForSection = id =>
     knex("Metadata")
@@ -155,7 +155,8 @@ module.exports = knex => {
       .join("Questionnaires", "Metadata.questionnaireId", "Questionnaires.id")
       .join("SectionsView", "SectionsView.questionnaireId", "Questionnaires.id")
       .where("SectionsView.id", id)
-      .andWhere("Metadata.isDeleted", false);
+      .andWhere("Metadata.isDeleted", false)
+      .orderBy("Metadata.id", "asc");
 
   return {
     findAll,

--- a/eq-author-api/repositories/SectionRepository.test.js
+++ b/eq-author-api/repositories/SectionRepository.test.js
@@ -546,16 +546,22 @@ describe("SectionRepository", () => {
 
       expect(pipingAnswers).toEqual([
         expect.objectContaining({
-          label: "Answer 1.1.7"
+          label: "Answer 1.1.1"
         }),
         expect.objectContaining({
-          label: "Answer 1.1.6"
+          label: "Answer 1.1.2"
         }),
         expect.objectContaining({
           label: "Answer 1.1.5"
         }),
         expect.objectContaining({
-          label: "Answer 1.1.2"
+          label: "Answer 1.1.6"
+        }),
+        expect.objectContaining({
+          label: "Answer 1.1.7"
+        }),
+        expect.objectContaining({
+          label: "Answer 1.2.1"
         }),
         expect.objectContaining({
           label: "Answer 1.2.2"
@@ -593,10 +599,10 @@ describe("SectionRepository", () => {
 
       expect(metadata).toEqual([
         expect.objectContaining({
-          key: "metadata_text"
+          key: "metadata_date"
         }),
         expect.objectContaining({
-          key: "metadata_date"
+          key: "metadata_text"
         })
       ]);
     });

--- a/eq-author-api/repositories/strategies/previousAnswersStrategy.js
+++ b/eq-author-api/repositories/strategies/previousAnswersStrategy.js
@@ -1,4 +1,3 @@
-const { head } = require("lodash/fp");
 module.exports = knex => {
   const getPreviousAnswersForSection = ({
     answerTypes,
@@ -12,44 +11,52 @@ module.exports = knex => {
       .whereIn("Answers.type", answerTypes)
       .andWhere("Answers.isDeleted", false)
       .andWhere({ questionnaireId })
-      .andWhere("SectionsView.position", "<", sectionPosition);
+      .andWhere("SectionsView.position", "<", sectionPosition)
+      .orderBy("SectionsView.position", "asc")
+      .orderBy("PagesView.position", "asc")
+      .orderBy("Answers.id", "asc");
 
-  const getPreviousAnswersForPage = ({
+  const getPreviousAnswersForPage = async ({
     id,
     answerTypes,
     select = "Answers.*",
     includeSelf = false
-  }) =>
-    knex("PagesView")
+  }) => {
+    const { questionnaireId, sectionPosition, pagePosition } = await knex(
+      "PagesView"
+    )
       .select("SectionsView.position as sectionPosition")
       .select("PagesView.position as pagePosition")
       .select("SectionsView.questionnaireId")
       .join("SectionsView", "PagesView.sectionId", "SectionsView.id")
       .where("PagesView.id", id)
-      .then(head)
-      .then(({ questionnaireId, sectionPosition, pagePosition }) =>
-        knex("PagesView")
-          .select(select)
-          .join("Answers", "Answers.questionPageId", "PagesView.id")
-          .join("SectionsView", "PagesView.sectionId", "SectionsView.id")
-          .whereIn("Answers.type", answerTypes)
-          .andWhere("Answers.isDeleted", false)
-          .andWhere({ questionnaireId })
-          .andWhere("SectionsView.position", "<=", sectionPosition)
-          .andWhere(query =>
+      .first();
+
+    return knex("PagesView")
+      .select(select)
+      .join("Answers", "Answers.questionPageId", "PagesView.id")
+      .join("SectionsView", "PagesView.sectionId", "SectionsView.id")
+      .whereIn("Answers.type", answerTypes)
+      .andWhere("Answers.isDeleted", false)
+      .andWhere({ questionnaireId })
+      .andWhere("SectionsView.position", "<=", sectionPosition)
+      .andWhere(query =>
+        query
+          .where("SectionsView.position", "<", sectionPosition)
+          .orWhere(query =>
             query
-              .where("SectionsView.position", "<", sectionPosition)
-              .orWhere(query =>
-                query
-                  .where("SectionsView.position", sectionPosition)
-                  .andWhere(
-                    "PagesView.position",
-                    includeSelf ? "<=" : "<",
-                    pagePosition
-                  )
+              .where("SectionsView.position", sectionPosition)
+              .andWhere(
+                "PagesView.position",
+                includeSelf ? "<=" : "<",
+                pagePosition
               )
           )
-      );
+      )
+      .orderBy("SectionsView.position", "asc")
+      .orderBy("PagesView.position", "asc")
+      .orderBy("Answers.id", "asc");
+  };
 
   const getPreviousQuestionsForPage = ({
     id,


### PR DESCRIPTION
### What is the context of this PR?
This was caused by us filtering out the date answers from the answers
you could pipe.

This change also fixes an issue where the get previous answers would
be returned in a non-deterministic order. So now we order in the db so
we can guarantee the order of the answers.

### How to review 
1. Ensure you can pipe dates anywhere you can pipe in the app.