### PR TITLE
Add question page definitions

### DIFF
--- a/eq-author-api/migrations/20190110091733_add_definition_fields_to_question_page.js
+++ b/eq-author-api/migrations/20190110091733_add_definition_fields_to_question_page.js
@@ -1,0 +1,23 @@
+const { noop } = require("lodash");
+
+exports.up = async function(knex) {
+  await knex.schema.table("Pages", table => {
+    table.text("definitionLabel");
+    table.text("definitionContent");
+  });
+
+  await knex.raw(`DROP VIEW "PagesView"`);
+
+  return knex.raw(`
+    CREATE OR REPLACE VIEW "PagesView" AS (
+      SELECT *, ROW_NUMBER () OVER (
+        PARTITION BY "sectionId"
+        ORDER BY "order" ASC
+      ) - 1 AS "position"
+      FROM "Pages"
+      WHERE "isDeleted" = false
+    )
+  `);
+};
+
+exports.down = noop;

--- a/eq-author-api/repositories/PageRepository.test.js
+++ b/eq-author-api/repositories/PageRepository.test.js
@@ -29,7 +29,9 @@ const buildPage = page => ({
   alias: "Page alias",
   title: "Test page",
   description: "page description",
-  guidance: "page description",
+  guidance: "page guidance",
+  definitionLabel: "page definitionLabel",
+  definitionContent: "page definitionContent",
   pageType: "QuestionPage",
   ...page
 });

--- a/eq-author-api/repositories/QuestionPageRepository.js
+++ b/eq-author-api/repositories/QuestionPageRepository.js
@@ -22,7 +22,9 @@ module.exports = knex => {
     description,
     guidance,
     sectionId,
-    order
+    order,
+    definitionLabel,
+    definitionContent
   }) {
     return QuestionPage(knex)
       .create({
@@ -31,7 +33,9 @@ module.exports = knex => {
         description,
         guidance,
         sectionId,
-        order
+        order,
+        definitionLabel,
+        definitionContent
       })
       .then(head);
   };
@@ -42,7 +46,9 @@ module.exports = knex => {
     alias,
     description,
     guidance,
-    isDeleted
+    isDeleted,
+    definitionLabel,
+    definitionContent
   }) {
     return QuestionPage(knex)
       .update(id, {
@@ -50,7 +56,9 @@ module.exports = knex => {
         alias,
         description,
         guidance,
-        isDeleted
+        isDeleted,
+        definitionLabel,
+        definitionContent
       })
       .then(head);
   };
@@ -70,7 +78,6 @@ module.exports = knex => {
   const getPipingAnswersForQuestionPage = id =>
     getPreviousAnswersForPage({
       id,
-
       answerTypes: PIPING_ANSWER_TYPES
     });
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -70,6 +70,8 @@ type QuestionPage implements Page {
   answers: [Answer]
   section: Section
   position: Int!
+  definitionLabel: String
+  definitionContent: String
   routingRuleSet: RoutingRuleSet
   availablePipingAnswers: [Answer!]!
   availablePipingMetadata: [Metadata!]!
@@ -709,6 +711,8 @@ input CreateQuestionPageInput {
   guidance: String
   sectionId: ID!
   position: Int
+  definitionLabel: String
+  definitionContent: String
 }
 
 input UpdateQuestionPageInput {
@@ -717,6 +721,8 @@ input UpdateQuestionPageInput {
   title: String
   description: String
   guidance: String
+  definitionLabel: String
+  definitionContent: String
 }
 
 input DeleteQuestionPageInput {

--- a/eq-author-api/tests/schema/mutations/createQuestionPage.test.js
+++ b/eq-author-api/tests/schema/mutations/createQuestionPage.test.js
@@ -10,6 +10,8 @@ describe("createQuestionPage", () => {
         alias
         description
         guidance
+        definitionLabel
+        definitionContent
       }
     }
   `;
@@ -28,7 +30,9 @@ describe("createQuestionPage", () => {
       alias: "Test alias",
       description: "Test question description",
       guidance: "Test question guidance",
-      sectionId: "1"
+      sectionId: "1",
+      definitionLabel: "Test question definition label",
+      definitionContent: "Test question definition content"
     };
 
     const result = await executeQuery(

--- a/eq-author-api/tests/schema/mutations/updateQuestionPage.test.js
+++ b/eq-author-api/tests/schema/mutations/updateQuestionPage.test.js
@@ -10,6 +10,8 @@ describe("updateQuestionPage", () => {
         title
         description
         guidance
+        definitionLabel
+        definitionContent
       }
     }
   `;
@@ -28,7 +30,9 @@ describe("updateQuestionPage", () => {
       alias: "Updated question alias",
       title: "Updated question title",
       description: "This is an updated question description",
-      guidance: "Updated question description"
+      guidance: "Updated question description",
+      definitionLabel: "Updated question definition label",
+      definitionContent: "Updated question definition content"
     };
 
     const result = await executeQuery(

--- a/eq-author/cypress/integration/authenticated/builder_spec.js
+++ b/eq-author/cypress/integration/authenticated/builder_spec.js
@@ -94,6 +94,25 @@ describe("builder", () => {
     );
   });
 
+  it("Can edit question definition", () => {
+    const definitionLabel = "this is some definition label";
+    cy.get(testId("txt-question-definition-label")).type(definitionLabel);
+    cy.get(testId("txt-question-definition-label")).should(
+      "contain",
+      definitionLabel
+    );
+
+    const definitionContent = "this is some definition content";
+    typeIntoDraftEditor(
+      testId("txt-question-definition-content", "testid"),
+      definitionContent
+    );
+    cy.get(testId("txt-question-definition-content", "testid")).should(
+      "contain",
+      definitionContent
+    );
+  });
+
   it("Can delete a page", () => {
     checkIsOnDesignPage();
 

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/DefinitionEditor.js
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/DefinitionEditor.js
@@ -1,0 +1,43 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import { colors, radius } from "constants/theme";
+
+const Definition = styled.div`
+  border: 1px solid ${colors.bordersLight};
+  position: relative;
+  margin-bottom: 2em;
+  border-radius: ${radius};
+
+  &:focus-within {
+    border-color: ${colors.blue};
+    box-shadow: 0 0 0 1px ${colors.blue};
+  }
+`;
+
+const DefinitionLabel = styled.div`
+  color: ${colors.darkGrey};
+  font-weight: bold;
+  margin-bottom: 0.5em;
+`;
+
+const Padding = styled.div`
+  padding: 1.5em 1.5em 0;
+`;
+
+const DefinitionEditor = ({ label, children }) => (
+  <>
+    <DefinitionLabel>{label}</DefinitionLabel>
+    <Definition>
+      <Padding>{children}</Padding>
+    </Definition>
+  </>
+);
+
+DefinitionEditor.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.node
+};
+
+export default DefinitionEditor;

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/DefinitionEditor.test.js
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/DefinitionEditor.test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import DefinitionEditor from "./DefinitionEditor";
+
+const createWrapper = props => shallow(<DefinitionEditor {...props} />);
+
+describe("DefinitionEditor", () => {
+  let wrapper, props;
+
+  beforeEach(() => {
+    props = {
+      label: "foobar",
+      children: <p>Test</p>
+    };
+
+    wrapper = createWrapper(props);
+  });
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/MetaEditor.js
@@ -2,13 +2,20 @@ import React from "react";
 import { withApollo } from "react-apollo";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-
+import { propType } from "graphql-anywhere";
+import styled from "styled-components";
 import { get, flip, partial, flowRight } from "lodash";
 
+import WrappingInput from "components/Forms/WrappingInput";
 import RichTextEditor from "components/RichTextEditor";
+import { Field, Label } from "components/Forms";
+
+import DefinitionEditor from "./DefinitionEditor";
 
 import pageFragment from "graphql/fragments/page.graphql";
 import getAnswersQuery from "graphql/getAnswers.graphql";
+
+import { colors } from "constants/theme";
 
 const titleControls = {
   emphasis: true,
@@ -27,6 +34,13 @@ const guidanceControls = {
   list: true,
   piping: true
 };
+
+const Paragraph = styled.p`
+  margin: 0 0 1em;
+  background: ${colors.lighterGrey};
+  padding: 0.5em;
+  border-left: 5px solid ${colors.lightGrey};
+`;
 
 export class StatelessMetaEditor extends React.Component {
   render() {
@@ -61,7 +75,7 @@ export class StatelessMetaEditor extends React.Component {
         <RichTextEditor
           id="question-description"
           name="description"
-          label="Question description (optional)…"
+          label="Question description"
           value={page.description}
           onUpdate={handleUpdate}
           controls={descriptionControls}
@@ -70,11 +84,39 @@ export class StatelessMetaEditor extends React.Component {
           metadata={get(page, "section.questionnaire.metadata", [])}
           testSelector="txt-question-description"
         />
-
+        <DefinitionEditor label="Question definition">
+          <Paragraph>
+            Only to be used to define word(s) or acronym(s) within the question.
+          </Paragraph>
+          <Field>
+            <Label htmlFor="definition-label">Label</Label>
+            <WrappingInput
+              id="definition-label"
+              name="definitionLabel"
+              data-test="txt-question-definition-label"
+              onChange={onChange}
+              onBlur={onUpdate}
+              value={page.definitionLabel}
+              bold
+            />
+          </Field>
+          <RichTextEditor
+            id="definition-content"
+            name="definitionContent"
+            label="Content"
+            value={page.definitionContent}
+            onUpdate={handleUpdate}
+            controls={descriptionControls}
+            multiline
+            fetchAnswers={fetchAnswers}
+            metadata={page.section.questionnaire.metadata}
+            testSelector="txt-question-definition-content"
+          />
+        </DefinitionEditor>
         <RichTextEditor
           id="question-guidance"
           name="guidance"
-          label="Include and exclude guidance"
+          label="Include/exclude"
           value={page.guidance}
           onUpdate={handleUpdate}
           controls={guidanceControls}
@@ -91,7 +133,7 @@ export class StatelessMetaEditor extends React.Component {
 StatelessMetaEditor.propTypes = {
   onChange: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
-  page: CustomPropTypes.page,
+  page: propType(pageFragment).isRequired,
   client: CustomPropTypes.apolloClient.isRequired
 };
 

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/MetaEditor.test.js
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/MetaEditor.test.js
@@ -22,10 +22,13 @@ describe("MetaEditor", () => {
     handleUpdate = jest.fn();
     handleTitleRef = jest.fn();
     page = {
+      id: "1",
       title: "Page title",
       alias: "Page alias",
       description: "Page description",
       guidance: "Page guidance",
+      definitionLabel: "Page definition label",
+      definitionContent: "Page definition content",
       section: {
         questionnaire: {
           metadata: []

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/__snapshots__/DefinitionEditor.test.js.snap
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/__snapshots__/DefinitionEditor.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefinitionEditor should render 1`] = `
+<Fragment>
+  <DefinitionEditor__DefinitionLabel>
+    foobar
+  </DefinitionEditor__DefinitionLabel>
+  <DefinitionEditor__Definition>
+    <DefinitionEditor__Padding>
+      <p>
+        Test
+      </p>
+    </DefinitionEditor__Padding>
+  </DefinitionEditor__Definition>
+</Fragment>
+`;

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -33,7 +33,7 @@ exports[`MetaEditor should render 1`] = `
     }
     fetchAnswers={[Function]}
     id="question-description"
-    label="Question description (optional)…"
+    label="Question description"
     metadata={Array []}
     multiline={true}
     name="description"
@@ -42,6 +42,52 @@ exports[`MetaEditor should render 1`] = `
     testSelector="txt-question-description"
     value="Page description"
   />
+  <DefinitionEditor
+    label="Question definition"
+  >
+    <MetaEditor__Paragraph>
+      Only to be used to define word(s) or acronym(s) within the question.
+    </MetaEditor__Paragraph>
+    <Field
+      last={false}
+    >
+      <Label
+        bold={true}
+        htmlFor="definition-label"
+      >
+        Label
+      </Label>
+      <withChangeHandler(WrappingInput)
+        bold={true}
+        data-test="txt-question-definition-label"
+        id="definition-label"
+        name="definitionLabel"
+        onBlur={[MockFunction]}
+        onChange={[MockFunction]}
+        value="Page definition label"
+      />
+    </Field>
+    <RichTextEditor
+      autoFocus={false}
+      controls={
+        Object {
+          "bold": true,
+          "emphasis": true,
+          "piping": true,
+        }
+      }
+      fetchAnswers={[Function]}
+      id="definition-content"
+      label="Content"
+      metadata={Array []}
+      multiline={true}
+      name="definitionContent"
+      onUpdate={[Function]}
+      placeholder=""
+      testSelector="txt-question-definition-content"
+      value="Page definition content"
+    />
+  </DefinitionEditor>
   <RichTextEditor
     autoFocus={false}
     controls={
@@ -54,7 +100,7 @@ exports[`MetaEditor should render 1`] = `
     }
     fetchAnswers={[Function]}
     id="question-guidance"
-    label="Include and exclude guidance"
+    label="Include/exclude"
     metadata={Array []}
     multiline={true}
     name="guidance"

--- a/eq-author/src/App/questionPage/Design/index.test.js
+++ b/eq-author/src/App/questionPage/Design/index.test.js
@@ -46,6 +46,8 @@ const movePageMock = {
                 alias: "bar-alias",
                 displayName: "bar",
                 position: 0,
+                definitionLabel: "definition label",
+                definitionContent: "definitionContent",
                 section: {
                   __typename: "Section",
                   questionnaire: {
@@ -61,6 +63,8 @@ const movePageMock = {
                 alias: "blah-alias",
                 displayName: "blah",
                 position: 1,
+                definitionLabel: "definition label",
+                definitionContent: "definitionContent",
                 section: {
                   __typename: "Section",
                   questionnaire: {
@@ -157,6 +161,8 @@ describe("QuestionPageRoute", () => {
               description: "bar",
               pageType: "QuestionPage",
               position: 0,
+              definitionLabel: "definition label",
+              definitionContent: "definitionContent",
               guidance: "",
               answers: [],
               section: {
@@ -200,6 +206,8 @@ describe("QuestionPageRoute", () => {
               description: "bar",
               pageType: "QuestionPage",
               position: 0,
+              definitionLabel: "definition label",
+              definitionContent: "definitionContent",
               guidance: "",
               answers: [],
               section: {
@@ -290,6 +298,8 @@ describe("QuestionPageRoute", () => {
       description: "bar",
       pageType: "QuestionPage",
       position: 0,
+      definitionLabel: "definition label",
+      definitionContent: "definitionContent",
       guidance: "",
       answers: [],
       section: {

--- a/eq-author/src/App/questionPage/Preview/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/questionPage/Preview/__snapshots__/index.test.js.snap
@@ -10,6 +10,8 @@ exports[`PreviewPageRoute should render 1`] = `
           "type": "TextField",
         },
       ],
+      "definitionContent": "<p>Definition Content</p>",
+      "definitionLabel": "<p>Definition Label</p>",
       "description": "<p>Description</p>",
       "displayName": "Question",
       "guidance": "<p>Guidance</p>",
@@ -51,6 +53,22 @@ exports[`PreviewPageRoute should render 1`] = `
         }
       />
     </Preview__Guidance>
+    <Preview__Details
+      data-test="definition"
+    >
+      <Preview__DetailsTitle>
+        &lt;p&gt;Definition Label&lt;/p&gt;
+      </Preview__DetailsTitle>
+      <Preview__DetailsContent>
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Definition Content</p>",
+            }
+          }
+        />
+      </Preview__DetailsContent>
+    </Preview__Details>
     <Preview__Answers>
       <Answer
         answer={

--- a/eq-author/src/App/questionPage/Preview/index.js
+++ b/eq-author/src/App/questionPage/Preview/index.js
@@ -1,19 +1,25 @@
+/* eslint-disable react/no-danger */
 import PropTypes from "prop-types";
 import React from "react";
 import { withApollo, Query } from "react-apollo";
 import gql from "graphql-tag";
 import { propType } from "graphql-anywhere";
 import styled from "styled-components";
+import { isEmpty } from "lodash";
 
-import EditorLayout from "App/questionPage/Design/EditorLayout";
 import IconText from "components/IconText";
 import Loading from "components/Loading";
 import Error from "components/preview/Error";
+import { Answer } from "components/preview/Answers";
+import PageTitle from "components/preview/elements/PageTitle";
+
+import EditorLayout from "App/questionPage/Design/EditorLayout";
 import QuestionPageEditor from "App/questionPage/Design/QuestionPageEditor";
 
-import { Answer } from "components/preview/Answers";
 import IconInfo from "./icon-info.svg?inline";
-import PageTitle from "components/preview/elements/PageTitle";
+import IconChevron from "./icon-chevron.svg";
+
+import { colors } from "constants/theme";
 
 const Container = styled.div`
   padding: 2em;
@@ -56,12 +62,45 @@ const Answers = styled.div`
   margin-bottom: 1em;
 `;
 
+const Details = styled.div`
+  margin-bottom: 1em;
+`;
+
+const DetailsTitle = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${colors.primary};
+  margin-bottom: 0.5em;
+
+  &::before {
+    width: 32px;
+    height: 32px;
+    display: inline-block;
+    margin-left: -10px;
+    content: url(${IconChevron});
+    transform: rotate(90deg);
+  }
+`;
+
+const DetailsContent = styled.div`
+  border-left: 2px solid #999;
+  margin-left: 6px;
+  padding: 0.2em 0 0.2em 1em;
+`;
+
 export const UnwrappedPreviewPageRoute = ({ loading, data }) => {
   if (loading) {
     return <Loading height="38rem">Preview loading…</Loading>;
   }
   const { questionPage } = data;
-  const { title, description, guidance, answers } = questionPage;
+  const {
+    title,
+    description,
+    guidance,
+    definitionLabel,
+    definitionContent,
+    answers
+  } = questionPage;
 
   return (
     <EditorLayout page={questionPage} preview routing>
@@ -80,6 +119,24 @@ export const UnwrappedPreviewPageRoute = ({ loading, data }) => {
             <Panel dangerouslySetInnerHTML={{ __html: guidance }} />
           </Guidance>
         )}
+
+        {(!isEmpty(definitionLabel) || !isEmpty(definitionContent)) && (
+          <Details data-test="definition">
+            <DetailsTitle>
+              {definitionLabel || <Error small>Missing definition label</Error>}
+            </DetailsTitle>
+            <DetailsContent>
+              {definitionContent ? (
+                <span dangerouslySetInnerHTML={{ __html: definitionContent }} />
+              ) : (
+                <Error large margin={false}>
+                  Missing definition content
+                </Error>
+              )}
+            </DetailsContent>
+          </Details>
+        )}
+
         {answers.length ? (
           <Answers>
             {answers.map(answer => (

--- a/eq-author/src/App/questionPage/Preview/index.test.js
+++ b/eq-author/src/App/questionPage/Preview/index.test.js
@@ -15,6 +15,8 @@ describe("PreviewPageRoute", () => {
       title: "<p>Hello world</p>",
       guidance: "<p>Guidance</p>",
       description: "<p>Description</p>",
+      definitionLabel: "<p>Definition Label</p>",
+      definitionContent: "<p>Definition Content</p>",
       answers: [{ id: "1", type: TEXTFIELD }],
       section: {
         id: "1",
@@ -60,5 +62,14 @@ describe("PreviewPageRoute", () => {
       <PreviewPageRoute loading={false} data={{ questionPage }} />
     );
     expect(wrapper.exists('[data-test="guidance"]')).toBeFalsy();
+  });
+
+  it("should not render definition if definition label and content empty", () => {
+    questionPage.definitionLabel = "";
+    questionPage.definitionContent = "";
+    const wrapper = shallow(
+      <PreviewPageRoute loading={false} data={{ questionPage }} />
+    );
+    expect(wrapper.exists('[data-test="definition"]')).toBeFalsy();
   });
 });

--- a/eq-author/src/components/Forms/WrappingInput/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/Forms/WrappingInput/__snapshots__/index.test.js.snap
@@ -60,12 +60,14 @@ exports[`WrappingInput should render 1`] = `
 
 <withChangeHandler(WrappingInput)
   id="foo"
+  onBlur={[MockFunction]}
   onChange={[MockFunction]}
   value="123"
 >
   <WrappingInput
     bold={false}
     id="foo"
+    onBlur={[MockFunction]}
     onChange={[Function]}
     value="123"
   >
@@ -81,6 +83,7 @@ exports[`WrappingInput should render 1`] = `
       >
         <WrappingInput__TextArea
           id="foo"
+          onBlur={[MockFunction]}
           onChange={[Function]}
           value="123"
         >
@@ -88,6 +91,7 @@ exports[`WrappingInput should render 1`] = `
             className="c1"
             id="foo"
             inputRef={[Function]}
+            onBlur={[MockFunction]}
             onChange={[Function]}
             onHeightChange={[Function]}
             useCacheForDOMMeasurements={false}
@@ -96,6 +100,7 @@ exports[`WrappingInput should render 1`] = `
             <textarea
               className="c1"
               id="foo"
+              onBlur={[MockFunction]}
               onChange={[Function]}
               style={
                 Object {

--- a/eq-author/src/components/Forms/WrappingInput/index.js
+++ b/eq-author/src/components/Forms/WrappingInput/index.js
@@ -23,6 +23,7 @@ class WrappingInput extends React.Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
     onKeyDown: PropTypes.func,
     id: PropTypes.string.isRequired,
     bold: PropTypes.bool,
@@ -48,7 +49,6 @@ class WrappingInput extends React.Component {
 
   render() {
     const { bold, placeholder, ...otherProps } = this.props;
-
     return (
       <StyleContext
         bold={bold}

--- a/eq-author/src/components/Forms/WrappingInput/index.test.js
+++ b/eq-author/src/components/Forms/WrappingInput/index.test.js
@@ -3,13 +3,19 @@ import { mount } from "enzyme";
 import WrappingInput from ".";
 
 describe("WrappingInput", () => {
-  let component, handleChange;
+  let component, handleChange, handleUpdate;
 
   beforeEach(() => {
     handleChange = jest.fn();
+    handleUpdate = jest.fn();
 
     component = mount(
-      <WrappingInput id="foo" value="123" onChange={handleChange} />
+      <WrappingInput
+        id="foo"
+        value="123"
+        onChange={handleChange}
+        onBlur={handleUpdate}
+      />
     );
   });
 

--- a/eq-author/src/graphql/fragments/page.graphql
+++ b/eq-author/src/graphql/fragments/page.graphql
@@ -4,4 +4,6 @@ fragment Page on QuestionPage {
   alias
   description
   guidance
+  definitionLabel
+  definitionContent
 }

--- a/eq-publisher/src/api/queries.js
+++ b/eq-publisher/src/api/queries.js
@@ -189,6 +189,8 @@ exports.getQuestionnaire = `
             title
             description
             guidance
+            definitionLabel
+            definitionContent
             pageType
             routingRuleSet {
               id

--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -1,6 +1,6 @@
 const Answer = require("./Answer");
 const {
-  parseGuidance,
+  parseContent,
   getInnerHTMLWithPiping,
   unescapePiping
 } = require("../utils/HTMLUtils");
@@ -23,18 +23,29 @@ const processPipedText = ctx =>
     convertPipes(ctx),
     getInnerHTMLWithPiping
   );
-const processGuidance = ctx =>
+
+const processContent = ctx =>
   flow(
     convertPipes(ctx),
-    parseGuidance
+    parseContent
   );
 
 class Question {
   constructor(question, ctx) {
     this.id = `question${question.id}`;
     this.title = processPipedText(ctx)(question.title);
-    this.guidance = processGuidance(ctx)(question.guidance);
+    this.description = processPipedText(ctx)(question.description);
+    this.guidance = processContent(ctx)(question.guidance);
     this.description = unescapePiping(convertPipes(ctx)(question.description));
+
+    if (question.definitionLabel || question.definitionContent) {
+      this.definitions = [
+        {
+          title: question.definitionLabel,
+          ...processContent(ctx)(question.definitionContent)
+        }
+      ];
+    }
 
     const dateRange = findDateRange(question);
 

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -66,6 +66,50 @@ describe("Question", () => {
     });
   });
 
+  describe("defintions", () => {
+    describe("when there is content", () => {
+      it("should be populated when both label and content", () => {
+        const question = new Question(
+          createQuestionJSON({
+            definitionLabel: "definition label",
+            definitionContent: "<p>definition content</p>"
+          })
+        );
+        expect(question.definitions).toBeDefined();
+      });
+      it("should be populated when label and no content", () => {
+        const question = new Question(
+          createQuestionJSON({
+            definitionLabel: "definition label",
+            definitionContent: ""
+          })
+        );
+        expect(question.definitions).toBeDefined();
+      });
+      it("should be populated when no label and content", () => {
+        const question = new Question(
+          createQuestionJSON({
+            definitionLabel: "",
+            definitionContent: "<p>definition content</p>"
+          })
+        );
+        expect(question.definitions).toBeDefined();
+      });
+    });
+
+    describe("when there is no content", () => {
+      it("should be undefined when neither label or content", () => {
+        const question = new Question(
+          createQuestionJSON({
+            definitionLabel: "",
+            definitionContent: ""
+          })
+        );
+        expect(question.guidance).toBeUndefined();
+      });
+    });
+  });
+
   describe("DateRange", () => {
     let validation = {};
     beforeEach(() => {

--- a/eq-publisher/src/utils/HTMLUtils.js
+++ b/eq-publisher/src/utils/HTMLUtils.js
@@ -39,7 +39,7 @@ const mapElementToObject = elem => {
   }
 };
 
-const parseGuidance = html => {
+const parseContent = html => {
   const content = cheerio(html)
     .filter((i, elem) => getInnerHTML(elem) !== "")
     .map((i, elem) => mapElementToObject(elem))
@@ -55,7 +55,7 @@ const parseGuidance = html => {
 module.exports = {
   getInnerHTML,
   getText,
-  parseGuidance,
+  parseContent,
   getInnerHTMLWithPiping,
   unescapePiping
 };

--- a/eq-publisher/src/utils/HTMLUtils.test.js
+++ b/eq-publisher/src/utils/HTMLUtils.test.js
@@ -1,4 +1,4 @@
-const { getInnerHTML, getText, parseGuidance } = require("./HTMLUtils");
+const { getInnerHTML, getText, parseContent } = require("./HTMLUtils");
 
 describe("HTMLUtils", () => {
   describe("getInnerHTML", () => {
@@ -21,14 +21,14 @@ describe("HTMLUtils", () => {
     });
   });
 
-  describe("parseGuidance", () => {
-    it("should return undefined if no guidance supplied", () => {
-      expect(parseGuidance()).toBeUndefined();
-      expect(parseGuidance("")).toBeUndefined();
-      expect(parseGuidance("<p></p>")).toBeUndefined();
+  describe("parseContent", () => {
+    it("should return undefined if no content supplied", () => {
+      expect(parseContent()).toBeUndefined();
+      expect(parseContent("")).toBeUndefined();
+      expect(parseContent("<p></p>")).toBeUndefined();
     });
 
-    it("should correctly parse guidance into runner-compatible object", () => {
+    it("should correctly parse content into runner-compatible object", () => {
       const guidance = `
         <h2>Vivamus sagittis lacus vel augue laoreet</h2>
         <p></p>
@@ -42,7 +42,7 @@ describe("HTMLUtils", () => {
         </ul>
       `;
 
-      expect(parseGuidance(guidance)).toEqual({
+      expect(parseContent(guidance)).toEqual({
         content: [
           {
             title: "Vivamus sagittis lacus vel augue laoreet"

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -66,6 +66,13 @@ describe("convertPipes", () => {
     });
 
     describe("formatting", () => {
+      it("should format Date Range answers with `format_date`", () => {
+        const html = createPipe({ id: "123", type: "DateRange" });
+        expect(convertPipes(createContext())(html)).toEqual(
+          "{{ answers['answer123'] | format_date }}"
+        );
+      });
+
       it("should format Date answers with `format_date`", () => {
         const html = createPipe({ id: "123", type: "Date" });
         expect(convertPipes(createContext())(html)).toEqual(


### PR DESCRIPTION
### What is the context of this PR?
Adds ability to create question page definitions

### How to review 
- Ensure tests pass
- Ensure `eq-survey-runner` can render questionnaires with and without question page definitions 