### PR TITLE
Fix race condtion in toggling/updating validation

### DIFF
--- a/eq-author/src/App/questionPage/Design/Validation/withToggleAnswerValidation.js
+++ b/eq-author/src/App/questionPage/Design/Validation/withToggleAnswerValidation.js
@@ -1,32 +1,13 @@
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
-import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
-import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
-import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
-import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
-import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
-import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
 
 export const TOGGLE_VALIDATION_RULE = gql`
   mutation ToggleValidationRule($input: ToggleValidationRuleInput!) {
     toggleValidationRule(input: $input) {
-      ...MinValueValidationRule
-      ...MaxValueValidationRule
-      ...MinDurationValidationRule
-      ...MaxDurationValidationRule
-      ...EarliestDateValidationRule
-      ...LatestDateValidationRule
+      id
+      enabled
     }
   }
-
-  ${MinValueValidationRule}
-  ${MaxValueValidationRule}
-  ${MinDurationValidationRule}
-  ${MaxDurationValidationRule}
-  ${EarliestDateValidationRule}
-  ${LatestDateValidationRule}
-  ${MinValueValidationRule}
-  ${LatestDateValidationRule}
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({

--- a/eq-author/src/App/questionPage/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/BasicAnswer/index.js
@@ -87,17 +87,21 @@ StatelessBasicAnswer.fragments = {
       validation {
         ... on NumberValidation {
           minValue {
+            enabled
             ...MinValueValidationRule
           }
           maxValue {
+            enabled
             ...MaxValueValidationRule
           }
         }
         ... on DateValidation {
           earliestDate {
+            enabled
             ...EarliestDateValidationRule
           }
           latestDate {
+            enabled
             ...LatestDateValidationRule
           }
         }

--- a/eq-author/src/App/questionPage/Design/answers/DateRange/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/DateRange/index.js
@@ -43,15 +43,19 @@ DateRange.fragments = {
         validation {
           ... on DateRangeValidation {
             earliestDate {
+              enabled
               ...EarliestDateValidationRule
             }
             latestDate {
+              enabled
               ...LatestDateValidationRule
             }
             minDuration {
+              enabled
               ...MinDurationValidationRule
             }
             maxDuration {
+              enabled
               ...MaxDurationValidationRule
             }
           }

--- a/eq-author/src/graphql/createAnswer.graphql
+++ b/eq-author/src/graphql/createAnswer.graphql
@@ -14,17 +14,21 @@ mutation createAnswer($input: CreateAnswerInput!) {
       validation {
         ... on NumberValidation {
           minValue {
+            enabled
             ...MinValueValidationRule
           }
           maxValue {
+            enabled
             ...MaxValueValidationRule
           }
         }
         ... on DateValidation {
           earliestDate {
+            enabled
             ...EarliestDateValidationRule
           }
           latestDate {
+            enabled
             ...LatestDateValidationRule
           }
         }
@@ -45,15 +49,19 @@ mutation createAnswer($input: CreateAnswerInput!) {
       validation {
         ... on DateRangeValidation {
           earliestDate {
+            enabled
             ...EarliestDateValidationRule
           }
           latestDate {
+            enabled
             ...LatestDateValidationRule
           }
           minDuration {
+            enabled
             ...MinDurationValidationRule
           }
           maxDuration {
+            enabled
             ...MaxDurationValidationRule
           }
         }

--- a/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
@@ -1,6 +1,5 @@
 fragment MaxDurationValidationRule on MaxDurationValidationRule {
     id
-    enabled
     duration {
         value
         unit

--- a/eq-author/src/graphql/fragments/max-value-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/max-value-validation-rule.graphql
@@ -1,6 +1,5 @@
 fragment MaxValueValidationRule on MaxValueValidationRule {
   id
-  enabled
   custom
   inclusive
   entityType

--- a/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
@@ -1,6 +1,5 @@
 fragment MinDurationValidationRule on MinDurationValidationRule {
   id
-  enabled
   duration {
     value
     unit

--- a/eq-author/src/graphql/fragments/min-value-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/min-value-validation-rule.graphql
@@ -1,6 +1,5 @@
 fragment MinValueValidationRule on MinValueValidationRule {
   id
-  enabled
   custom
   inclusive
   entityType


### PR DESCRIPTION
### What is the context of this PR?
Sometimes when changing an input and then toggling a validation to be
enabled/disabled then a race condition could occur causing apollo cache
to not be correct. We can resolve this by only fetching the necessary
fields for each mutation so that they do not clash and possibly update
themselves in the wrong order.

This possibly fixes #157

### How to review 
1. Ensure test pass
2. Ensure you can still update and toggle validations as expected.