### PR TITLE
Refactor and remove CompositeAnswers to use JSON backend store

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -885,8 +885,6 @@ const Resolvers = {
     __resolveType: ({ type }) => {
       if (includes(["Checkbox", "Radio"], type)) {
         return "MultipleChoiceAnswer";
-      } else if (includes(["DateRange"], type)) {
-        return "CompositeAnswer";
       } else {
         return "BasicAnswer";
       }
@@ -907,20 +905,10 @@ const Resolvers = {
       return parentPage;
     },
     validation: answer =>
-      ["number", "date"].includes(getValidationEntity(answer.type))
+      ["number", "date", "dateRange"].includes(getValidationEntity(answer.type))
         ? answer
         : null,
     displayName: answer => getName(answer, "BasicAnswer"),
-  },
-
-  CompositeAnswer: {
-    childAnswers: (answer, args, ctx) =>
-      ctx.repositories.Answer.splitComposites(answer),
-    page: (answer, args, ctx) =>
-      ctx.repositories.QuestionPage.getById(answer.questionPageId),
-    validation: answer =>
-      ["dateRange"].includes(getValidationEntity(answer.type)) ? answer : null,
-    displayName: answer => getName(answer, "CompositeAnswer"),
   },
 
   MultipleChoiceAnswer: {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -112,6 +112,7 @@ interface Answer {
   guidance: String
   qCode: String
   label: String
+  secondaryLabel: String
   type: AnswerType!
   page: QuestionPage
   properties: JSON
@@ -138,25 +139,12 @@ type MultipleChoiceAnswer implements Answer {
   guidance: String
   qCode: String
   label: String
+  secondaryLabel: String
   type: AnswerType!
   options: [Option]
   mutuallyExclusiveOption: Option
   page: QuestionPage
   properties: JSON
-}
-
-type CompositeAnswer implements Answer {
-  id: ID!
-  displayName: String!
-  description: String
-  guidance: String
-  qCode: String
-  label: String
-  type: AnswerType!
-  page: QuestionPage
-  childAnswers: [BasicAnswer]!
-  properties: JSON
-  validation: ValidationType
 }
 
 type Option {

--- a/eq-author/src/App/questionPage/Design/Validation/AvailableMetadataQuery.js
+++ b/eq-author/src/App/questionPage/Design/Validation/AvailableMetadataQuery.js
@@ -26,10 +26,6 @@ const GET_AVAILABLE_METADATA = gql`
               }
             }
           }
-        }
-      }
-      ... on CompositeAnswer {
-        validation {
           ... on DateRangeValidation {
             earliestDate {
               id

--- a/eq-author/src/App/questionPage/Design/answers/Date/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/Date/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import CustomPropTypes from "custom-prop-types";
 import DummyDate from "App/questionPage/Design/answers/dummy/Date";
 
 import { Field, Label } from "components/Forms";
@@ -31,7 +30,8 @@ const Legend = VisuallyHidden.withComponent("legend");
 export const UnwrappedDate = ({
   label,
   name,
-  answer,
+  id,
+  value,
   onChange,
   onUpdate,
   placeholder,
@@ -42,14 +42,14 @@ export const UnwrappedDate = ({
   <Fieldset>
     <Legend>Date options</Legend>
     <Field>
-      <Label htmlFor={`${name}-${answer.id}`}>{label}</Label>
+      <Label htmlFor={`${name}-${id}`}>{label}</Label>
       <WrappingInput
-        id={`${name}-${answer.id}`}
+        id={`${name}-${id}`}
         name={name}
         size="medium"
         onChange={onChange}
         onBlur={onUpdate}
-        value={answer.label}
+        value={value}
         placeholder={placeholder}
         data-test="date-answer-label"
         data-autofocus
@@ -70,10 +70,11 @@ export const UnwrappedDate = ({
 );
 
 UnwrappedDate.propTypes = {
-  answer: CustomPropTypes.answer.isRequired,
+  id: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
   name: PropTypes.string,
+  value: PropTypes.string,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   showDay: PropTypes.bool,
@@ -90,10 +91,9 @@ UnwrappedDate.fragments = {
   Date: gql`
     fragment Date on Answer {
       id
-      label
       properties
     }
   `,
 };
 
-export default withEntityEditor("answer", answerFragment)(UnwrappedDate);
+export default UnwrappedDate;

--- a/eq-author/src/App/questionPage/Design/answers/DateRange/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/DateRange/index.js
@@ -5,7 +5,9 @@ import gql from "graphql-tag";
 import styled from "styled-components";
 
 import Date from "App/questionPage/Design/answers/Date";
+import withEntityEditor from "components/withEntityEditor";
 
+import answerFragment from "graphql/fragments/answer.graphql";
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
 import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
@@ -17,16 +19,26 @@ const Wrapper = styled.div`
 
 const DateRange = ({ answer, ...otherProps }) => (
   <Wrapper data-test="date-range-editor">
-    {answer.childAnswers.map(answer => (
-      <Date
-        key={answer.id}
-        answer={answer}
-        showDay
-        showMonth
-        showYear
-        {...otherProps}
-      />
-    ))}
+    <Date
+      key={`from-${answer.id}`}
+      id={answer.id}
+      value={answer.label}
+      answer={answer}
+      showDay
+      showMonth
+      showYear
+      {...otherProps}
+    />
+    <Date
+      key={`to-${answer.id}`}
+      id={answer.id}
+      value={answer.secondaryLabel}
+      name="secondaryLabel"
+      showDay
+      showMonth
+      showYear
+      {...otherProps}
+    />
   </Wrapper>
 );
 
@@ -39,7 +51,7 @@ DateRange.fragments = {
   DateRange: gql`
     fragment DateRange on Answer {
       id
-      ... on CompositeAnswer {
+      ... on BasicAnswer {
         validation {
           ... on DateRangeValidation {
             earliestDate {
@@ -56,10 +68,6 @@ DateRange.fragments = {
             }
           }
         }
-        childAnswers {
-          id
-          label
-        }
       }
     }
     ${Date.fragments.Date}
@@ -70,4 +78,4 @@ DateRange.fragments = {
   `,
 };
 
-export default DateRange;
+export default withEntityEditor("answer", answerFragment)(DateRange);

--- a/eq-author/src/App/questionPage/Design/answers/withCreateAnswer.js
+++ b/eq-author/src/App/questionPage/Design/answers/withCreateAnswer.js
@@ -1,4 +1,7 @@
 import { graphql } from "react-apollo";
+
+import { DATE_RANGE } from "constants/answer-types";
+
 import createAnswerMutation from "graphql/createAnswer.graphql";
 import fragment from "graphql/pageFragment.graphql";
 
@@ -28,6 +31,10 @@ export const mapMutateToProps = ({ mutate }) => ({
       qCode: "",
       label: "",
     };
+
+    if (type === DATE_RANGE) {
+      answer.secondaryLabel = "";
+    }
 
     const update = createUpdater(pageId);
 

--- a/eq-author/src/components/ContentPickerModal/GetContentPickerQuery.js
+++ b/eq-author/src/components/ContentPickerModal/GetContentPickerQuery.js
@@ -24,14 +24,6 @@ export const CONTENT_PICKER_QUERY = gql`
               label
               displayName
               type
-              ... on CompositeAnswer {
-                childAnswers {
-                  id
-                  label
-                  displayName
-                  type
-                }
-              }
             }
           }
         }

--- a/eq-author/src/graphql/createAnswer.graphql
+++ b/eq-author/src/graphql/createAnswer.graphql
@@ -28,21 +28,6 @@ mutation createAnswer($input: CreateAnswerInput!) {
             ...LatestDateValidationRule
           }
         }
-      }
-    }
-    ... on MultipleChoiceAnswer {
-      options {
-        ...Option
-      }
-      mutuallyExclusiveOption {
-        id
-      }
-    }
-    ... on CompositeAnswer {
-      childAnswers {
-        ...Answer
-      }
-      validation {
         ... on DateRangeValidation {
           earliestDate {
             ...EarliestDateValidationRule
@@ -57,6 +42,14 @@ mutation createAnswer($input: CreateAnswerInput!) {
             ...MaxDurationValidationRule
           }
         }
+      }
+    }
+    ... on MultipleChoiceAnswer {
+      options {
+        ...Option
+      }
+      mutuallyExclusiveOption {
+        id
       }
     }
   }

--- a/eq-author/src/graphql/fragments/answer.graphql
+++ b/eq-author/src/graphql/fragments/answer.graphql
@@ -3,6 +3,7 @@ fragment Answer on Answer {
   description
   guidance
   label
+  secondaryLabel
   type
   properties
 }


### PR DESCRIPTION
### What is the context of this PR?
- Removes `CompositeAnswer` type and utilises `BasicAnswer` type for `DateRange` answers

### How to review 
- Ensure you can add/modify/delete `DateRange` answers
- Ensure you can add/modify/delete `DateRange` validations