### PR TITLE
Master failing - Fix predeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - docker push onsdigital/eq-publisher:$TAG
 
 before_deploy:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then pushd eq-author; yarn storybook-build; popd; fi
+  - if [ "$TRAVIS_BRANCH" == "master" ]; yarn storybook-build; fi
 
 deploy:
   local_dir: eq-author/storybook-static


### PR DESCRIPTION
### What is the context of this PR?
Travis does not reset directories between each stage so it was left in `eq-author` not at the root as I had assumed so `pushd` failed as there was nowhere to go back to.

This change couples the finishing directory of `script` and `before_deploy` but I think that is acceptable as I assume the next time we touch this will be re-organising the monorepo into one app.

### How to review 
1. Ensure this passes
2. Ensure this makes sense given this new information.
