### PR TITLE
Travis perf - Dont pull two postgres containers

### DIFF
--- a/eq-author/scripts/test_docker-compose.yml
+++ b/eq-author/scripts/test_docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - 19000:9000
 
   eq-author-db:
-    image: postgres
+    image: postgres:9.4-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mysecretpassword


### PR DESCRIPTION
### What is the context of this PR?
Use the same container in the API tests and the integration tests.

### How to review 
1. Ensure we are only download the postgres container when running the API tests not when starting integration tests.