### PR TITLE
Remove hard-coded date on createQuestionnaire

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -150,7 +150,7 @@ const createQuestionnaire = input => ({
   legalBasis: "Voluntary",
   navigation: false,
   surveyId: "",
-  createdAt: "2019-01-01",
+  createdAt: new Date(),
   metadata: [],
   sections: [createSection()],
   ...input,
@@ -233,7 +233,6 @@ const Resolvers = {
       const questionnaireList = getQuestionnaireList();
       questionnaireList.push({
         ...omit(questionnaire, "sections", "metadata"),
-        createdAt: questionnaire.createdAt.toString().split("T")[0],
       });
       saveQuestionnaireList(questionnaireList);
 
@@ -267,7 +266,7 @@ const Resolvers = {
       const questionnaireList = getQuestionnaireList();
       questionnaireList.push({
         ...omit(newQuestionnaire, "sections", "metadata"),
-        createdAt: newQuestionnaire.createdAt.toString().split("T")[0],
+        createdAt: new Date(),
       });
       saveQuestionnaireList(questionnaireList);
       return newQuestionnaire;
@@ -662,6 +661,7 @@ const Resolvers = {
       id: questionnaire.createdBy, // Temporary until next PR introduces users table.
       name: questionnaire.createdBy,
     }),
+    createdAt: questionnaire => new Date(questionnaire.createdAt),
     questionnaireInfo: questionnaire => questionnaire,
     metadata: questionnaire => questionnaire.metadata,
   },


### PR DESCRIPTION
### What is the context of this PR?
When we started work to migrate away from the RDB to a JSON document store we hard coded the date on `createQuestionnaire` to overcome some strange behaviour with the resolvers that we were experiencing at the time.

This PR replaces the hard coded date with the current date. This PR also ensures that the full ISO formatted date string is stored rather than just the date portion of the string.

### How to review 
Ensure that newly created questionnaires have the correct date timestamp.
Ensure that duplicated questionnaires have a different `createdAt` timestamp to the original.
