### PR TITLE
Add min and max duration validation to date range answers

### DIFF
--- a/eq-author-api/migrations/20181221185711_add_duration_to_date_range_answers.js
+++ b/eq-author-api/migrations/20181221185711_add_duration_to_date_range_answers.js
@@ -1,0 +1,56 @@
+const { noop } = require("lodash");
+const migrateEnumChecks = require("../utils/migrateEnumChecks");
+const { DATE_RANGE } = require("../constants/answerTypes");
+
+exports.up = async function(knex, Promise) {
+  await knex.raw(
+    migrateEnumChecks("Validation_AnswerRules", "validationType", [
+      "minValue",
+      "maxValue",
+      "earliestDate",
+      "latestDate",
+      "minDuration",
+      "maxDuration"
+    ])
+  );
+
+  const answersWithId = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where({ type: DATE_RANGE });
+
+  const ids = answersWithId.map(({ id }) => id);
+
+  await knex("Validation_AnswerRules")
+    .whereIn("answerId", ids)
+    .del();
+
+  const inserts = ids.map(id =>
+    knex("Validation_AnswerRules").insert([
+      {
+        answerId: id,
+        validationType: "minDuration",
+        config: {
+          duration: {
+            value: 0,
+            unit: "Days"
+          }
+        }
+      },
+      {
+        answerId: id,
+        validationType: "maxDuration",
+        config: {
+          duration: {
+            value: 0,
+            unit: "Days"
+          }
+        }
+      }
+    ])
+  );
+
+  return Promise.all(inserts);
+};
+
+exports.down = noop;

--- a/eq-author-api/schema/resolvers.js
+++ b/eq-author-api/schema/resolvers.js
@@ -1,4 +1,5 @@
 const { GraphQLDate } = require("graphql-iso-date");
+
 const { includes, isNil } = require("lodash");
 const GraphQLJSON = require("graphql-type-json");
 const { getName } = require("../utils/getName");
@@ -385,7 +386,7 @@ const Resolvers = {
     page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.getById(answer.questionPageId),
     validation: answer =>
-      ["date"].includes(getValidationEntity(answer.type)) ? answer : null,
+      ["dateRange"].includes(getValidationEntity(answer.type)) ? answer : null,
     displayName: answer => getName(answer, "CompositeAnswer")
   },
 
@@ -421,6 +422,8 @@ const Resolvers = {
           return "NumberValidation";
         case "date":
           return "DateValidation";
+        case "dateRange":
+          return "DateRangeValidation";
 
         default:
           throw new TypeError(
@@ -441,7 +444,10 @@ const Resolvers = {
           return "EarliestDateValidationRule";
         case "latestDate":
           return "LatestDateValidationRule";
-
+        case "minDuration":
+          return "MinDurationValidationRule";
+        case "maxDuration":
+          return "MaxDurationValidationRule";
         default:
           throw new TypeError(
             `Validation is not supported on '${validationType}' answers`
@@ -473,6 +479,29 @@ const Resolvers = {
       ctx.repositories.Validation.findByAnswerIdAndValidationType(
         answer,
         "latestDate"
+      )
+  },
+
+  DateRangeValidation: {
+    earliestDate: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "earliestDate"
+      ),
+    latestDate: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "latestDate"
+      ),
+    minDuration: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "minDuration"
+      ),
+    maxDuration: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "maxDuration"
       )
   },
 
@@ -527,6 +556,14 @@ const Resolvers = {
       ctx.repositories.Validation.getPreviousAnswersForValidation(id),
     availableMetadata: ({ id }, args, ctx) =>
       ctx.repositories.Validation.getMetadataForValidation(id)
+  },
+
+  MinDurationValidationRule: {
+    duration: ({ config: { duration } }) => duration,
+  },
+
+  MaxDurationValidationRule: {
+    duration: ({ config: { duration } }) => duration,
   },
 
   Metadata: {

--- a/eq-author-api/schema/resolversTests/validation.test.js
+++ b/eq-author-api/schema/resolversTests/validation.test.js
@@ -348,7 +348,7 @@ describe("resolvers", () => {
 
     describe("Earliest", () => {
       it("should be able to update properties", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
         const result = await mutateValidationParameters({
           id: validation.earliestDate.id,
@@ -368,8 +368,8 @@ describe("resolvers", () => {
       });
 
       it("can update previous answer", async () => {
-        const previousAnswer = await createNewAnswer(firstPage, "Date");
-        const answer = await createNewAnswer(firstPage, "Date");
+        const previousAnswer = await createNewAnswer(firstPage, DATE);
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const result = await mutateValidationParameters({
@@ -391,7 +391,7 @@ describe("resolvers", () => {
 
       it("can update metadata", async () => {
         const metadata = await createMetadata(questionnaire.id);
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const result = await mutateValidationParameters({
@@ -412,7 +412,7 @@ describe("resolvers", () => {
       });
 
       it("can update entity type", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const entityTypes = [CUSTOM, PREVIOUS_ANSWER, METADATA, NOW];
@@ -582,7 +582,7 @@ describe("resolvers", () => {
 
     describe("Earliest", () => {
       it("should be able to update properties", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
         const validation = await queryAnswerValidations(answer.id);
         const result = await mutateValidationParameters({
           id: validation.earliestDate.id,
@@ -604,7 +604,7 @@ describe("resolvers", () => {
 
     describe("Latest", () => {
       it("should be able to update properties", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
         const validation = await queryAnswerValidations(answer.id);
         const result = await mutateValidationParameters({
           id: validation.latestDate.id,
@@ -621,6 +621,54 @@ describe("resolvers", () => {
           ...params
         };
 
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("MinDuration", () => {
+      it("should be able to update properties", async () => {
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+        const input = {
+          duration: {
+            value: 8,
+            unit: "Days"
+          }
+        };
+        const result = await mutateValidationParameters({
+          id: validation.minDuration.id,
+          minDurationInput: {
+            ...input
+          }
+        });
+        const expected = {
+          id: validation.minDuration.id,
+          ...input
+        };
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("MaxDuration", () => {
+      it("should be able to update properties", async () => {
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+        const input = {
+          duration: {
+            value: 8,
+            unit: "Days"
+          }
+        };
+        const result = await mutateValidationParameters({
+          id: validation.maxDuration.id,
+          maxDurationInput: {
+            ...input
+          }
+        });
+        const expected = {
+          id: validation.maxDuration.id,
+          ...input
+        };
         expect(result).toEqual(expected);
       });
     });

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -218,7 +218,7 @@ type NumberValue {
 
 union RoutingConditionValue = IDArrayValue | NumberValue
 
-union ValidationType = NumberValidation | DateValidation
+union ValidationType = NumberValidation | DateValidation | DateRangeValidation
 
 enum ValidationRuleEntityType {
   Custom
@@ -235,6 +235,13 @@ type NumberValidation {
 type DateValidation {
   earliestDate: EarliestDateValidationRule!
   latestDate: LatestDateValidationRule!
+}
+
+type DateRangeValidation {
+  earliestDate: EarliestDateValidationRule!
+  latestDate: LatestDateValidationRule!
+  minDuration: MinDurationValidationRule!
+  maxDuration: MaxDurationValidationRule!
 }
 
 interface ValidationRule {
@@ -283,6 +290,18 @@ type LatestDateValidationRule implements ValidationRule {
   entityType: ValidationRuleEntityType
   availablePreviousAnswers: [Answer!]!
   availableMetadata: [Metadata!]!
+}
+
+type MinDurationValidationRule implements ValidationRule {
+  id: ID!
+  enabled: Boolean!
+  duration: Duration!
+}
+
+type MaxDurationValidationRule implements ValidationRule {
+  id: ID!
+  enabled: Boolean!
+  duration: Duration!
 }
 
 type Duration {
@@ -730,6 +749,8 @@ input UpdateValidationRuleInput {
   maxValueInput:  UpdateMaxValueInput
   earliestDateInput: UpdateEarliestDateInput
   latestDateInput: UpdateLatestDateInput
+  minDurationInput: UpdateMinDurationInput
+  maxDurationInput: UpdateMaxDurationInput
 }
 
 input UpdateMinValueInput {
@@ -760,6 +781,14 @@ input UpdateLatestDateInput {
   custom: Date
   previousAnswer: ID
   metadata: ID
+}
+
+input UpdateMinDurationInput {
+  duration: DurationInput!
+}
+
+input UpdateMaxDurationInput {
+  duration: DurationInput!
 }
 
 input DurationInput {

--- a/eq-author-api/tests/utils/graphql.js
+++ b/eq-author-api/tests/utils/graphql.js
@@ -584,12 +584,18 @@ const getAnswerValidations = `
 
 fragment CompositeAnswer on CompositeAnswer {
   validation {
-    ... on DateValidation {
+    ... on DateRangeValidation {
       earliestDate {
         ...EarliestDateValidationRule
       }
       latestDate {
         ...LatestDateValidationRule
+      }
+      minDuration {
+        ...MinDurationValidationRule
+      }
+      maxDuration {
+        ...MaxDurationValidationRule
       }
     }
   }
@@ -658,6 +664,24 @@ fragment LatestDateValidationRule on LatestDateValidationRule {
   }
   relativePosition
 }
+
+fragment MinDurationValidationRule on MinDurationValidationRule {
+  id
+  enabled
+  duration {
+    value
+    unit
+  }
+}
+
+fragment MaxDurationValidationRule on MaxDurationValidationRule {
+  id
+  enabled
+  duration {
+    value
+    unit
+  }
+}
 `;
 
 const toggleAnswerValidation = `
@@ -713,6 +737,18 @@ mutation updateValidation($input: UpdateValidationRuleInput!){
       }
       metadata {
         id
+      }
+    }
+    ...on MinDurationValidationRule {
+      duration {
+        value
+        unit
+      }
+    }
+    ...on MaxDurationValidationRule {
+      duration {
+        value
+        unit
       }
     }
   }

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -1,40 +1,38 @@
 const { CUSTOM, NOW } = require("../constants/validationEntityTypes");
-const { DATE } = require("../constants/answerTypes");
+const {
+  DATE,
+  DATE_RANGE,
+  CURRENCY,
+  NUMBER
+} = require("../constants/answerTypes");
 
 const answerTypeMap = {
-  number: ["Currency", "Number"],
-  date: ["Date", "DateRange"]
+  number: [CURRENCY, NUMBER],
+  date: [DATE],
+  dateRange: [DATE_RANGE]
 };
 
 const validationRuleMap = {
   number: ["minValue", "maxValue"],
   date: ["earliestDate", "latestDate"],
+  dateRange: ["earliestDate", "latestDate", "minDuration", "maxDuration"]
+};
+
+const duration = {
+  value: 0,
+  unit: "Days"
 };
 
 const defaultValidationRuleConfigs = {
-  minValue: {
-    inclusive: false
-  },
-  maxValue: {
-    inclusive: false
-  },
-  earliestDate: {
-    offset: {
-      value: 0,
-      unit: "Days"
-    },
-    relativePosition: "Before"
-  },
-  latestDate: {
-    offset: {
-      value: 0,
-      unit: "Days"
-    },
-    relativePosition: "After"
-  }
+  minValue: { inclusive: false },
+  maxValue: { inclusive: false },
+  earliestDate: { offset: duration, relativePosition: "Before" },
+  latestDate: { offset: duration, relativePosition: "After" },
+  minDuration: { duration },
+  maxDuration: { duration }
 };
 
-const defaultValidationEntityTypes = ({type}) => ({
+const defaultValidationEntityTypes = ({ type }) => ({
   minValue: {
     entityType: CUSTOM
   },
@@ -45,7 +43,13 @@ const defaultValidationEntityTypes = ({type}) => ({
     entityType: type === DATE ? NOW : CUSTOM
   },
   latestDate: {
-    entityType:  type === DATE ? NOW : CUSTOM
+    entityType: type === DATE ? NOW : CUSTOM
+  },
+  minDuration: {
+    entityType: CUSTOM
+  },
+  maxDuration: {
+    entityType: CUSTOM
   }
 });
 

--- a/eq-author/cypress/integration/authenticated/validation_spec.js
+++ b/eq-author/cypress/integration/authenticated/validation_spec.js
@@ -547,5 +547,123 @@ describe("Answer Validation", () => {
         removeAnswer();
       });
     });
+
+    describe("Min duration", () => {
+      beforeEach(() => {
+        addAnswerType(DATE_RANGE);
+        cy.get(testId("date-answer-label"))
+          .eq(0)
+          .type("Validation Answer 1");
+        cy.get(testId("date-answer-label"))
+          .eq(1)
+          .type("Validation Answer 2");
+        cy.get(testId("sidebar-button-min-duration")).as("minDuration");
+        cy.get("@minDuration").click();
+        cy.get(testId("validation-view-toggle")).within(() => {
+          cy.get('[role="switch"]').as("minDurationToggle");
+        });
+      });
+
+      it("should exist in the side bar", () => {
+        cy.get("@minDuration").should("be.visible");
+      });
+
+      it("should show the validation modal", () => {
+        cy.get(testId("sidebar-title")).contains("Date Range validation");
+      });
+
+      it("can be toggled on", () => {
+        cy.get(testId("min-duration-validation")).contains(
+          "Min duration is disabled"
+        );
+
+        toggleCheckboxOn("@minDurationToggle");
+
+        cy.get(testId("min-duration-validation")).should(
+          "not.contain",
+          "Min duration is disabled"
+        );
+      });
+
+      it("should update the duration value", () => {
+        toggleCheckboxOn("@minDurationToggle");
+        cy.get('[name="duration.value"]')
+          .type("{backspace}5")
+          .blur()
+          .should("have.value", "5");
+      });
+
+      it("should update the duration unit", () => {
+        toggleCheckboxOn("@minDurationToggle");
+
+        cy.get('[name="duration.unit"]')
+          .select("Months")
+          .blur()
+          .should("have.value", "Months");
+      });
+
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+
+    describe("Max duration", () => {
+      beforeEach(() => {
+        addAnswerType(DATE_RANGE);
+        cy.get(testId("date-answer-label"))
+          .eq(0)
+          .type("Validation Answer 1");
+        cy.get(testId("date-answer-label"))
+          .eq(1)
+          .type("Validation Answer 2");
+        cy.get(testId("sidebar-button-max-duration")).as("maxDuration");
+        cy.get("@maxDuration").click();
+        cy.get(testId("validation-view-toggle")).within(() => {
+          cy.get('[role="switch"]').as("maxDurationToggle");
+        });
+      });
+
+      it("should exist in the side bar", () => {
+        cy.get("@maxDuration").should("be.visible");
+      });
+
+      it("should show the validation modal", () => {
+        cy.get(testId("sidebar-title")).contains("Date Range validation");
+      });
+
+      it("can be toggled on", () => {
+        cy.get(testId("max-duration-validation")).contains(
+          "Max duration is disabled"
+        );
+
+        toggleCheckboxOn("@maxDurationToggle");
+
+        cy.get(testId("max-duration-validation")).should(
+          "not.contain",
+          "Max duration is disabled"
+        );
+      });
+
+      it("should update the duration value", () => {
+        toggleCheckboxOn("@maxDurationToggle");
+        cy.get('[name="duration.value"]')
+          .type("{backspace}5")
+          .blur()
+          .should("have.value", "5");
+      });
+
+      it("should update the duration unit", () => {
+        toggleCheckboxOn("@maxDurationToggle");
+
+        cy.get('[name="duration.unit"]')
+          .select("Months")
+          .blur()
+          .should("have.value", "Months");
+      });
+
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
   });
 });

--- a/eq-author/src/components/Answers/DateRange/index.js
+++ b/eq-author/src/components/Answers/DateRange/index.js
@@ -8,6 +8,8 @@ import Date from "components/Answers/Date";
 
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
+import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
+import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -39,12 +41,18 @@ DateRange.fragments = {
       id
       ... on CompositeAnswer {
         validation {
-          ... on DateValidation {
+          ... on DateRangeValidation {
             earliestDate {
               ...EarliestDateValidationRule
             }
             latestDate {
               ...LatestDateValidationRule
+            }
+            minDuration {
+              ...MinDurationValidationRule
+            }
+            maxDuration {
+              ...MaxDurationValidationRule
             }
           }
         }
@@ -57,6 +65,8 @@ DateRange.fragments = {
     ${Date.fragments.Date}
     ${EarliestDateValidationRule}
     ${LatestDateValidationRule}
+    ${MinDurationValidationRule}
+    ${MaxDurationValidationRule}
   `
 };
 

--- a/eq-author/src/components/Validation/AnswerValidation.js
+++ b/eq-author/src/components/Validation/AnswerValidation.js
@@ -12,9 +12,16 @@ import ModalWithNav from "components/ModalWithNav";
 
 import MinValueValidation from "components/Validation/MinValue";
 import MaxValueValidation from "components/Validation/MaxValue";
-import { EarliestDate, LatestDate } from "components/Validation/Date";
+import {
+  EarliestDate,
+  LatestDate,
+  MinDuration,
+  MaxDuration
+} from "components/Validation/Date";
+
 import ValidationContext from "components/Validation/ValidationContext";
 import DatePreview from "components/Validation/Date/DatePreview";
+import DurationPreview from "components/Validation/Date/DurationPreview";
 
 import { CURRENCY, DATE, DATE_RANGE, NUMBER } from "constants/answer-types";
 import { colors } from "constants/theme";
@@ -54,6 +61,20 @@ const validationTypes = [
     render: () => <LatestDate />,
     types: [DATE, DATE_RANGE],
     preview: DatePreview
+  },
+  {
+    id: "minDuration",
+    title: "Min Duration",
+    render: () => <MinDuration />,
+    types: [DATE_RANGE],
+    preview: DurationPreview
+  },
+  {
+    id: "maxDuration",
+    title: "Max Duration",
+    render: () => <MaxDuration />,
+    types: [DATE_RANGE],
+    preview: DurationPreview
   }
 ];
 

--- a/eq-author/src/components/Validation/Date/AlignedColumn.js
+++ b/eq-author/src/components/Validation/Date/AlignedColumn.js
@@ -1,0 +1,11 @@
+import { Column } from "components/Grid";
+import styled from "styled-components";
+
+const AlignedColumn = styled(Column)`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+export default AlignedColumn;

--- a/eq-author/src/components/Validation/Date/DateValidation.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.js
@@ -1,9 +1,10 @@
+import Duration from "components/Validation/Date/Duration";
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { get } from "lodash";
 
-import { Input, Number, Select } from "components/Forms";
+import { Input, Select } from "components/Forms";
 import { Grid, Column } from "components/Grid";
 
 import PreviousAnswerContentPicker from "components/Validation/PreviousAnswerContentPicker";
@@ -13,11 +14,14 @@ import { ValidationPills } from "components/Validation/ValidationPills";
 import ValidationView from "components/Validation/ValidationView";
 import Path from "components/Validation/path.svg?inline";
 import PathEnd from "components/Validation/path-end.svg?inline";
+import EmphasisedText from "components/Validation/Date/EmphasisedText";
+import AlignedColumn from "components/Validation/Date/AlignedColumn";
 
 import * as entityTypes from "constants/validation-entity-types";
 import { DATE, DATE_RANGE } from "constants/answer-types";
+import { DAYS, MONTHS, YEARS } from "constants/durations";
 
-const UNITS = ["Days", "Months", "Years"];
+const UNITS = [DAYS, MONTHS, YEARS];
 const RELATIVE_POSITIONS = ["Before", "After"];
 
 const DateInput = styled(Input)`
@@ -29,22 +33,8 @@ const ConnectedPath = styled(Path)`
   height: 3.6em;
 `;
 
-const AlignedColumn = styled(Column)`
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-`;
-
 const RelativePositionSelect = styled(Select)`
   width: 6em;
-`;
-
-const EmphasisedText = styled.p`
-  font-size: 0.9em;
-  font-weight: bold;
-  margin: 0;
-  text-transform: uppercase;
 `;
 
 const StartDateText = styled.div`
@@ -53,7 +43,7 @@ const StartDateText = styled.div`
 `;
 
 const CustomInput = styled.div`
-  margin-top: 6em;
+  margin-top: 5em;
 `;
 
 const START_COL_SIZE = 3;
@@ -143,7 +133,6 @@ class DateValidation extends React.Component {
     } = this.props;
 
     const availableUnits = getUnits({ format, type });
-    const offsetUnitIsInvalid = !availableUnits.includes(offset.unit);
 
     return (
       <div>
@@ -152,39 +141,13 @@ class DateValidation extends React.Component {
             <EmphasisedText>{displayName} is</EmphasisedText>
           </AlignedColumn>
           <Column cols={END_COL_SIZE}>
-            <Grid>
-              <Column cols={2}>
-                <Number
-                  id="offset-value"
-                  name="offset.value"
-                  value={offset.value}
-                  onChange={onChange}
-                  onBlur={onUpdate}
-                  max={99999}
-                  min={0}
-                />
-              </Column>
-              <Column cols={4}>
-                <Select
-                  name="offset.unit"
-                  value={!offsetUnitIsInvalid ? offset.unit : ""}
-                  onChange={onChange}
-                  onBlur={onUpdate}
-                  data-test="offset-unit-select"
-                >
-                  {offsetUnitIsInvalid && (
-                    <option key="Please select" value="" disabled>
-                      Please select…
-                    </option>
-                  )}
-                  {availableUnits.map(unit => (
-                    <option key={unit} value={unit}>
-                      {unit}
-                    </option>
-                  ))}
-                </Select>
-              </Column>
-            </Grid>
+            <Duration
+              name="offset"
+              duration={offset}
+              units={availableUnits}
+              onChange={onChange}
+              onUpdate={onUpdate}
+            />
           </Column>
         </Grid>
         <Grid>
@@ -232,9 +195,7 @@ class DateValidation extends React.Component {
     );
   };
 
-  renderDisabled = () => (
-    <DisabledMessage>{this.props.displayName} is disabled</DisabledMessage>
-  );
+  renderDisabled = () => <DisabledMessage name={this.props.displayName} />;
 
   render() {
     const {

--- a/eq-author/src/components/Validation/Date/DateValidation.test.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { Number } from "components/Forms";
 import { ValidationPills } from "components/Validation/ValidationPills";
+import Duration from "components/Validation/Date/Duration";
 import { DATE, DATE_RANGE } from "constants/answer-types";
 import { CUSTOM, PREVIOUS_ANSWER } from "constants/validation-entity-types";
 
@@ -68,21 +68,12 @@ describe("Date Validation", () => {
     });
   });
 
-  it("should trigger update answer validation when the offset value changes", () => {
+  it("should trigger update answer validation when the duration value changes", () => {
     const wrapper = shallow(<DateValidation {...props} />);
-    const updateValueField = wrapper.find(Number);
-    updateValueField.simulate("change", "event");
+    const duration = wrapper.find(Duration);
+    duration.simulate("change", "event");
     expect(props.onChange).toHaveBeenCalledWith("event");
-    updateValueField.simulate("blur", "event");
-    expect(props.onUpdate).toHaveBeenCalledWith("event");
-  });
-
-  it("should trigger update answer validation when the offset unit changes", () => {
-    const wrapper = shallow(<DateValidation {...props} />);
-    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
-    updateUnitField.simulate("change", "event");
-    expect(props.onChange).toHaveBeenCalledWith("event");
-    updateUnitField.simulate("blur", "event");
+    duration.simulate("update", "event");
     expect(props.onUpdate).toHaveBeenCalledWith("event");
   });
 
@@ -160,26 +151,29 @@ describe("Date Validation", () => {
     );
   });
 
-  it("should filter the available units for the format", () => {
+  it("should filter the available units for the mm/yyyy", () => {
     const answer = {
       properties: {
         format: "mm/yyyy"
       }
     };
     const wrapper = shallow(<DateValidation {...props} answer={answer} />);
-    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
-    expect(updateUnitField).toMatchSnapshot();
+    const duration = wrapper.find(Duration);
+    expect(duration.prop("units")).toMatchSnapshot();
   });
 
-  it("should render a please select for offset unit when the offset unit is not available for the format", () => {
-    const answer = {
-      properties: {
-        format: "yyyy"
-      }
-    };
+  it("should filter the available units for the dd/mm/yyyy", () => {
+    const answer = { properties: { format: "dd/mm/yyyy" } };
     const wrapper = shallow(<DateValidation {...props} answer={answer} />);
-    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
-    expect(updateUnitField).toMatchSnapshot();
+    const duration = wrapper.find(Duration);
+    expect(duration.prop("units")).toMatchSnapshot();
+  });
+
+  it("should filter the available units for the yyyy", () => {
+    const answer = { properties: { format: "yyyy" } };
+    const wrapper = shallow(<DateValidation {...props} answer={answer} />);
+    const duration = wrapper.find(Duration);
+    expect(duration.prop("units")).toMatchSnapshot();
   });
 
   it("should render all units for date range answers", () => {
@@ -188,7 +182,7 @@ describe("Date Validation", () => {
       type: DATE_RANGE
     };
     const wrapper = shallow(<DateValidation {...props} answer={answer} />);
-    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
-    expect(updateUnitField).toMatchSnapshot();
+    const duration = wrapper.find(Duration);
+    expect(duration.prop("units")).toMatchSnapshot();
   });
 });

--- a/eq-author/src/components/Validation/Date/Duration.js
+++ b/eq-author/src/components/Validation/Date/Duration.js
@@ -1,0 +1,58 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Number, Select } from "components/Forms";
+import { Grid, Column } from "components/Grid";
+
+import { DAYS, MONTHS, YEARS } from "constants/durations";
+const UNITS = [DAYS, MONTHS, YEARS];
+
+const Duration = ({
+  name,
+  units,
+  duration: { value, unit },
+  onChange,
+  onUpdate
+}) => (
+  <Grid>
+    <Column cols={2}>
+      <Number
+        id={`${name}-value`}
+        name={`${name}.value`}
+        value={value}
+        onChange={onChange}
+        onBlur={onUpdate}
+        max={99999}
+        min={0}
+      />
+    </Column>
+    <Column cols={4}>
+      <Select
+        id={`${name}-unit`}
+        name={`${name}.unit`}
+        value={unit}
+        onChange={onChange}
+        onBlur={onUpdate}
+      >
+        {units.map(unit => (
+          <option key={unit} value={unit}>
+            {unit}
+          </option>
+        ))}
+      </Select>
+    </Column>
+  </Grid>
+);
+
+Duration.propTypes = {
+  name: PropTypes.string.isRequired,
+  duration: PropTypes.shape({
+    value: PropTypes.number.isRequired,
+    unit: PropTypes.oneOf(UNITS).isRequired
+  }).isRequired,
+  units: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
+};
+
+export default Duration;

--- a/eq-author/src/components/Validation/Date/Duration.test.js
+++ b/eq-author/src/components/Validation/Date/Duration.test.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Duration from "components/Validation/Date/Duration";
+import { Number, Select } from "components/Forms";
+
+import { DAYS, MONTHS, YEARS } from "constants/durations";
+const UNITS = [DAYS, MONTHS, YEARS];
+
+const render = props => shallow(<Duration {...props} />);
+
+describe("Duration", () => {
+  let wrapper, props;
+
+  beforeEach(() => {
+    props = {
+      name: "foobar",
+      duration: {
+        value: 3,
+        unit: YEARS
+      },
+      units: UNITS,
+      onChange: jest.fn(),
+      onUpdate: jest.fn()
+    };
+
+    wrapper = render(props);
+  });
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should correctly change and update duration value", () => {
+    const value = wrapper.find(Number);
+    value.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    value.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+
+  it("should correctly change and update duration unit", () => {
+    const value = wrapper.find(Select);
+    value.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    value.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+});

--- a/eq-author/src/components/Validation/Date/DurationPreview.js
+++ b/eq-author/src/components/Validation/Date/DurationPreview.js
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const DurationPreview = ({ duration: { unit, value } }) => {
+  if (value === 0) {
+    return;
+  }
+  return (
+    <React.Fragment>
+      <div>{`${value} ${unit.toLowerCase()}`}</div>
+    </React.Fragment>
+  );
+};
+
+DurationPreview.propTypes = {
+  duration: PropTypes.shape({
+    value: PropTypes.number.isRequired,
+    unit: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default DurationPreview;

--- a/eq-author/src/components/Validation/Date/DurationPreview.test.js
+++ b/eq-author/src/components/Validation/Date/DurationPreview.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import DurationPreview from "components/Validation/Date/DurationPreview";
+
+import { DAYS } from "constants/durations";
+
+const render = props => shallow(<DurationPreview {...props} />);
+
+describe("Duration Preview", () => {
+  let wrapper, props;
+
+  beforeEach(() => {
+    props = {
+      duration: {
+        unit: DAYS,
+        value: 5
+      }
+    };
+    wrapper = render(props);
+  });
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should not render when value 0", () => {
+    const duration = {
+      unit: DAYS,
+      value: 0
+    };
+    expect(render({ duration })).toMatchSnapshot();
+  });
+});

--- a/eq-author/src/components/Validation/Date/DurationValidation.js
+++ b/eq-author/src/components/Validation/Date/DurationValidation.js
@@ -1,0 +1,101 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Grid, Column } from "components/Grid";
+
+import DisabledMessage from "components/Validation/DisabledMessage";
+import ValidationView from "components/Validation/ValidationView";
+import Duration from "components/Validation/Date/Duration";
+import EmphasisedText from "components/Validation/Date/EmphasisedText";
+import AlignedColumn from "components/Validation/Date/AlignedColumn";
+
+import { DAYS, MONTHS, YEARS } from "constants/durations";
+
+const UNITS = [DAYS, MONTHS, YEARS];
+
+class DurationValidation extends React.Component {
+  handleToggleChange = ({ value: enabled }) => {
+    const {
+      onToggleValidationRule,
+      duration: { id }
+    } = this.props;
+
+    onToggleValidationRule({
+      id,
+      enabled
+    });
+  };
+
+  renderContent = () => {
+    const {
+      duration: {
+        duration
+      },
+      displayName,
+      onChange,
+      onUpdate
+    } = this.props;
+
+    return (
+      <div>
+        <Grid>
+          <AlignedColumn cols={3}>
+            <EmphasisedText>{displayName} is</EmphasisedText>
+          </AlignedColumn>
+          <Column cols={9}>
+            <Duration
+              name="duration"
+              duration={duration}
+              units={UNITS}
+              onChange={onChange}
+              onUpdate={onUpdate}
+            />
+          </Column>
+        </Grid>
+      </div>
+    );
+  };
+
+  renderDisabled = () => <DisabledMessage name={this.props.displayName} />;
+
+  render() {
+    const {
+      testId,
+      duration: { enabled }
+    } = this.props;
+
+    return (
+      <ValidationView
+        data-test={testId}
+        enabled={enabled}
+        onToggleChange={this.handleToggleChange}
+      >
+        {enabled ? this.renderContent() : this.renderDisabled()}
+      </ValidationView>
+    );
+  }
+}
+
+DurationValidation.propTypes = {
+  displayName: PropTypes.string.isRequired,
+  duration: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    enabled: PropTypes.bool.isRequired,
+    duration: PropTypes.shape({
+      unit: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired
+    }).isRequired
+  }).isRequired,
+  answer: PropTypes.shape({
+    id: PropTypes.string.required,
+    properties: PropTypes.shape({
+      format: PropTypes.string
+    }).isRequired
+  }).isRequired,
+  onToggleValidationRule: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  testId: PropTypes.string.isRequired
+};
+
+export default DurationValidation;

--- a/eq-author/src/components/Validation/Date/DurationValidation.test.js
+++ b/eq-author/src/components/Validation/Date/DurationValidation.test.js
@@ -1,0 +1,65 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Duration from "components/Validation/Date/Duration";
+import { DATE_RANGE } from "constants/answer-types";
+
+import DurationValidation from "components/Validation/Date/DurationValidation";
+
+describe("Duration Validation", () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      answer: {
+        id: "1",
+        properties: {
+          format: "dd/mm/yyyy"
+        },
+        type: DATE_RANGE
+      },
+      duration: {
+        id: "123",
+        enabled: true,
+        duration: {
+          value: 5,
+          unit: "Months"
+        }
+      },
+      onToggleValidationRule: jest.fn(),
+      onChange: jest.fn(),
+      onUpdate: jest.fn(),
+      displayName: "Some date",
+      testId: "duration-test-id"
+    };
+  });
+
+  it("should render disabled message when not enabled", () => {
+    props.duration.enabled = false;
+    const wrapper = shallow(<DurationValidation {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render the form input with the values when enabled", () => {
+    const wrapper = shallow(<DurationValidation {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call onToggleValidationRule when enabled/disabled", () => {
+    const wrapper = shallow(<DurationValidation {...props} />);
+    wrapper.find("ValidationView").simulate("toggleChange", { value: true });
+    expect(props.onToggleValidationRule).toHaveBeenCalledWith({
+      id: "123",
+      enabled: true
+    });
+  });
+
+  it("should trigger update answer validation when the duration value changes", () => {
+    const wrapper = shallow(<DurationValidation {...props} />);
+    const duration = wrapper.find(Duration);
+    duration.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+
+    duration.simulate("update", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+});

--- a/eq-author/src/components/Validation/Date/EmphasisedText.js
+++ b/eq-author/src/components/Validation/Date/EmphasisedText.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const EmphasisedText = styled.p`
+  font-size: 0.9em;
+  font-weight: bold;
+  margin: 0;
+  text-transform: uppercase;
+`;
+
+export default EmphasisedText;

--- a/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
@@ -1,79 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Date Validation should filter the available units for the format 1`] = `
-<withChangeHandler(Select__SimpleSelect)
-  data-test="offset-unit-select"
-  name="offset.unit"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  value="Months"
->
-  <option
-    key="Months"
-    value="Months"
-  >
-    Months
-  </option>
-  <option
-    key="Years"
-    value="Years"
-  >
-    Years
-  </option>
-</withChangeHandler(Select__SimpleSelect)>
+exports[`Date Validation should filter the available units for the dd/mm/yyyy 1`] = `
+Array [
+  "Days",
+  "Months",
+  "Years",
+]
 `;
 
-exports[`Date Validation should render a please select for offset unit when the offset unit is not available for the format 1`] = `
-<withChangeHandler(Select__SimpleSelect)
-  data-test="offset-unit-select"
-  name="offset.unit"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  value=""
->
-  <option
-    disabled={true}
-    key="Please select"
-    value=""
-  >
-    Please select…
-  </option>
-  <option
-    key="Years"
-    value="Years"
-  >
-    Years
-  </option>
-</withChangeHandler(Select__SimpleSelect)>
+exports[`Date Validation should filter the available units for the mm/yyyy 1`] = `
+Array [
+  "Months",
+  "Years",
+]
+`;
+
+exports[`Date Validation should filter the available units for the yyyy 1`] = `
+Array [
+  "Years",
+]
 `;
 
 exports[`Date Validation should render all units for date range answers 1`] = `
-<withChangeHandler(Select__SimpleSelect)
-  data-test="offset-unit-select"
-  name="offset.unit"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  value="Months"
->
-  <option
-    key="Days"
-    value="Days"
-  >
-    Days
-  </option>
-  <option
-    key="Months"
-    value="Months"
-  >
-    Months
-  </option>
-  <option
-    key="Years"
-    value="Years"
-  >
-    Years
-  </option>
-</withChangeHandler(Select__SimpleSelect)>
+Array [
+  "Days",
+  "Months",
+  "Years",
+]
 `;
 
 exports[`Date Validation should render custom input for date range type answer 1`] = `
@@ -87,67 +40,35 @@ exports[`Date Validation should render custom input for date range type answer 1
       align="top"
       fillHeight={true}
     >
-      <DateValidation__AlignedColumn
+      <AlignedColumn
         cols={3}
       >
-        <DateValidation__EmphasisedText>
+        <EmphasisedText>
           Some date
            is
-        </DateValidation__EmphasisedText>
-      </DateValidation__AlignedColumn>
+        </EmphasisedText>
+      </AlignedColumn>
       <Column
         cols={9}
       >
-        <Grid
-          align="top"
-          fillHeight={true}
-        >
-          <Column
-            cols={2}
-          >
-            <Number
-              default={0}
-              id="offset-value"
-              max={99999}
-              min={0}
-              name="offset.value"
-              onBlur={[MockFunction]}
-              onChange={[MockFunction]}
-              step={1}
-              value={5}
-            />
-          </Column>
-          <Column
-            cols={4}
-          >
-            <withChangeHandler(Select__SimpleSelect)
-              data-test="offset-unit-select"
-              name="offset.unit"
-              onBlur={[MockFunction]}
-              onChange={[MockFunction]}
-              value="Months"
-            >
-              <option
-                key="Days"
-                value="Days"
-              >
-                Days
-              </option>
-              <option
-                key="Months"
-                value="Months"
-              >
-                Months
-              </option>
-              <option
-                key="Years"
-                value="Years"
-              >
-                Years
-              </option>
-            </withChangeHandler(Select__SimpleSelect)>
-          </Column>
-        </Grid>
+        <Duration
+          duration={
+            Object {
+              "unit": "Months",
+              "value": 5,
+            }
+          }
+          name="offset"
+          onChange={[MockFunction]}
+          onUpdate={[MockFunction]}
+          units={
+            Array [
+              "Days",
+              "Months",
+              "Years",
+            ]
+          }
+        />
       </Column>
     </Grid>
     <Grid
@@ -164,14 +85,14 @@ exports[`Date Validation should render custom input for date range type answer 1
       align="top"
       fillHeight={true}
     >
-      <DateValidation__AlignedColumn
+      <AlignedColumn
         cols={3}
       >
-        <DateValidation__EmphasisedText>
+        <EmphasisedText>
           Before
-        </DateValidation__EmphasisedText>
+        </EmphasisedText>
         <Component />
-      </DateValidation__AlignedColumn>
+      </AlignedColumn>
       <Column
         cols={9}
       >
@@ -198,10 +119,9 @@ exports[`Date Validation should render disabled message when not enabled 1`] = `
   enabled={false}
   onToggleChange={[Function]}
 >
-  <DisabledMessage>
-    Some date
-     is disabled
-  </DisabledMessage>
+  <DisabledMessage
+    name="Some date"
+  />
 </ValidationView>
 `;
 
@@ -216,67 +136,35 @@ exports[`Date Validation should render the form input with the values when enabl
       align="top"
       fillHeight={true}
     >
-      <DateValidation__AlignedColumn
+      <AlignedColumn
         cols={3}
       >
-        <DateValidation__EmphasisedText>
+        <EmphasisedText>
           Some date
            is
-        </DateValidation__EmphasisedText>
-      </DateValidation__AlignedColumn>
+        </EmphasisedText>
+      </AlignedColumn>
       <Column
         cols={9}
       >
-        <Grid
-          align="top"
-          fillHeight={true}
-        >
-          <Column
-            cols={2}
-          >
-            <Number
-              default={0}
-              id="offset-value"
-              max={99999}
-              min={0}
-              name="offset.value"
-              onBlur={[MockFunction]}
-              onChange={[MockFunction]}
-              step={1}
-              value={5}
-            />
-          </Column>
-          <Column
-            cols={4}
-          >
-            <withChangeHandler(Select__SimpleSelect)
-              data-test="offset-unit-select"
-              name="offset.unit"
-              onBlur={[MockFunction]}
-              onChange={[MockFunction]}
-              value="Months"
-            >
-              <option
-                key="Days"
-                value="Days"
-              >
-                Days
-              </option>
-              <option
-                key="Months"
-                value="Months"
-              >
-                Months
-              </option>
-              <option
-                key="Years"
-                value="Years"
-              >
-                Years
-              </option>
-            </withChangeHandler(Select__SimpleSelect)>
-          </Column>
-        </Grid>
+        <Duration
+          duration={
+            Object {
+              "unit": "Months",
+              "value": 5,
+            }
+          }
+          name="offset"
+          onChange={[MockFunction]}
+          onUpdate={[MockFunction]}
+          units={
+            Array [
+              "Days",
+              "Months",
+              "Years",
+            ]
+          }
+        />
       </Column>
     </Grid>
     <Grid
@@ -293,7 +181,7 @@ exports[`Date Validation should render the form input with the values when enabl
       align="top"
       fillHeight={true}
     >
-      <DateValidation__AlignedColumn
+      <AlignedColumn
         cols={3}
       >
         <DateValidation__RelativePositionSelect
@@ -317,7 +205,7 @@ exports[`Date Validation should render the form input with the values when enabl
           </option>
         </DateValidation__RelativePositionSelect>
         <Component />
-      </DateValidation__AlignedColumn>
+      </AlignedColumn>
       <Column
         cols={9}
       >

--- a/eq-author/src/components/Validation/Date/__snapshots__/Duration.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/Duration.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Duration should render 1`] = `
+<Grid
+  align="top"
+  fillHeight={true}
+>
+  <Column
+    cols={2}
+  >
+    <Number
+      default={0}
+      id="foobar-value"
+      max={99999}
+      min={0}
+      name="foobar.value"
+      onBlur={[MockFunction]}
+      onChange={[MockFunction]}
+      step={1}
+      value={3}
+    />
+  </Column>
+  <Column
+    cols={4}
+  >
+    <withChangeHandler(Select__SimpleSelect)
+      id="foobar-unit"
+      name="foobar.unit"
+      onBlur={[MockFunction]}
+      onChange={[MockFunction]}
+      value="Years"
+    >
+      <option
+        key="Days"
+        value="Days"
+      >
+        Days
+      </option>
+      <option
+        key="Months"
+        value="Months"
+      >
+        Months
+      </option>
+      <option
+        key="Years"
+        value="Years"
+      >
+        Years
+      </option>
+    </withChangeHandler(Select__SimpleSelect)>
+  </Column>
+</Grid>
+`;

--- a/eq-author/src/components/Validation/Date/__snapshots__/DurationPreview.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/DurationPreview.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Duration Preview should not render when value 0 1`] = `""`;
+
+exports[`Duration Preview should render 1`] = `
+<Fragment>
+  <div>
+    5 days
+  </div>
+</Fragment>
+`;

--- a/eq-author/src/components/Validation/Date/__snapshots__/DurationValidation.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/DurationValidation.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Duration Validation should render disabled message when not enabled 1`] = `
+<ValidationView
+  data-test="duration-test-id"
+  enabled={false}
+  onToggleChange={[Function]}
+>
+  <DisabledMessage
+    name="Some date"
+  />
+</ValidationView>
+`;
+
+exports[`Duration Validation should render the form input with the values when enabled 1`] = `
+<ValidationView
+  data-test="duration-test-id"
+  enabled={true}
+  onToggleChange={[Function]}
+>
+  <div>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <AlignedColumn
+        cols={3}
+      >
+        <EmphasisedText>
+          Some date
+           is
+        </EmphasisedText>
+      </AlignedColumn>
+      <Column
+        cols={9}
+      >
+        <Duration
+          duration={
+            Object {
+              "unit": "Months",
+              "value": 5,
+            }
+          }
+          name="duration"
+          onChange={[MockFunction]}
+          onUpdate={[MockFunction]}
+          units={
+            Array [
+              "Days",
+              "Months",
+              "Years",
+            ]
+          }
+        />
+      </Column>
+    </Grid>
+  </div>
+</ValidationView>
+`;

--- a/eq-author/src/components/Validation/Date/builder.js
+++ b/eq-author/src/components/Validation/Date/builder.js
@@ -1,61 +1,27 @@
-import { flowRight, omit } from "lodash/fp";
+import { flowRight } from "lodash/fp";
 
 import withToggleAnswerValidation from "containers/enhancers/withToggleAnswerValidation";
 import withUpdateAnswerValidation from "containers/enhancers/withUpdateAnswerValidation";
 import withEntityEditor from "components/withEntityEditor";
 
-import withAnswerValidation from "../withAnswerValidation";
-
-import DateValidation from "./DateValidation";
-import { withProps, withPropRenamed, withPropRemapped } from "./enhancers";
+import withAnswerValidation from "components/Validation/withAnswerValidation";
 
 import {
-  CUSTOM,
-  PREVIOUS_ANSWER,
-  METADATA
-} from "constants/validation-entity-types";
+  withProps,
+  withPropRenamed,
+  withPropRemapped
+} from "components/Validation/Date/enhancers";
 
-const getCustom = (entityType, customDate) => {
-  if (entityType !== CUSTOM || !customDate) {
-    return null;
-  }
-  return customDate;
-};
-
-const getPreviousAnswer = (entityType, previousAnswer) => {
-  if (entityType !== PREVIOUS_ANSWER || !previousAnswer) {
-    return null;
-  }
-  return previousAnswer.id;
-};
-
-const getMetadata = (entityType, metadata) => {
-  if (entityType !== METADATA || !metadata) {
-    return null;
-  }
-  return metadata.id;
-};
-
-export const readToWriteMapper = outputKey => ({
-  id,
-  customDate,
-  previousAnswer,
-  metadata,
-  entityType,
-  ...rest
-}) => ({
-  id,
-  [outputKey]: {
-    ...omit("enabled", rest),
-    entityType,
-    custom: getCustom(entityType, customDate),
-    previousAnswer: getPreviousAnswer(entityType, previousAnswer),
-    metadata: getMetadata(entityType, metadata)
-  }
-});
-
-export default (displayName, testId, readKey, writeKey, fragment) => {
-  const withEditing = flowRight(
+export default (
+  displayName,
+  testId,
+  readKey,
+  writeKey,
+  fragment,
+  readToWriteMapper,
+  propKey
+) =>
+  flowRight(
     withProps({ displayName, testId, readKey }),
     withAnswerValidation(readKey),
     withUpdateAnswerValidation,
@@ -66,7 +32,5 @@ export default (displayName, testId, readKey, writeKey, fragment) => {
       readToWriteMapper(writeKey)
     ),
     withEntityEditor(readKey, fragment),
-    withPropRenamed(readKey, "date")
+    withPropRenamed(readKey, propKey)
   );
-  return withEditing(DateValidation);
-};

--- a/eq-author/src/components/Validation/Date/index.js
+++ b/eq-author/src/components/Validation/Date/index.js
@@ -1,19 +1,52 @@
-import dateBuilder from "./builder";
-import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
-import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
+import builder from "components/Validation/Date/builder";
+import {
+  dateReadToWriteMapper,
+  durationReadToWriteMapper
+} from "components/Validation/Date/readToWriteMapper";
+import DateValidation from "components/Validation/Date/DateValidation";
+import DurationValidation from "components/Validation/Date/DurationValidation";
 
-export const LatestDate = dateBuilder(
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
+import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
+import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
+import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
+
+export const LatestDate = builder(
   "Latest date",
   "latest-date-validation",
   "latestDate",
   "latestDateInput",
-  LatestDateValidationRule
-);
+  LatestDateValidationRule,
+  dateReadToWriteMapper,
+  "date"
+)(DateValidation);
 
-export const EarliestDate = dateBuilder(
+export const EarliestDate = builder(
   "Earliest date",
   "earliest-date-validation",
   "earliestDate",
   "earliestDateInput",
-  EarliestDateValidationRule
-);
+  EarliestDateValidationRule,
+  dateReadToWriteMapper,
+  "date"
+)(DateValidation);
+
+export const MinDuration = builder(
+  "Min duration",
+  "min-duration-validation",
+  "minDuration",
+  "minDurationInput",
+  MinDurationValidationRule,
+  durationReadToWriteMapper,
+  "duration"
+)(DurationValidation);
+
+export const MaxDuration = builder(
+  "Max duration",
+  "max-duration-validation",
+  "maxDuration",
+  "maxDurationInput",
+  MaxDurationValidationRule,
+  durationReadToWriteMapper,
+  "duration"
+)(DurationValidation);

--- a/eq-author/src/components/Validation/Date/readToWriteMapper.js
+++ b/eq-author/src/components/Validation/Date/readToWriteMapper.js
@@ -1,0 +1,51 @@
+import { omit } from "lodash/fp";
+
+import {
+  CUSTOM,
+  PREVIOUS_ANSWER,
+  METADATA
+} from "constants/validation-entity-types";
+
+const getCustom = (entityType, customDate) => {
+  if (entityType !== CUSTOM || !customDate) {
+    return null;
+  }
+  return customDate;
+};
+
+const getPreviousAnswer = (entityType, previousAnswer) => {
+  if (entityType !== PREVIOUS_ANSWER || !previousAnswer) {
+    return null;
+  }
+  return previousAnswer.id;
+};
+
+const getMetadata = (entityType, metadata) => {
+  if (entityType !== METADATA || !metadata) {
+    return null;
+  }
+  return metadata.id;
+};
+
+export const dateReadToWriteMapper = outputKey => ({
+  id,
+  customDate,
+  previousAnswer,
+  metadata,
+  entityType,
+  ...rest
+}) => ({
+  id,
+  [outputKey]: {
+    ...omit("enabled", rest),
+    entityType,
+    custom: getCustom(entityType, customDate),
+    previousAnswer: getPreviousAnswer(entityType, previousAnswer),
+    metadata: getMetadata(entityType, metadata)
+  }
+});
+
+export const durationReadToWriteMapper = outputKey => ({ id, ...rest }) => ({
+  id,
+  [outputKey]: { ...omit("enabled", rest) }
+});

--- a/eq-author/src/components/Validation/Date/readToWriteMapper.test.js
+++ b/eq-author/src/components/Validation/Date/readToWriteMapper.test.js
@@ -1,14 +1,17 @@
-import { readToWriteMapper } from "./builder";
+import {
+  dateReadToWriteMapper,
+  durationReadToWriteMapper
+} from "components/Validation/Date/readToWriteMapper";
 import {
   CUSTOM,
   METADATA,
   PREVIOUS_ANSWER
 } from "constants/validation-entity-types";
 
-describe("Date validation builder", () => {
-  describe("readToWriteMapper", () => {
+describe("readToWriteMapper", () => {
+  describe("dateReadToWriteMapper", () => {
     it("should map from the read to write structure for custom date", () => {
-      const mapper = readToWriteMapper("earliestDateInput");
+      const mapper = dateReadToWriteMapper("earliestDateInput");
       expect(
         mapper({
           id: 1,
@@ -40,7 +43,7 @@ describe("Date validation builder", () => {
     });
 
     it("should map from the read to write structure for previous answer", () => {
-      const mapper = readToWriteMapper("earliestDateInput");
+      const mapper = dateReadToWriteMapper("earliestDateInput");
       expect(
         mapper({
           id: 1,
@@ -58,8 +61,8 @@ describe("Date validation builder", () => {
       ).toEqual({
         id: 1,
         earliestDateInput: {
-          custom: null,
           previousAnswer: "1",
+          custom: null,
           metadata: null,
           entityType: PREVIOUS_ANSWER,
           offset: {
@@ -72,7 +75,7 @@ describe("Date validation builder", () => {
     });
 
     it("should map from the read to write structure for metadata", () => {
-      const mapper = readToWriteMapper("earliestDateInput");
+      const mapper = dateReadToWriteMapper("earliestDateInput");
       expect(
         mapper({
           id: 1,
@@ -90,9 +93,9 @@ describe("Date validation builder", () => {
       ).toEqual({
         id: 1,
         earliestDateInput: {
+          metadata: "1",
           custom: null,
           previousAnswer: null,
-          metadata: "1",
           entityType: METADATA,
           offset: {
             unit: "Months",
@@ -104,7 +107,7 @@ describe("Date validation builder", () => {
     });
 
     it("should null custom date when different entity type", () => {
-      const mapper = readToWriteMapper("earliestDateInput");
+      const mapper = dateReadToWriteMapper("earliestDateInput");
       expect(
         mapper({
           id: 1,
@@ -121,7 +124,6 @@ describe("Date validation builder", () => {
       ).toMatchObject({
         id: 1,
         earliestDateInput: {
-          custom: null,
           previousAnswer: "1",
           entityType: PREVIOUS_ANSWER
         }
@@ -129,7 +131,7 @@ describe("Date validation builder", () => {
     });
 
     it("should null previous answer when different entity type", () => {
-      const mapper = readToWriteMapper("earliestDateInput");
+      const mapper = dateReadToWriteMapper("earliestDateInput");
       expect(
         mapper({
           id: 1,
@@ -147,14 +149,13 @@ describe("Date validation builder", () => {
         id: 1,
         earliestDateInput: {
           custom: "12/12/2000",
-          previousAnswer: null,
           entityType: CUSTOM
         }
       });
     });
 
     it("should send null when the custom date is empty", () => {
-      const mapper = readToWriteMapper("latestDateInput");
+      const mapper = dateReadToWriteMapper("latestDateInput");
       expect(
         mapper({
           id: 1,
@@ -171,8 +172,8 @@ describe("Date validation builder", () => {
         id: 1,
         latestDateInput: {
           custom: null,
-          previousAnswer: null,
           metadata: null,
+          previousAnswer: null,
           offset: {
             unit: "Months",
             value: 1
@@ -184,7 +185,7 @@ describe("Date validation builder", () => {
     });
 
     it("should not get previous answer id when previous answer is null", () => {
-      const mapper = readToWriteMapper("latestDateInput");
+      const mapper = dateReadToWriteMapper("latestDateInput");
       expect(
         mapper({
           id: 1,
@@ -203,8 +204,8 @@ describe("Date validation builder", () => {
         id: 1,
         latestDateInput: {
           custom: null,
-          previousAnswer: null,
           metadata: null,
+          previousAnswer: null,
           offset: {
             unit: "Months",
             value: 1
@@ -216,7 +217,7 @@ describe("Date validation builder", () => {
     });
 
     it("should not get metadata id when metadata is null", () => {
-      const mapper = readToWriteMapper("latestDateInput");
+      const mapper = dateReadToWriteMapper("latestDateInput");
       expect(
         mapper({
           id: 1,
@@ -235,14 +236,38 @@ describe("Date validation builder", () => {
         id: 1,
         latestDateInput: {
           custom: null,
-          previousAnswer: null,
           metadata: null,
+          previousAnswer: null,
           offset: {
             unit: "Months",
             value: 1
           },
           relativePosition: "Before",
           entityType: METADATA
+        }
+      });
+    });
+  });
+
+  describe("durationReadToWriteMapper", () => {
+    it("should remove enabled key", () => {
+      const mapper = durationReadToWriteMapper("minDurationInput");
+      expect(
+        mapper({
+          id: 1,
+          duration: {
+            unit: "Months",
+            value: 1
+          },
+          enabled: true
+        })
+      ).toEqual({
+        id: 1,
+        minDurationInput: {
+          duration: {
+            unit: "Months",
+            value: 1
+          }
         }
       });
     });

--- a/eq-author/src/components/Validation/DisabledMessage.js
+++ b/eq-author/src/components/Validation/DisabledMessage.js
@@ -1,6 +1,8 @@
+import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 
-const DisabledMessage = styled.div`
+const Message = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8,5 +10,11 @@ const DisabledMessage = styled.div`
   font-weight: bold;
   margin-bottom: 3em;
 `;
+
+const DisabledMessage = ({ name }) => <Message>{name} is disabled</Message>;
+
+DisabledMessage.propTypes = {
+  name: PropTypes.string.isRequired
+};
 
 export default DisabledMessage;

--- a/eq-author/src/components/Validation/DisabledMessage.test.js
+++ b/eq-author/src/components/Validation/DisabledMessage.test.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import DisabledMessage from "components/Validation/DisabledMessage";
+
+const render = props => shallow(<DisabledMessage {...props} />);
+
+describe("AnswerValidation", () => {
+  let props, wrapper;
+  beforeEach(() => {
+    props = {
+      name: "foobar"
+    };
+
+    wrapper = render(props);
+  });
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/eq-author/src/components/Validation/MaxValue.js
+++ b/eq-author/src/components/Validation/MaxValue.js
@@ -128,9 +128,7 @@ export class MaxValue extends React.Component {
     this.props.onUpdateAnswerValidation(updateValidationRuleInput);
   };
 
-  renderDisabled = () => (
-    <DisabledMessage>Max value is disabled</DisabledMessage>
-  );
+  renderDisabled = () => <DisabledMessage name="Max value" />;
 
   renderContent = () => {
     return (

--- a/eq-author/src/components/Validation/MinValue.js
+++ b/eq-author/src/components/Validation/MinValue.js
@@ -65,9 +65,7 @@ export const MinValue = ({
     onUpdateAnswerValidation(updateValidationRuleInput);
   };
 
-  const renderDisabled = () => (
-    <DisabledMessage>Min value is disabled</DisabledMessage>
-  );
+  const renderDisabled = () => <DisabledMessage name="Min value" />;
 
   const renderContent = () => (
     <Grid>

--- a/eq-author/src/components/Validation/__snapshots__/DisabledMessage.test.js.snap
+++ b/eq-author/src/components/Validation/__snapshots__/DisabledMessage.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AnswerValidation should render 1`] = `
+<DisabledMessage__Message>
+  foobar
+   is disabled
+</DisabledMessage__Message>
+`;

--- a/eq-author/src/components/Validation/__snapshots__/MaxValue.test.js.snap
+++ b/eq-author/src/components/Validation/__snapshots__/MaxValue.test.js.snap
@@ -53,8 +53,8 @@ exports[`MaxValue should render with disabled content 1`] = `
   enabled={false}
   onToggleChange={[Function]}
 >
-  <DisabledMessage>
-    Max value is disabled
-  </DisabledMessage>
+  <DisabledMessage
+    name="Max value"
+  />
 </ValidationView>
 `;

--- a/eq-author/src/components/Validation/__snapshots__/MinValue.test.js.snap
+++ b/eq-author/src/components/Validation/__snapshots__/MinValue.test.js.snap
@@ -48,8 +48,8 @@ exports[`MinValue should render with disabled content 1`] = `
   enabled={false}
   onToggleChange={[Function]}
 >
-  <DisabledMessage>
-    Min value is disabled
-  </DisabledMessage>
+  <DisabledMessage
+    name="Min value"
+  />
 </ValidationView>
 `;

--- a/eq-author/src/constants/durations.js
+++ b/eq-author/src/constants/durations.js
@@ -1,0 +1,3 @@
+export const DAYS = "Days";
+export const MONTHS = "Months";
+export const YEARS = "Years";

--- a/eq-author/src/containers/enhancers/withToggleAnswerValidation.js
+++ b/eq-author/src/containers/enhancers/withToggleAnswerValidation.js
@@ -2,6 +2,8 @@ import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
+import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
+import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
 
@@ -10,6 +12,8 @@ export const TOGGLE_VALIDATION_RULE = gql`
     toggleValidationRule(input: $input) {
       ...MinValueValidationRule
       ...MaxValueValidationRule
+      ...MinDurationValidationRule
+      ...MaxDurationValidationRule
       ...EarliestDateValidationRule
       ...LatestDateValidationRule
     }
@@ -17,7 +21,11 @@ export const TOGGLE_VALIDATION_RULE = gql`
 
   ${MinValueValidationRule}
   ${MaxValueValidationRule}
+  ${MinDurationValidationRule}
+  ${MaxDurationValidationRule}
   ${EarliestDateValidationRule}
+  ${LatestDateValidationRule}
+  ${MinValueValidationRule}
   ${LatestDateValidationRule}
 `;
 

--- a/eq-author/src/containers/enhancers/withUpdateAnswerValidation.js
+++ b/eq-author/src/containers/enhancers/withUpdateAnswerValidation.js
@@ -4,6 +4,8 @@ import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
+import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
+import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
 
 export const UPDATE_VALIDATION_RULE = gql`
   mutation updateValidationRule($input: UpdateValidationRuleInput!) {
@@ -12,6 +14,8 @@ export const UPDATE_VALIDATION_RULE = gql`
       ...MaxValueValidationRule
       ...EarliestDateValidationRule
       ...LatestDateValidationRule
+      ...MinDurationValidationRule
+      ...MaxDurationValidationRule
     }
   }
 
@@ -19,6 +23,8 @@ export const UPDATE_VALIDATION_RULE = gql`
   ${MaxValueValidationRule}
   ${EarliestDateValidationRule}
   ${LatestDateValidationRule}
+  ${MinDurationValidationRule}
+  ${MaxDurationValidationRule}
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({

--- a/eq-author/src/graphql/createAnswer.graphql
+++ b/eq-author/src/graphql/createAnswer.graphql
@@ -4,6 +4,8 @@
 #import "./fragments/max-value-validation-rule.graphql"
 #import "./fragments/earliest-date-validation-rule.graphql"
 #import "./fragments/latest-date-validation-rule.graphql"
+#import "./fragments/min-duration-validation-rule.graphql"
+#import "./fragments/max-duration-validation-rule.graphql"
 
 mutation createAnswer($input: CreateAnswerInput!) {
   createAnswer(input: $input) {
@@ -41,12 +43,18 @@ mutation createAnswer($input: CreateAnswerInput!) {
         ...Answer
       }
       validation {
-        ... on DateValidation {
+        ... on DateRangeValidation {
           earliestDate {
             ...EarliestDateValidationRule
           }
           latestDate {
             ...LatestDateValidationRule
+          }
+          minDuration {
+            ...MinDurationValidationRule
+          }
+          maxDuration {
+            ...MaxDurationValidationRule
           }
         }
       }

--- a/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
@@ -1,0 +1,8 @@
+fragment MaxDurationValidationRule on MaxDurationValidationRule {
+    id
+    enabled
+    duration {
+        value
+        unit
+    }
+}

--- a/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
@@ -1,0 +1,8 @@
+fragment MinDurationValidationRule on MinDurationValidationRule {
+  id
+  enabled
+  duration {
+    value
+    unit
+  }
+}

--- a/eq-publisher/src/api/queries.js
+++ b/eq-publisher/src/api/queries.js
@@ -13,12 +13,18 @@ exports.getQuestionnaire = `
   
   fragment CompositeAnswer on CompositeAnswer {
     validation {
-      ... on DateValidation {
+      ... on DateRangeValidation {
         earliestDate {
           ...EarliestDateValidationRule
         }
         latestDate {
           ...LatestDateValidationRule
+        }
+        minDuration {
+          ...MinDurationValidationRule
+        }
+        maxDuration {
+          ...MaxDurationValidationRule
         }
       }
     }
@@ -100,6 +106,24 @@ exports.getQuestionnaire = `
     }
     metadata {
       key
+    }
+  }
+  
+  fragment MinDurationValidationRule on MinDurationValidationRule {
+    id
+    enabled
+    duration {
+      value
+      unit
+    }
+  }
+    
+  fragment MaxDurationValidationRule on MaxDurationValidationRule {
+    id
+    enabled
+    duration {
+      value
+      unit
     }
   }
 

--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -1,6 +1,7 @@
 const Answer = require("./Answer");
 const { parseGuidance, getInnerHTMLWithPiping } = require("../utils/HTMLUtils");
 const { find, get, flow, isNil, assign, concat } = require("lodash/fp");
+const { set } = require("lodash");
 const convertPipes = require("../utils/convertPipes");
 
 const findDateRange = flow(
@@ -39,10 +40,34 @@ class Question {
       this.type = "DateRange";
       this.answers = this.buildDateRangeAnswers(dateRange);
 
-      const { earliestDate, latestDate } = dateRange.validation;
+      const {
+        earliestDate,
+        latestDate,
+        minDuration,
+        maxDuration
+      } = dateRange.validation;
+
       if (earliestDate.enabled || latestDate.enabled) {
         this.answers[0].minimum = Answer.buildDateValidation(earliestDate);
         this.answers[1].maximum = Answer.buildDateValidation(latestDate);
+      }
+
+      if (minDuration.enabled || maxDuration.enabled) {
+        /* eslint-disable-next-line camelcase */
+        if (minDuration.enabled) {
+          set(
+            this,
+            `period_limits.minimum.${minDuration.duration.unit}`.toLowerCase(),
+            minDuration.duration.value
+          );
+        }
+        if (maxDuration.enabled) {
+          set(
+            this,
+            `period_limits.maximum.${maxDuration.duration.unit}`.toLowerCase(),
+            maxDuration.duration.value
+          );
+        }
       }
     } else if (mutuallyExclusive) {
       this.type = "MutuallyExclusive";

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -89,6 +89,22 @@ describe("Question", () => {
             unit: "Years"
           },
           relativePosition: "After"
+        },
+        minDuration: {
+          id: "3",
+          enabled: true,
+          duration: {
+            value: 13,
+            unit: "Days"
+          }
+        },
+        maxDuration: {
+          id: "4",
+          enabled: true,
+          duration: {
+            value: 2,
+            unit: "Months"
+          }
         }
       };
     });
@@ -246,6 +262,20 @@ describe("Question", () => {
             offset_by: {
               years: 10
             }
+          }
+        })
+      );
+      expect(question.period_limits).toEqual(
+        expect.objectContaining({
+          minimum: {
+            days: 13
+          }
+        })
+      );
+      expect(question.period_limits).toEqual(
+        expect.objectContaining({
+          maximum: {
+            months: 2
           }
         })
       );


### PR DESCRIPTION
### What is the context of this PR?
Adds min and max duration validation to date range answers.  This enforces users in `eq-survey-runner` to enter a date within the specified duration period. 

### How to review 
- Ensure test pass
- Create a date range answer and add a min/max duration validation rule and ensure `eq-survey-runner` shows appropriate validation messages when trying to submit data outside of the min/max duration rules set

