### PR TITLE
Travis perf - Upgrade yarn to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ language: node_js
 node_js:
   - "10"
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 cache:
   yarn: true
 


### PR DESCRIPTION
### What is the context of this PR?
We are currently running yarn `v1.3.2` which was released in November 2017.

### How to review 
1. Ensure that run is faster.
