### PR TITLE
fix flexbox issues

### DIFF
--- a/eq-author/src/App/questionPage/Design/Validation/ValidationView.js
+++ b/eq-author/src/App/questionPage/Design/Validation/ValidationView.js
@@ -48,7 +48,7 @@ class ValidationView extends Component {
           </Label>
         </InlineField>
 
-        <TransitionGroup component={Container}>
+        <TransitionGroup>
           <FadeTransition
             key={`validation-enabled-${enabled}`}
             enter

--- a/eq-author/src/App/questionPage/Design/Validation/__snapshots__/ValidationView.test.js.snap
+++ b/eq-author/src/App/questionPage/Design/Validation/__snapshots__/ValidationView.test.js.snap
@@ -21,7 +21,7 @@ exports[`ValidationView should render children when enabled 1`] = `
   </ValidationView__InlineField>
   <TransitionGroup
     childFactory={[Function]}
-    component={[Function]}
+    component="div"
   >
     <FadeTransition
       enter={true}
@@ -61,7 +61,7 @@ exports[`ValidationView should render disabled messaged when disabled 1`] = `
   </ValidationView__InlineField>
   <TransitionGroup
     childFactory={[Function]}
-    component={[Function]}
+    component="div"
   >
     <FadeTransition
       enter={true}

--- a/eq-author/src/components/BaseLayout/index.js
+++ b/eq-author/src/components/BaseLayout/index.js
@@ -26,6 +26,7 @@ const Main = styled.main`
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  height: calc(100vh - 4em);
 `;
 
 const Title = styled.h1`

--- a/eq-author/src/components/ContentPicker/ContentPickerPanel.js
+++ b/eq-author/src/components/ContentPicker/ContentPickerPanel.js
@@ -7,9 +7,9 @@ import { colors, radius } from "constants/theme";
 const StyledScrollPane = styled(ScrollPane)`
   padding: 0.25em 0;
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: column;
+  justify-content: flex-start;
 `;
 
 const PanelWrapper = styled.div`


### PR DESCRIPTION
### What is the context of this PR?

Updating to Chrome 73 caused some layout problems related to flexbox, namely:

- scrolling of main content column broken
- layout of date validation modal

### How to review 

- test scrolling works on "homepage" (ie. you can scroll when there are enough questionnaires to cause overflow and scrolling).
- add a date answer and test that layout of validation modal is as expected.
