### PR TITLE
Added an env variable that allows silencing logger during tests

### DIFF
--- a/eq-author-api/db/index.js
+++ b/eq-author-api/db/index.js
@@ -1,5 +1,5 @@
 const pinoMiddleware = require("express-pino-logger");
-const pino = pinoMiddleware();
+const pino = pinoMiddleware({ enabled: !process.env.SILENCE_LOGS });
 const logger = pino.logger;
 
 const config = require("../config/knexfile.js");

--- a/eq-author-api/scripts/test.sh
+++ b/eq-author-api/scripts/test.sh
@@ -26,4 +26,4 @@ echo "waiting on postgres to start..."
 echo "running tests..."
 
 # --runInBand is required to run the tests in parallel, as all tests use the same database
-DB_CONNECTION_URI="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/postgres" yarn jest --runInBand --detectOpenHandles --forceExit "$@"
+DB_CONNECTION_URI="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/postgres" SILENCE_LOGS=true yarn jest --runInBand --detectOpenHandles --forceExit "$@"


### PR DESCRIPTION
### What is the context of this PR?
During a yarn test the logger would output a large number of logs causing the cli test to become harder to read this PR silences those logs when the tests are run with `yarn test`

### How to review 
There a no logs cluttering the terminal during a test but all logs are present during normal operations.
