### PR TITLE
Bug - Editor column changing width

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -94,7 +94,7 @@ exports[`QuestionnaireDesignPage should render 1`] = `
         />
       </Column>
       <Column
-        cols={12}
+        cols={9}
       >
         <Switch>
           <Route

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -148,7 +148,7 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
                 onAddQuestionConfirmation={this.handleAddQuestionConfirmation}
               />
             </Column>
-            <Column>
+            <Column cols={9}>
               <Switch location={location}>
                 <Route path={Routes.SECTION} component={SectionRoute} exact />
                 <Route path={Routes.PAGE} component={QuestionPageRoute} exact />


### PR DESCRIPTION
### What is the context of this PR?
Fix issue where editing RTE could cause editing column to change width. This was caused by the max allowed width being 100% so it would grow with the RTE when it wasn't supposed to.

I appreciate the recreation steps are very specific but this is a guaranteed way of creating it but the causes are more common than just this case.

### How to review 
1. Set your viewport width to 1280px (use Chrome dev tools mobile button to make this easy)
1. Create a question with the title `Afafafafafaf afhoaaadad`
1. Add an answer with properties to the page (e.g. Currency)
1. Refresh the page.
1. Start updating the title and keep typing - at 10-12 characters (character width matters) into the second line the width of the editing column starts to grow.
1. Change to this branch and this no longer happens.
