### PR TITLE
Added auth to graphql endpoint on Publisher

### DIFF
--- a/eq-publisher/src/main.js
+++ b/eq-publisher/src/main.js
@@ -38,7 +38,14 @@ const app = express();
 const setAuthHeaders = createAuthHeaderMiddleware(apolloFetch);
 
 if (process.env.NODE_ENV === "development") {
-  app.get("/graphql/:questionnaireId", logger, fetchData(api), respondWithData);
+  app.get(
+    "/graphql/:questionnaireId",
+    logger,
+    createAuthToken,
+    setAuthHeaders,
+    fetchData(api),
+    respondWithData
+  );
 }
 
 app.get(


### PR DESCRIPTION
### What is the context of this PR?
After a recent change to add an authentication header to api requests the `/graphql/:questionnaireId` endpoint would fail authentication as the header was not being correctly applied. This PR adds the correct headers to that endpoint allowing the data to be retrieved correctly.

### How to review 
Start up the app and assert that a request to `/graphql/:questionnaireId` works as expected.
