### PR TITLE
Fix ability to create Knex.js migrations as per README

### DIFF
--- a/eq-author-api/README.md
+++ b/eq-author-api/README.md
@@ -106,7 +106,7 @@ First start app using Docker.
 #### Create migration
 
 ```
-yarn knex -- migrate:make name_of_migration
+yarn knex migrate:make name_of_migration
 ```
 
 Where `name_of_migration` is the name you wish to use. e.g. `create_questionnaires_table`

--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "test": "./scripts/test.sh",
     "test:coverage": "yarn test --coverage",
-    "test:breakingChanges": "node scripts/checkForBreakingChanges.js"
+    "test:breakingChanges": "node scripts/checkForBreakingChanges.js",
+    "knex": "knex --knexfile config/knexfile.js --cwd ."
   },
   "dependencies": {
     "aws-sdk": "^2.363.0",


### PR DESCRIPTION
### What is the context of this PR?
- Fixes the ability to create database migrations using the command `yarn knex migrate:make name_of_migration` from our `README.md`.
- Removed as part of https://github.com/ONSdigital/eq-author-app/pull/74
- Updated `README.md` command to remove warning: `From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`

### How to review 
- Ensure tests pass
- Ensure you can run command `yarn knex migrate:make name_of_migration` from `eq-author-api` and migration is created