### PR TITLE
Fix pre deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - docker push onsdigital/eq-publisher:$TAG
 
 before_deploy:
-  - if ["$TRAVIS_BRANCH" == "master"]; then pushd eq-author; yarn storybook-build; popd; fi
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then pushd eq-author; yarn storybook-build; popd; fi
 
 deploy:
   local_dir: eq-author/storybook-static


### PR DESCRIPTION
### What is the context of this PR?
Whitespace matters and I recreate the error locally by running the following
```bash
$ export TRAVIS_BRANCH="master"
$ if ["$TRAVIS_BRANCH" == "master"]; then echo "true"; else echo "false"; fi
```
And then it is fixed by adding the spaces

### How to review 
1. Check that this script makes sense. 