### PR TITLE
Remove SVG titles during webpack builds

### DIFF
--- a/eq-author/config/webpack.config.dev.js
+++ b/eq-author/config/webpack.config.dev.js
@@ -305,7 +305,14 @@ module.exports = {
                 resourceQuery: /inline/, // foo.svg?inline
                 use: [
                   { loader: "babel-loader" },
-                  { loader: "react-svg-loader" }
+                  {
+                    loader: "react-svg-loader",
+                    options: {
+                      svgo: {
+                        plugins: [{ removeTitle: true }]
+                      }
+                    }
+                  }
                 ]
               },
               {

--- a/eq-author/config/webpack.config.prod.js
+++ b/eq-author/config/webpack.config.prod.js
@@ -390,7 +390,14 @@ module.exports = {
                 resourceQuery: /inline/, // foo.svg?inline
                 use: [
                   { loader: "babel-loader" },
-                  { loader: "react-svg-loader" }
+                  {
+                    loader: "react-svg-loader",
+                    options: {
+                      svgo: {
+                        plugins: [{ removeTitle: true }]
+                      }
+                    }
+                  }
                 ]
               },
               {

--- a/eq-author/cypress/integration/authenticated/question_confirmation_spec.js
+++ b/eq-author/cypress/integration/authenticated/question_confirmation_spec.js
@@ -66,6 +66,7 @@ describe("Question Confirmation", () => {
 
   it("should be preview-able", () => {
     questionConfirmation.add();
+    cy.get(testId("preview")).contains('Preview');
     cy.get(testId("preview")).click();
     cy.hash().should("match", /\/preview$/);
   });


### PR DESCRIPTION
### What is the context of this PR?
Removes SVG titles during webpack builds as screen-readers will read out the title of an SVG if it is inlined.

### How to review 
- Ensure tests pass
- Validate SVG titles have been stripped out by inspecting a page.
- An example of an SVG with a title is: `src/App/QuestionnaireDesignPage/NavigationSidebar/icon-plus.svg` which can be found on the questionnaire design page. 