### PR TITLE
Support OIDC compliant auth provider

### DIFF
--- a/eq-author-api/README.md
+++ b/eq-author-api/README.md
@@ -37,6 +37,7 @@ In most cases sensible defaults have been selected.
 | `DB_CONNECTION_URI`     | Connection string for database                                                     | Yes      |
 | `SECRETS_S3_BUCKET`     | Name of S3 bucket where secrets are stored                                         | No       |
 | `KEYS_FILE`             | Name of the keys file to use inside the bucket                                     | No       |
+| `AUTH_HEADER_KEY`       | Name of the header values that contains the Auth token                             | No       |
 | `EQ_AUTHOR_API_VERSION` | The current Author API version. This is what gets reported on the /status endpoint | No       |
 | `PORT`                  | The port which express listens on (defaults to `4000`)                             | No       |
 | `NODE_ENV`              | Sets the environment the code is running in                                        | No       |

--- a/eq-author-api/middleware/auth.js
+++ b/eq-author-api/middleware/auth.js
@@ -2,14 +2,14 @@ const { isNil, isEmpty } = require("lodash/fp");
 const jwt = require("jsonwebtoken");
 
 module.exports = (logger, context) => (req, res, next) => {
-  const authHeader = req.header("authorization");
+  const authHeader = req.header(process.env.AUTH_HEADER_KEY || "authorization");
   if (isNil(authHeader)) {
     logger.error("Request must contain a valid authorization header.");
     res.send(401);
     return;
   }
 
-  const accessToken = authHeader.replace("Bearer ", "");
+  const accessToken = authHeader.replace("Bearer ", "").replace(/=/g, "");
   if (isEmpty(accessToken)) {
     logger.error("Request must contain a valid access token.");
     res.send(401);

--- a/eq-author-api/middleware/auth.test.js
+++ b/eq-author-api/middleware/auth.test.js
@@ -88,10 +88,8 @@ describe("auth middleware", () => {
     });
 
     describe("valid token", () => {
-      let payload;
-
-      beforeEach(() => {
-        payload = {
+      it("should add token payload to context if valid token", () => {
+        let payload = {
           payload: {
             data: {
               some: "value",
@@ -101,15 +99,30 @@ describe("auth middleware", () => {
 
         const expected = jwt.sign(payload, uuid.v4());
         req.header.mockImplementation(() => `Bearer ${expected}`);
-      });
-
-      it("should add token payload to context if valid token", () => {
         middleware(req, res, next);
         expect(context.auth).toMatchObject(payload);
+        expect(next).toHaveBeenCalled();
       });
 
-      it("should call next middleware function", () => {
+      it("should add token payload to context if valid token with padding", () => {
+        let payload = {
+          payload: {
+            data: {
+              some: "value",
+            },
+          },
+        };
+
+        const expected = jwt.sign(payload, uuid.v4());
+        const position = expected.indexOf(".");
+        const expectedWithEquals = [
+          expected.slice(0, position),
+          "==",
+          expected.slice(position),
+        ].join("");
+        req.header.mockImplementation(() => `Bearer ${expectedWithEquals}`);
         middleware(req, res, next);
+        expect(context.auth).toMatchObject(payload);
         expect(next).toHaveBeenCalled();
       });
     });

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -25,7 +25,7 @@ const Resolvers = {
     questionConfirmation: (root, { id }, ctx) =>
       ctx.repositories.QuestionConfirmation.findById(id),
     me: (root, args, ctx) => ({
-      id: ctx.auth.user_id,
+      id: ctx.auth.sub,
       ...pick(ctx.auth, ["name", "email", "picture"]),
     }),
   },

--- a/eq-author-api/tests/utils/mockAuthPayload.js
+++ b/eq-author-api/tests/utils/mockAuthPayload.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 module.exports = {
-  user_id: "mock_user_id",
+  sub: "mock_user_id",
   name: "Author Integration Test",
   email: "eq-team@ons.gov.uk",
   picture: "file:///path/to/some/picture.jpg",

--- a/eq-author/cypress/support/commands.js
+++ b/eq-author/cypress/support/commands.js
@@ -4,7 +4,7 @@ import { get } from "lodash/fp";
 
 Cypress.Commands.add("login", options => {
   const tokenPayload = {
-    user_id: "CypressUserId",
+    sub: "CypressUserId",
     name: get("displayName", options) || "Cypress",
     email: "cypresstest@ons.gov.uk",
     picture: "",

--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -35,6 +35,7 @@
     window.config.REACT_APP_LAUNCH_URL="";
     window.config.REACT_APP_FULLSTORY_ORG="";
     window.config.REACT_APP_SENTRY_DSN="";
+    window.config.REACT_APP_AUTH_TYPE="";
   </script>
   <script type="text/javascript">
     if (window.config.REACT_APP_FULLSTORY_ORG) {

--- a/eq-author/src/components/Header/index.js
+++ b/eq-author/src/components/Header/index.js
@@ -96,7 +96,7 @@ export class UnconnectedHeader extends React.Component {
   };
 
   displayToast = () => {
-    this.props.raiseToast("ShareToast", "Error link copied to clipboard");
+    this.props.raiseToast("ShareToast", "Link copied to clipboard");
   };
 
   handleSignOut = () => {

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -18,6 +18,8 @@ const config = {
     process.env.REACT_APP_FULLSTORY_ORG,
   REACT_APP_SENTRY_DSN:
     window.config.REACT_APP_SENTRY_DSN || process.env.REACT_APP_SENTRY_DSN,
+  REACT_APP_AUTH_TYPE:
+    window.config.REACT_APP_AUTH_TYPE || process.env.REACT_APP_AUTH_TYPE,
 };
 
 export default config;

--- a/eq-author/src/redux/auth/reducer.js
+++ b/eq-author/src/redux/auth/reducer.js
@@ -1,3 +1,4 @@
+import config from "config";
 import { get, isNil } from "lodash";
 import { SIGN_IN_USER, SIGN_OUT_USER } from "./actions";
 
@@ -26,6 +27,10 @@ export default (state = initialState, { type, payload }) => {
 };
 
 export const getUser = state => get(state, "auth.user");
-export const isSignedIn = () =>
-  localStorage && !isNil(localStorage.getItem("accessToken"));
+export const isSignedIn = () => {
+  return (
+    config.REACT_APP_AUTH_TYPE === "external" ||
+    (localStorage && !isNil(localStorage.getItem("accessToken")))
+  );
+};
 export const verifiedAuthStatus = state => get(state, "auth.verifiedStatus");


### PR DESCRIPTION
### What is the context of this PR?
This allows us to disable firebase and trust that the infrastructure performs authentication for us using an OIDC compliant auth provider

### How to review 
With `AUTH_HEADER_KEY` set to `firebase` it should continue to work as before.
With `AUTH_HEADER_KEY` set to `external` the built in auth should be disabled so that the LoadBalancer can handle the auth for us.
