### PR TITLE
Upgrade apollo

### DIFF
--- a/eq-author/cypress/builders/answer.js
+++ b/eq-author/cypress/builders/answer.js
@@ -17,6 +17,7 @@ const configureMultipleChoice = ({ initialCount }, { options }) => {
       cy.get(testId("btn-add-option")).click();
     }
   });
+  cy.get(testId("option-label")).should("have.length", options.length);
 };
 
 const configueBasicAnswer = ({ label, description }) => {

--- a/eq-author/cypress/e2e/e2e_spec.js
+++ b/eq-author/cypress/e2e/e2e_spec.js
@@ -3,21 +3,12 @@ import { question, questionnaire, section } from "../builders";
 describe("End to end", () => {
   let questionnaireId;
 
-  before(() => {
-    cy.visit("/");
-  });
-
-  beforeEach(() => {
-    cy.login();
-  });
-
   it("Can create a questionnaire", () => {
+    cy.visit("/");
+    cy.login();
     questionnaire.add({ title: "UKIS" }).then(({ id }) => {
       questionnaireId = id;
     });
-  });
-
-  it("Can create General Business Information Section", () => {
     section.updateInitial({
       title: "General Business Information"
     });

--- a/eq-author/cypress/utils/index.js
+++ b/eq-author/cypress/utils/index.js
@@ -153,9 +153,9 @@ export function assertHash({
 }
 
 export const typeIntoDraftEditor = (selector, text) => {
-  cy.log("Typing into RTE", text)
-    .get(selector)
+  cy.get(selector)
     .type(text)
+    .blur()
     .blur();
   cy.get(selector).should("contain", text);
 };

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -200,7 +200,10 @@ class RichTextEditor extends React.Component {
       this.focus();
     }
     /*eslint-disable react/no-did-update-set-state */
-    if (prevProps.value !== this.props.value) {
+    if (
+      prevProps.value !== this.props.value &&
+      typeof this.props.value === "string"
+    ) {
       const { editorState } = this.state;
       const anchorOffset = editorState.getSelection().get("anchorOffset");
       const valueUpdatedES = EditorState.push(

--- a/eq-author/src/components/withEntityEditor/index.js
+++ b/eq-author/src/components/withEntityEditor/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { filter } from "graphql-anywhere";
-import { isEqual } from "lodash";
+import { debounce, isEqual } from "lodash";
 import fp from "lodash/fp";
 import { startRequest, endRequest } from "../../redux/saving/actions";
 import { connect } from "react-redux";
@@ -68,23 +68,27 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
       }
     };
 
-    handleUpdate = () => {
-      if (!this.dirtyField) {
-        return;
-      }
+    handleUpdate = debounce(
+      () => {
+        if (!this.dirtyField) {
+          return;
+        }
 
-      this.dirtyField = null;
-      this.props.startRequest();
+        this.dirtyField = null;
+        this.props.startRequest();
 
-      this.props
-        .onUpdate(this.filteredEntity)
-        .then(() => {
-          this.props.endRequest();
-        })
-        .catch(() => {
-          this.props.endRequest();
-        });
-    };
+        this.props
+          .onUpdate(this.filteredEntity)
+          .then(() => {
+            this.props.endRequest();
+          })
+          .catch(() => {
+            this.props.endRequest();
+          });
+      },
+      20,
+      { trailing: true }
+    );
 
     componentWillUnmount() {
       this.unmounted = true;

--- a/eq-author/src/components/withEntityEditor/index.test.js
+++ b/eq-author/src/components/withEntityEditor/index.test.js
@@ -49,6 +49,7 @@ describe("withEntityEditor", () => {
       alias: "alias",
       __typename: "Foo"
     };
+    jest.useFakeTimers();
 
     wrapper = render();
   });
@@ -70,6 +71,7 @@ describe("withEntityEditor", () => {
     wrapper.simulate("change", { name: "title", value: newValue });
     wrapper.setProps({ entity });
     wrapper.simulate("update");
+    jest.runAllTimers();
     expect(handleUpdate).toHaveBeenCalledWith({
       ...omit(entity, "__typename"),
       title: "foo1"
@@ -116,6 +118,7 @@ describe("withEntityEditor", () => {
 
     wrapper.simulate("change", { name: "title", value: newValue });
     wrapper.simulate("update");
+    jest.runAllTimers();
 
     expect(handleUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ title: newValue })
@@ -175,6 +178,7 @@ describe("withEntityEditor", () => {
 
     wrapper.simulate("change", { name: "title", value: newValue });
     wrapper.simulate("update");
+    jest.runAllTimers();
 
     expect(handleUpdate).toHaveBeenCalled();
   });
@@ -188,6 +192,7 @@ describe("withEntityEditor", () => {
     });
     wrapper.simulate("change", { name: "title", value: newValue });
     wrapper.simulate("update");
+    jest.runAllTimers();
 
     expect(handleStartRequest).toHaveBeenCalled();
     expect(handleEndRequest).toHaveBeenCalled();
@@ -206,6 +211,7 @@ describe("withEntityEditor", () => {
 
     failingWrapper.simulate("change", { name: "title", value: newValue });
     failingWrapper.simulate("update");
+    jest.runAllTimers();
 
     expect(handleStartRequest).toHaveBeenCalled();
     expect(handleEndRequest).toHaveBeenCalled();
@@ -248,6 +254,8 @@ describe("withEntityEditor", () => {
 
     wrapper.simulate("change", { name: "deep.thing", value: "updated" });
     wrapper.simulate("update");
+    jest.runAllTimers();
+
     expect(handleUpdate).toHaveBeenCalledWith({
       id: 1,
       title: "title",
@@ -275,6 +283,8 @@ describe("withEntityEditor", () => {
     });
 
     wrapper.simulate("update");
+    jest.runAllTimers();
+
     expect(handleUpdate).toHaveBeenCalledWith({
       id: 1,
       title: "New title",
@@ -296,6 +306,8 @@ describe("withEntityEditor", () => {
     wrapper.simulate("submit", { preventDefault: jest.fn() });
 
     wrapper.simulate("update");
+    jest.runAllTimers();
+
     expect(handleUpdate).not.toHaveBeenCalled();
   });
 
@@ -305,5 +317,23 @@ describe("withEntityEditor", () => {
     expect(() => {
       instance.handleChange({ name: "title", value: "New title" });
     }).not.toThrow();
+  });
+
+  it("should run update once if triggered in quick succession", () => {
+    wrapper.simulate("change", { name: "alias", value: "updated alias" });
+    wrapper.simulate("update");
+
+    wrapper.simulate("change", { name: "title", value: "updated title" });
+    wrapper.simulate("update");
+
+    wrapper.simulate("update");
+    jest.runAllTimers();
+
+    expect(handleUpdate.mock.calls).toHaveLength(1);
+    expect(handleUpdate).toHaveBeenCalledWith({
+      id: entity.id,
+      title: "updated title",
+      alias: "updated alias"
+    });
   });
 });

--- a/eq-author/src/containers/enhancers/withUpdateSection.js
+++ b/eq-author/src/containers/enhancers/withUpdateSection.js
@@ -4,11 +4,9 @@ import updateSectionMutation from "graphql/updateSection.graphql";
 
 export const mapMutateToProps = ({ mutate }) => ({
   onUpdateSection(section) {
-    const mutation = mutate({
+    return mutate({
       variables: { input: section }
     });
-
-    return mutation.then(() => mutation);
   }
 });
 

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -1332,6 +1332,11 @@
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
   integrity sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==
 
+"@types/async@2.0.50":
+  version "2.0.50"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.50.tgz#117540e026d64e1846093abbd5adc7e27fda7bcb"
+  integrity sha512-VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==
+
 "@types/blob-util@1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/blob-util/-/blob-util-1.3.3.tgz#adba644ae34f88e1dd9a5864c66ad651caaf628a"
@@ -1886,7 +1891,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-cache-inmemory@^1.1.7, apollo-cache-inmemory@^1.2.5:
+apollo-cache-inmemory@^1.1.7:
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.10.tgz#362d6c36cfd815a309b966f71e5d2b6c770c7989"
   integrity sha512-eBusPFVtYIuo+PIfJdAwUCQ4cs7AJ4mB7sTdXxNQCXToYw8mzE6EfHnV37kdVfBXSaa82BzE2rb/YUq/duuamw==
@@ -1895,12 +1900,28 @@ apollo-cache-inmemory@^1.1.7, apollo-cache-inmemory@^1.2.5:
     apollo-utilities "^1.0.21"
     graphql-anywhere "^4.1.19"
 
-apollo-cache@1.1.17, apollo-cache@^1.1.17:
+apollo-cache-inmemory@^1.2.5:
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.12.tgz#cf7ef7c15730d0b6787d79047d5c06087ac31991"
+  integrity sha512-jxWcW64QoYQZ09UH6v3syvCCl3MWr6bsxT3wYYL6ORi8svdJUpnNrHTcv5qXqJYVg/a+NHhfEt+eGjJUG2ytXA==
+  dependencies:
+    apollo-cache "^1.1.22"
+    apollo-utilities "^1.0.27"
+    optimism "^0.6.8"
+
+apollo-cache@1.1.17:
   version "1.1.17"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.17.tgz#1fcca8423125223723b97fd72808be91a1a76490"
   integrity sha512-7sp24n2HZO4vXgTaKNomLyIfGxG4gDdDkBB0jkRzRi7HhnKmfwhiF/RCiKNbgLdrPX151INdls0KwIVliD0dHQ==
   dependencies:
     apollo-utilities "^1.0.21"
+
+apollo-cache@1.1.22, apollo-cache@^1.1.17, apollo-cache@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.22.tgz#d4682ea6e8b2508a934f61c2fd9e36b4a65041d9"
+  integrity sha512-8PoxhQLISj2oHwT7i/r4l+ly4y3RKZls+dtXzAewu3U77P9dNZKhYkRNAhx9iEfsrNoHgXBV8vMp64hb1uYh+g==
+  dependencies:
+    apollo-utilities "^1.0.27"
 
 apollo-client-preset@^1.0.8:
   version "1.0.8"
@@ -1913,7 +1934,7 @@ apollo-client-preset@^1.0.8:
     apollo-link-http "^1.3.1"
     graphql-tag "^2.4.2"
 
-apollo-client@^2.2.2, apollo-client@^2.3.5:
+apollo-client@^2.2.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.4.2.tgz#d2f044d8740723bf98a6d8d8b9684ee8c36150e6"
   integrity sha512-g1z23umaVSoKLj9xNl0aAnk2KBF4JeBi7MeKFc9CGTixH7TkqeQUQtxcjrC7j2h4KmDbuhOAHOFUGf8YshN+ag==
@@ -1928,35 +1949,51 @@ apollo-client@^2.2.2, apollo-client@^2.3.5:
   optionalDependencies:
     "@types/async" "2.0.49"
 
-apollo-link-context@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.10.tgz#c20b0b32c6e4e08c0d3967174f9c2a897c8431fe"
-  integrity sha512-HX3BEmkANs2A8AcYCy92SFJrW+0SbGrhDTSHV6ZwKIJ9ZrsOtly8cMrRLzEw1emjHIz5SP7XJEn3ko7BwhBBSw==
+apollo-client@^2.3.5:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.4.8.tgz#3a798f1076243465a59061d44d11bd030b68deb9"
+  integrity sha512-OAFbCTnGPtaIv0j+EZYzY20d+MD2JNbJ/YXZ4s0/oZlSg87bb0gjcIbccw2lnytipymZcZNr5ArFFeh0saGEwA==
   dependencies:
-    apollo-link "^1.2.4"
+    "@types/zen-observable" "^0.8.0"
+    apollo-cache "1.1.22"
+    apollo-link "^1.0.0"
+    apollo-link-dedup "^1.0.0"
+    apollo-utilities "1.0.27"
+    symbol-observable "^1.0.2"
+    zen-observable "^0.8.0"
+  optionalDependencies:
+    "@types/async" "2.0.50"
+
+apollo-link-context@^1.0.10:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.12.tgz#02d72e621a3b75239d4419a9bfd38d8bd9bb0d3f"
+  integrity sha512-gb4UptV9O6Kp3i5b2TlDEfPSL2LG//mTSb3zyuR5U2cAzu/huw98f1CCxcjUKTrlIMsQuE6G/hbaThDxnoIThQ==
+  dependencies:
+    apollo-link "^1.2.6"
 
 apollo-link-dedup@^1.0.0:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz#7b94589fe7f969777efd18a129043c78430800ae"
-  integrity sha512-tpUI9lMZsidxdNygSY1FxflXEkUZnvKRkMUsXXuQUNoSLeNtEvUX7QtKRAl4k9ubLl8JKKc9X3L3onAFeGTK8w==
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.13.tgz#bb22957e18b6125ae8bfb46cab6bda8d33ba8046"
+  integrity sha512-i4NuqT3DSFczFcC7NMUzmnYjKX7NggLY+rqYVf+kE9JjqKOQhT6wqhaWsVIABfIUGE/N0DTgYJBCMu/18aXmYA==
   dependencies:
-    apollo-link "^1.2.3"
+    apollo-link "^1.2.6"
 
 apollo-link-error@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.1.tgz#69d7124d4dc11ce60f505c940f05d4f1aa0945fb"
-  integrity sha512-/yPcaQWcBdB94vpJ4FsiCJt1dAGGRm+6Tsj3wKwP+72taBH+UsGRQQZk7U/1cpZwl1yqhHZn+ZNhVOebpPcIlA==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.5.tgz#1d600dfa75c4e4bf017f50d60da7b375b53047ab"
+  integrity sha512-gE0P711K+rI3QcTzfYhzRI9axXaiuq/emu8x8Y5NHK9jl9wxh7qmEc3ZTyGpnGFDDTXfhalmX17X5lp3RCVHDQ==
   dependencies:
-    apollo-link "^1.2.3"
+    apollo-link "^1.2.6"
+    apollo-link-http-common "^0.2.8"
 
-apollo-link-http-common@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz#d094beb7971523203359bf830bfbfa7b4e7c30ed"
-  integrity sha512-6FV1wr5AqAyJ64Em1dq5hhGgiyxZE383VJQmhIoDVc3MyNcFL92TkhxREOs4rnH2a9X2iJMko7nodHSGLC6d8w==
+apollo-link-http-common@^0.2.5, apollo-link-http-common@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.8.tgz#c6deedfc2739db8b11013c3c2d2ccd657152941f"
+  integrity sha512-gGmXZN8mr7e9zjopzKQfZ7IKnh8H12NxBDzvp9nXI3U82aCVb72p+plgoYLcpMY8w6krvoYjgicFmf8LO20TCQ==
   dependencies:
-    apollo-link "^1.2.3"
+    apollo-link "^1.2.6"
 
-apollo-link-http@^1.3.1, apollo-link-http@^1.5.3:
+apollo-link-http@^1.3.1:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.5.tgz#7dbe851821771ad67fa29e3900c57f38cbd80da8"
   integrity sha512-C5N6N/mRwmepvtzO27dgMEU3MMtRKSqcljBkYNZmWwH11BxkUQ5imBLPM3V4QJXNE7NFuAQAB5PeUd4ligivTQ==
@@ -1964,7 +2001,23 @@ apollo-link-http@^1.3.1, apollo-link-http@^1.5.3:
     apollo-link "^1.2.3"
     apollo-link-http-common "^0.2.5"
 
-apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.3:
+apollo-link-http@^1.5.3:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.9.tgz#9046f5640a94c8a8b508a39e0f2c628b781baecc"
+  integrity sha512-9tJy2zGm4Cm/1ycScDNZJe51dgnTSfKx7pKIgPZmcxkdDpgUY2DZitDH6ZBv4yp9z8MC9Xr9wgwc29s6hcadUQ==
+  dependencies:
+    apollo-link "^1.2.6"
+    apollo-link-http-common "^0.2.8"
+
+apollo-link@^1.0.0, apollo-link@^1.1.0, apollo-link@^1.2.3, apollo-link@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.6.tgz#d9b5676d79c01eb4e424b95c7171697f6ad2b8da"
+  integrity sha512-sUNlA20nqIF3gG3F8eyMD+mO80fmf3dPZX+GUOs3MI9oZR8ug09H3F0UsWJMcpEg6h55Yy5wZ+BMmAjrbenF/Q==
+  dependencies:
+    apollo-utilities "^1.0.0"
+    zen-observable-ts "^0.8.13"
+
+apollo-link@^1.0.6:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.3.tgz#9bd8d5fe1d88d31dc91dae9ecc22474d451fb70d"
   integrity sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==
@@ -1972,21 +2025,20 @@ apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.3:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.10"
 
-apollo-link@^1.1.0, apollo-link@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.4.tgz#ab4d21d2e428db848e88b5e8f4adc717b19c954b"
-  integrity sha512-B1z+9H2nTyWEhMXRFSnoZ1vSuAYP+V/EdUJvRx9uZ8yuIBZMm6reyVtr1n0BWlKeSFyPieKJy2RLzmITAAQAMQ==
-  dependencies:
-    apollo-utilities "^1.0.0"
-    zen-observable-ts "^0.8.11"
-
-apollo-utilities@1.0.21, apollo-utilities@^1.0.0, apollo-utilities@^1.0.21:
+apollo-utilities@1.0.21:
   version "1.0.21"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.21.tgz#cb8b5779fe275850b16046ff8373f4af2de90765"
   integrity sha512-ZcxELlEl+sDCYBgEMdNXJAsZtRVm8wk4HIA58bMsqYfd1DSAJQEtZ93F0GZgYNAGy3QyaoBeZtbb0/01++G8JQ==
   dependencies:
     fast-json-stable-stringify "^2.0.0"
     fclone "^1.0.11"
+
+apollo-utilities@1.0.27, apollo-utilities@^1.0.0, apollo-utilities@^1.0.21, apollo-utilities@^1.0.27:
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.27.tgz#77c550f9086552376eca3a48e234a1466b5b057e"
+  integrity sha512-nzrMQ89JMpNmYnVGJ4t8zN75gQbql27UDhlxNi+3OModp0Masx5g+fQmQJ5B4w2dpRuYOsdwFLmj3lQbwOKV1Q==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
 
 apollo-utilities@^1.0.1:
   version "1.0.25"
@@ -6427,7 +6479,14 @@ graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphql-anywhere@^4.1.19, graphql-anywhere@^4.1.3:
+graphql-anywhere@^4.1.19:
+  version "4.1.24"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.24.tgz#59e2a8bfd3d00ac75f6a377e31e4e9fdaa5ce786"
+  integrity sha512-g81K7FqXSF3q1iqFWlwiwD+g0SDkPUUa9+Wa+7BOrAe5+7R4BdNWL4dw9BRsJxt0Xx6nOaI2E+VM7QMAucQFvA==
+  dependencies:
+    apollo-utilities "^1.0.27"
+
+graphql-anywhere@^4.1.3:
   version "4.1.19"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.19.tgz#5f6ca3b58218e5449f4798e3c6d942fcd2fef082"
   integrity sha512-mQlvbECzYPBcgBC9JsdM4v+DSvNmcIP+8Vwr+ij3gktbaLSE0Iza30mztuz40Jlf7ooMs+0emBZucNjLzqz7tA==
@@ -6971,6 +7030,11 @@ ignore@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.0.4.tgz#33168af4a21e99b00c5d41cbadb6a6cb49903a45"
   integrity sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==
+
+immutable-tuple@^0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/immutable-tuple/-/immutable-tuple-0.4.9.tgz#473ebdd6c169c461913a454bf87ef8f601a20ff0"
+  integrity sha512-LWbJPZnidF8eczu7XmcnLBsumuyRBkpwIRPCZxlojouhBo5jEBO4toj6n7hMy6IxHU/c+MqDSWkvaTpPlMQcyA==
 
 immutable@^3.8.1:
   version "3.8.2"
@@ -9795,6 +9859,13 @@ opn@5.4.0, opn@^5.1.0, opn@^5.3.0:
   integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
   dependencies:
     is-wsl "^1.1.0"
+
+optimism@^0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.6.8.tgz#0780b546da8cd0a72e5207e0c3706c990c8673a6"
+  integrity sha512-bN5n1KCxSqwBDnmgDnzMtQTHdL+uea2HYFx1smvtE+w2AMl0Uy31g0aXnP/Nt85OINnMJPRpJyfRQLTCqn5Weg==
+  dependencies:
+    immutable-tuple "^0.4.9"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -14753,21 +14824,14 @@ yauzl@2.8.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-zen-observable-ts@^0.8.10:
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz#18e2ce1c89fe026e9621fd83cc05168228fce829"
-  integrity sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==
-  dependencies:
-    zen-observable "^0.8.0"
-
-zen-observable-ts@^0.8.11:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.11.tgz#d54a27cd17dc4b4bb6bd008e5c096af7fcb068a9"
-  integrity sha512-8bs7rgGV4kz5iTb9isudkuQjtWwPnQ8lXq6/T76vrepYZVMsDEv6BXaEA+DHdJSK3KVLduagi9jSpSAJ5NgKHw==
+zen-observable-ts@^0.8.10, zen-observable-ts@^0.8.13:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.13.tgz#ae1fd77c84ef95510188b1f8bca579d7a5448fc2"
+  integrity sha512-WDb8SM0tHCb6c0l1k60qXWlm1ok3zN9U4VkLdnBKQwIYwUoB9psH7LIFgR+JVCCMmBxUgOjskIid8/N02k/2Bg==
   dependencies:
     zen-observable "^0.8.0"
 
 zen-observable@^0.8.0:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.9.tgz#0475c760ff0eda046bbdfa4dc3f95d392807ac53"
-  integrity sha512-Y9kPzjGvIZ5jchSlqlCpBW3I82zBBL4z+ulXDRVA1NwsKzjt5kwAi+gOYIy0htNkfuehGZZtP5mRXHRV6TjDWw==
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.11.tgz#d3415885eeeb42ee5abb9821c95bb518fcd6d199"
+  integrity sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==


### PR DESCRIPTION
### What is the context of this PR?
Upgrade apollo packages which were causing issues in greenkeeper PRs.

Resolves #17 

Issues faced:
1. Race condition when adding a section introduction - As you blur a field (e.g. alias or title) to add a section introduction you trigger two updates of the section which was causing a race condition depending on which one finished first. So I have debounced update to make sure we collect all the updates in withEntityEditor and then send the complete entity after 20ms from the last update.
2. withDeletePage expected a stale cached read but it is now up to date so it was adding a new page when you deleted the second page in a section instead of only adding one when you deleted the last one.

### How to review 
1. Ensure all tests pass.
