### PR TITLE
Add metadata to earliest and latest date validation for date range answers

### DIFF
--- a/eq-author-api/repositories/ValidationRepository.js
+++ b/eq-author-api/repositories/ValidationRepository.js
@@ -1,6 +1,6 @@
 const Validation = require("../db/Validation");
 const { head, flow, keys, remove, first } = require("lodash/fp");
-const { DATE: ANSWER_DATE } = require("../constants/answerTypes");
+const { DATE, DATE_RANGE } = require("../constants/answerTypes");
 const { DATE: METADATA_DATE } = require("../constants/metadataTypes");
 
 module.exports = knex => {
@@ -78,7 +78,7 @@ module.exports = knex => {
       .where("Validation_AnswerRules.id", id)
       .then(head)
       .then(({ answerType, questionnaireId }) => {
-        if (answerType === ANSWER_DATE) {
+        if (answerType === DATE || answerType === DATE_RANGE) {
           return knex("Metadata")
             .select("Metadata.*")
             .andWhere("type", METADATA_DATE)

--- a/eq-author-api/schema/resolversTests/validation.test.js
+++ b/eq-author-api/schema/resolversTests/validation.test.js
@@ -437,7 +437,7 @@ describe("resolvers", () => {
 
     describe("Latest", () => {
       it("should be able to update properties", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
         const result = await mutateValidationParameters({
           id: validation.latestDate.id,
@@ -458,8 +458,8 @@ describe("resolvers", () => {
       });
 
       it("can update previous answer", async () => {
-        const previousAnswer = await createNewAnswer(firstPage, "Date");
-        const answer = await createNewAnswer(firstPage, "Date");
+        const previousAnswer = await createNewAnswer(firstPage, DATE);
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const result = await mutateValidationParameters({
@@ -481,7 +481,7 @@ describe("resolvers", () => {
 
       it("can update metadata", async () => {
         const metadata = await createMetadata(questionnaire.id);
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const result = await mutateValidationParameters({
@@ -502,7 +502,7 @@ describe("resolvers", () => {
       });
 
       it("can update entity type", async () => {
-        const answer = await createNewAnswer(firstPage, "Date");
+        const answer = await createNewAnswer(firstPage, DATE);
         const validation = await queryAnswerValidations(answer.id);
 
         const entityTypes = [CUSTOM, PREVIOUS_ANSWER, METADATA, NOW];
@@ -599,6 +599,52 @@ describe("resolvers", () => {
         };
         expect(result).toEqual(expected);
       });
+
+      it("can update metadata", async () => {
+        const metadata = await createMetadata(questionnaire.id);
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+
+        const result = await mutateValidationParameters({
+          id: validation.earliestDate.id,
+          earliestDateInput: {
+            ...params,
+            entityType: METADATA,
+            metadata: metadata.id
+          }
+        });
+
+        expect(result).toMatchObject({
+          entityType: METADATA,
+          metadata: {
+            id: metadata.id
+          }
+        });
+      });
+
+      it("can update entity type", async () => {
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+
+        const entityTypes = [CUSTOM, METADATA];
+
+        const promises = entityTypes.map(async entityType => {
+          const result = await mutateValidationParameters({
+            id: validation.earliestDate.id,
+            earliestDateInput: {
+              ...params,
+              entityType
+            }
+          });
+
+          expect(result).toMatchObject({
+            id: validation.earliestDate.id,
+            entityType
+          });
+        });
+
+        await Promise.all(promises);
+      });
     });
 
     describe("Latest", () => {
@@ -621,6 +667,52 @@ describe("resolvers", () => {
         };
 
         expect(result).toEqual(expected);
+      });
+
+      it("can update metadata", async () => {
+        const metadata = await createMetadata(questionnaire.id);
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+
+        const result = await mutateValidationParameters({
+          id: validation.latestDate.id,
+          latestDateInput: {
+            ...params,
+            entityType: METADATA,
+            metadata: metadata.id
+          }
+        });
+
+        expect(result).toMatchObject({
+          entityType: METADATA,
+          metadata: {
+            id: metadata.id
+          }
+        });
+      });
+
+      it("can update entity type", async () => {
+        const answer = await createNewAnswer(firstPage, DATE_RANGE);
+        const validation = await queryAnswerValidations(answer.id);
+
+        const entityTypes = [CUSTOM, METADATA];
+
+        const promises = entityTypes.map(async entityType => {
+          const result = await mutateValidationParameters({
+            id: validation.latestDate.id,
+            latestDateInput: {
+              ...params,
+              entityType
+            }
+          });
+
+          expect(result).toMatchObject({
+            id: validation.latestDate.id,
+            entityType
+          });
+        });
+
+        await Promise.all(promises);
       });
     });
 

--- a/eq-author/cypress/builders/metadata.js
+++ b/eq-author/cypress/builders/metadata.js
@@ -21,3 +21,17 @@ export const addMetadata = (metadataKey, type) => {
     .contains("Done")
     .click();
 };
+
+export const deleteFirstMetadata = () => {
+  cy.get(testId("metadata-btn")).as("metadataBtn");
+  cy.get("@metadataBtn").should("be.visible");
+  cy.get("@metadataBtn").click();
+
+  cy.get(testId("metadata-delete-row")).as("deleteMetadataBtn");
+  cy.get("@deleteMetadataBtn").should("be.visible");
+  cy.get("@deleteMetadataBtn").click();
+
+  cy.get("button")
+    .contains("Done")
+    .click();
+};

--- a/eq-author/cypress/integration/authenticated/validation_spec.js
+++ b/eq-author/cypress/integration/authenticated/validation_spec.js
@@ -19,7 +19,7 @@ import {
   switchPilltab
 } from "../../utils";
 
-import { addMetadata } from "../../builders/metadata";
+import { addMetadata, deleteFirstMetadata } from "../../builders/metadata";
 
 const METADATA_KEY = "ru_ref_custom";
 
@@ -427,9 +427,18 @@ describe("Answer Validation", () => {
         removeAnswer();
       });
     });
+
+    after(() => {
+      deleteFirstMetadata();
+    });
   });
 
   describe("Date Range", () => {
+    before(() => {
+      cy.login();
+      addMetadata(METADATA_KEY, "Date");
+    });
+
     beforeEach(() => {
       cy.login();
     });
@@ -497,6 +506,11 @@ describe("Answer Validation", () => {
           .should("have.value", "1985-09-14");
       });
 
+      it("should update metadata", () => {
+        toggleCheckboxOn("@earliestDateToggle");
+        setMetadata("@earliestDate", METADATA_KEY);
+      });
+
       afterEach(() => {
         removeAnswer();
       });
@@ -556,6 +570,11 @@ describe("Answer Validation", () => {
           .type("1985-09-14")
           .blur()
           .should("have.value", "1985-09-14");
+      });
+
+      it("should update metadata", () => {
+        toggleCheckboxOn("@latestDateToggle");
+        setMetadata("@latestDate", METADATA_KEY);
       });
 
       afterEach(() => {
@@ -679,6 +698,10 @@ describe("Answer Validation", () => {
       afterEach(() => {
         removeAnswer();
       });
+    });
+
+    after(() => {
+      deleteFirstMetadata();
     });
   });
 });

--- a/eq-author/src/components/ContentPickerSelect/index.js
+++ b/eq-author/src/components/ContentPickerSelect/index.js
@@ -27,7 +27,6 @@ export const ContentSelectButton = styled(Button).attrs({
   height: 2.5em;
   width: 100%;
   justify-content: space-between;
-  margin-bottom: 1px;
 
   &::after {
     content: url(${iconChevron});

--- a/eq-author/src/components/Validation/AvailableMetadataQuery.js
+++ b/eq-author/src/components/Validation/AvailableMetadataQuery.js
@@ -28,6 +28,24 @@ const GET_AVAILABLE_METADATA = gql`
           }
         }
       }
+      ... on CompositeAnswer {
+        validation {
+          ... on DateRangeValidation {
+            earliestDate {
+              id
+              availableMetadata {
+                ...AvailableMetadata
+              }
+            }
+            latestDate {
+              id
+              availableMetadata {
+                ...AvailableMetadata
+              }
+            }
+          }
+        }
+      }
     }
   }
   ${AvailableMetadata}

--- a/eq-author/src/components/Validation/Date/DateValidation.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.js
@@ -26,7 +26,7 @@ const RELATIVE_POSITIONS = ["Before", "After"];
 
 const DateInput = styled(Input)`
   width: 12em;
-  height: 2.25em;
+  height: 2.5em;
 `;
 
 const ConnectedPath = styled(Path)`
@@ -37,13 +37,15 @@ const RelativePositionSelect = styled(Select)`
   width: 6em;
 `;
 
-const StartDateText = styled.div`
-  margin: 0;
-  padding-top: 0.4em;
+const RelativePositionText = styled(EmphasisedText)`
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
 `;
 
-const CustomInput = styled.div`
-  margin-top: 5em;
+const StartDateText = styled.div`
+  margin: 0;
+  padding-top: 0.5em;
+  height: 2.5em;
 `;
 
 const START_COL_SIZE = 3;
@@ -134,6 +136,16 @@ class DateValidation extends React.Component {
 
     const availableUnits = getUnits({ format, type });
 
+    const validationPills = {
+      Metadata: this.Metadata,
+      Custom: this.Custom
+    };
+
+    if (type === DATE) {
+      validationPills.PreviousAnswer = this.PreviousAnswer;
+      validationPills.Now = this.Now;
+    }
+
     return (
       <div>
         <Grid>
@@ -173,22 +185,16 @@ class DateValidation extends React.Component {
               </RelativePositionSelect>
             )}
             {type === DATE_RANGE && (
-              <EmphasisedText>{relativePosition}</EmphasisedText>
+              <RelativePositionText>{relativePosition}</RelativePositionText>
             )}
             <PathEnd />
           </AlignedColumn>
           <Column cols={9}>
-            {type === DATE && (
-              <ValidationPills
-                entityType={entityType}
-                onEntityTypeChange={this.handleEntityTypeChange}
-                PreviousAnswer={this.PreviousAnswer}
-                Metadata={this.Metadata}
-                Custom={this.Custom}
-                Now={this.Now}
-              />
-            )}
-            {type === DATE_RANGE && <CustomInput>{this.Custom()}</CustomInput>}
+            <ValidationPills
+              entityType={entityType}
+              onEntityTypeChange={this.handleEntityTypeChange}
+              {...validationPills}
+            />
           </Column>
         </Grid>
       </div>

--- a/eq-author/src/components/Validation/Date/DateValidation.test.js
+++ b/eq-author/src/components/Validation/Date/DateValidation.test.js
@@ -50,13 +50,22 @@ describe("Date Validation", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("should render custom input for date range type answer", () => {
+  it("should render previous answer, metadata, custom and now for date type answer", () => {
+    const answer = {
+      ...props.answer,
+      type: DATE
+    };
+    const wrapper = shallow(<DateValidation {...props} answer={answer} />);
+    expect(wrapper.find(ValidationPills)).toMatchSnapshot();
+  });
+
+  it("should render metadata and custom for date range type answer", () => {
     const answer = {
       ...props.answer,
       type: DATE_RANGE
     };
     const wrapper = shallow(<DateValidation {...props} answer={answer} />);
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(ValidationPills)).toMatchSnapshot();
   });
 
   it("should call onToggleValidationRule when enabled/disabled", () => {

--- a/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
+++ b/eq-author/src/components/Validation/Date/__snapshots__/DateValidation.test.js.snap
@@ -29,90 +29,6 @@ Array [
 ]
 `;
 
-exports[`Date Validation should render custom input for date range type answer 1`] = `
-<ValidationView
-  data-test="example-test-id"
-  enabled={true}
-  onToggleChange={[Function]}
->
-  <div>
-    <Grid
-      align="top"
-      fillHeight={true}
-    >
-      <AlignedColumn
-        cols={3}
-      >
-        <EmphasisedText>
-          Some date
-           is
-        </EmphasisedText>
-      </AlignedColumn>
-      <Column
-        cols={9}
-      >
-        <Duration
-          duration={
-            Object {
-              "unit": "Months",
-              "value": 5,
-            }
-          }
-          name="offset"
-          onChange={[MockFunction]}
-          onUpdate={[MockFunction]}
-          units={
-            Array [
-              "Days",
-              "Months",
-              "Years",
-            ]
-          }
-        />
-      </Column>
-    </Grid>
-    <Grid
-      align="top"
-      fillHeight={true}
-    >
-      <Column
-        cols={3}
-      >
-        <DateValidation__ConnectedPath />
-      </Column>
-    </Grid>
-    <Grid
-      align="top"
-      fillHeight={true}
-    >
-      <AlignedColumn
-        cols={3}
-      >
-        <EmphasisedText>
-          Before
-        </EmphasisedText>
-        <Component />
-      </AlignedColumn>
-      <Column
-        cols={9}
-      >
-        <DateValidation__CustomInput>
-          <DateValidation__DateInput
-            max="9999-12-30"
-            min="1000-01-01"
-            name="customDate"
-            onBlur={[MockFunction]}
-            onChange={[MockFunction]}
-            type="date"
-            value="2018-01-01"
-          />
-        </DateValidation__CustomInput>
-      </Column>
-    </Grid>
-  </div>
-</ValidationView>
-`;
-
 exports[`Date Validation should render disabled message when not enabled 1`] = `
 <ValidationView
   data-test="example-test-id"
@@ -123,6 +39,26 @@ exports[`Date Validation should render disabled message when not enabled 1`] = `
     name="Some date"
   />
 </ValidationView>
+`;
+
+exports[`Date Validation should render metadata and custom for date range type answer 1`] = `
+<ValidationPills
+  Custom={[Function]}
+  Metadata={[Function]}
+  entityType="Custom"
+  onEntityTypeChange={[Function]}
+/>
+`;
+
+exports[`Date Validation should render previous answer, metadata, custom and now for date type answer 1`] = `
+<ValidationPills
+  Custom={[Function]}
+  Metadata={[Function]}
+  Now={[Function]}
+  PreviousAnswer={[Function]}
+  entityType="Custom"
+  onEntityTypeChange={[Function]}
+/>
 `;
 
 exports[`Date Validation should render the form input with the values when enabled 1`] = `

--- a/eq-author/src/components/Validation/ValidationInput.js
+++ b/eq-author/src/components/Validation/ValidationInput.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 const ValidationInput = styled(Input)`
   width: 10em;
+  height: 2.5em;
 `;
 
 export default ValidationInput;

--- a/eq-author/src/components/Validation/path-end.svg
+++ b/eq-author/src/components/Validation/path-end.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="150px" height="99px" viewBox="-25 0 150 99" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="150px" height="100px" viewBox="-25 0 150 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
     <desc>Created with Sketch.</desc>
     <defs></defs>


### PR DESCRIPTION
### What is the context of this PR?
Adds metadata to earliest and latest date validation for date range answers.  This enforces `eq-survey-runner` users to enter a date within the boundaries specified.

### How to review 
- Run tests
- Ensure appropriate validation messages appear on `eq-survey-runner` when entering a date outside the valid boundaries