### PR TITLE
Fixed routing bug and added test

### DIFF
--- a/eq-author-api/repositories/SelectedOptions2Repository.js
+++ b/eq-author-api/repositories/SelectedOptions2Repository.js
@@ -18,5 +18,10 @@ module.exports = knex => {
       .del()
       .where({ sideId });
 
-  return { insert, getBySideId, deleteBySideId };
+  const deleteByOptionId = optionId =>
+    knex("Routing2_SelectedOptions")
+      .del()
+      .where({ optionId });
+
+  return { insert, getBySideId, deleteBySideId, deleteByOptionId };
 };

--- a/eq-author-api/repositories/SelectedOptions2Repository.test.js
+++ b/eq-author-api/repositories/SelectedOptions2Repository.test.js
@@ -108,4 +108,19 @@ describe("ChoseOptions Repository", () => {
       expect(remainingOptions.length).toEqual(0);
     });
   });
+
+  describe("deleteByOptionId", () => {
+    it("will delete all selected options for a given option Id", async () => {
+      await SelectedOptionsRepository.insert({
+        sideId: rightSide.id,
+        optionId: answer.options[0].id,
+      });
+
+      await SelectedOptionsRepository.deleteByOptionId(answer.options[0].id);
+      const remainingOptions = await SelectedOptionsRepository.getBySideId(
+        rightSide.id
+      );
+      expect(remainingOptions.length).toEqual(0);
+    });
+  });
 });

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -159,8 +159,13 @@ const Resolvers = {
     createMutuallyExclusiveOption: (root, { input }, ctx) =>
       ctx.repositories.Option.insert({ mutuallyExclusive: true, ...input }),
     updateOption: (_, args, ctx) => ctx.repositories.Option.update(args.input),
-    deleteOption: (_, args, ctx) =>
-      ctx.repositories.Option.remove(args.input.id),
+    deleteOption: async (_, args, ctx) => {
+      const deletedOption = await ctx.repositories.Option.remove(args.input.id);
+      await ctx.repositories.SelectedOptions2.deleteByOptionId(
+        deletedOption.id
+      );
+      return deletedOption;
+    },
     undeleteOption: (_, args, ctx) =>
       ctx.repositories.Option.undelete(args.input.id),
     createRoutingRuleSet: async (root, args, ctx) =>


### PR DESCRIPTION
### What is the context of this PR?
There is currently a small bug in the api meaning that if you create a routing on a multiple choice answer, add a new option then set up routing based on that option the app will error when you then delete the option. This PR fixes the bug and ensures we do not return options that have been deleted. 

### How to review 
Above error is fixed and new test passes.
