### PR TITLE
Fix flakey cypress tests

### DIFF
--- a/eq-author/cypress/utils/index.js
+++ b/eq-author/cypress/utils/index.js
@@ -102,6 +102,7 @@ export const buildMultipleChoiceAnswer = labelArray => {
       .get(testId("option-label"))
       .eq(index)
       .type(label)
+      .blur()
   );
 };
 

--- a/eq-author/src/redux/auth/reducer.js
+++ b/eq-author/src/redux/auth/reducer.js
@@ -26,5 +26,6 @@ export default (state = initialState, { type, payload }) => {
 };
 
 export const getUser = state => get(state, "auth.user");
-export const isSignedIn = () => !isNil(localStorage.getItem("accessToken"));
+export const isSignedIn = () =>
+  localStorage && !isNil(localStorage.getItem("accessToken"));
 export const verifiedAuthStatus = state => get(state, "auth.verifiedStatus");

--- a/eq-author/src/utils/appendAuthHeader.js
+++ b/eq-author/src/utils/appendAuthHeader.js
@@ -1,4 +1,11 @@
 export default headers => {
+  if (!window.localStorage) {
+    return {
+      headers: {
+        ...headers
+      }
+    };
+  }
   const accessToken = localStorage.getItem("accessToken");
   const returnedHeaders = {
     ...headers

--- a/eq-author/src/utils/appendAuthHeader.test.js
+++ b/eq-author/src/utils/appendAuthHeader.test.js
@@ -11,6 +11,25 @@ describe("appendAuthHeader", () => {
     localStorage.removeItem("accessToken");
   });
 
+  describe("non-existent localStorage", () => {
+    let tempLocalStorage = {};
+    beforeEach(() => {
+      Object.assign(tempLocalStorage, localStorage);
+      delete window.localStorage;
+    });
+    afterEach(() => {
+      Object.defineProperty(window, "localStorage", {
+        value: tempLocalStorage
+      });
+    });
+
+    it("should just return default headers if no localStorage exists", () => {
+      expect(appendAuthHeader(otherHeaders).headers).toMatchObject({
+        ContentType: "text/html"
+      });
+    });
+  });
+
   it("should append auth header if token exists", () => {
     localStorage.setItem("accessToken", "abc.def.ghi");
 


### PR DESCRIPTION
### What is the context of this PR?
Thi Pr is required as for some reason when cypress tests in the CI environment the local storage is not always initialised in time meaning that when we try and set it within our code base we get Type Errors.

Fixes https://github.com/ONSdigital/eq-author-app/issues/109

Also fixes an issue in the routing_spec where the option label fields were not being blurred after input causing the data to occasionally not be saved.

### How to review 
Not convinced this is the most correct way to fix it but it does seem to do the job so any discussion would be good. Other than that make sure CI tests pass.
