### PR TITLE
Fix to stop description cut off

### DIFF
--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -76,9 +76,12 @@ const Input = styled.div`
   padding: 0;
 
   .header-two,
-  .unstyled,
   .unordered-list-item {
     margin: 0;
+  }
+
+  .unstyled:not(:last-of-type) {
+    margin: 0 0 1em;
   }
 
   .header-two {

--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -1,5 +1,9 @@
 const Answer = require("./Answer");
-const { parseGuidance, getInnerHTMLWithPiping } = require("../utils/HTMLUtils");
+const {
+  parseGuidance,
+  getInnerHTMLWithPiping,
+  unescapePiping
+} = require("../utils/HTMLUtils");
 const { find, get, flow, isNil, assign, concat } = require("lodash/fp");
 const { set } = require("lodash");
 const convertPipes = require("../utils/convertPipes");
@@ -30,7 +34,7 @@ class Question {
     this.id = `question${question.id}`;
     this.title = processPipedText(ctx)(question.title);
     this.guidance = processGuidance(ctx)(question.guidance);
-    this.description = processPipedText(ctx)(question.description);
+    this.description = unescapePiping(convertPipes(ctx)(question.description));
 
     const dateRange = findDateRange(question);
 

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -323,6 +323,17 @@ describe("Question", () => {
       });
     });
 
+    it("should ensure discription text is not truncated if it includes multiple p tags", () => {
+      const question = new Question(
+        createQuestionJSON({
+          description: `<p>foo</p><p>bar</p>`
+        }),
+        createContext()
+      );
+
+      expect(question.description).toEqual("<p>foo</p><p>bar</p>");
+    });
+
     it("should handle piped values in description", () => {
       const question = new Question(
         createQuestionJSON({
@@ -331,7 +342,9 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.description).toEqual("{{ answers['answer123'] }}");
+      expect(question.description).toEqual(
+        "<h2>{{ answers['answer123'] }}</h2>"
+      );
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
The question description was getting cut off after a line break. Originally it was just taking the first html tag and dropping the rest when it got into publisher. So this change has been to bypass the stripping of HTML tags that is done in the processPipedText for this field and then update the test concerning this. The users still cannot put line breaks in but the text will no longer be cut off because of it. This was deemed out of scope for this task and is something that will need to be looked at in the future.

### How to review 
Make sure tests pass
