### PR TITLE
Bug - RTE requiring double blur after change

### DIFF
--- a/eq-author/cypress/utils/index.js
+++ b/eq-author/cypress/utils/index.js
@@ -155,7 +155,6 @@ export function assertHash({
 export const typeIntoDraftEditor = (selector, text) => {
   cy.get(selector)
     .type(text)
-    .blur()
     .blur();
   cy.get(selector).should("contain", text);
 };

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -202,7 +202,8 @@ class RichTextEditor extends React.Component {
     /*eslint-disable react/no-did-update-set-state */
     if (
       prevProps.value !== this.props.value &&
-      typeof this.props.value === "string"
+      typeof this.props.value === "string" &&
+      this.props.value !== filterEmptyTags(this.getHTML())
     ) {
       const { editorState } = this.state;
       const anchorOffset = editorState.getSelection().get("anchorOffset");


### PR DESCRIPTION
### What is the context of this PR?
Only force selection when the new value coming in doesn't match the editor state.

Resolves #101 

### How to review 
1. Ensure you can recreate as per #101 on `master`
1. Ensure that this PR resolves the issue.