### PR TITLE
Redact authorization header from the logs

### DIFF
--- a/eq-author-api/app.js
+++ b/eq-author-api/app.js
@@ -13,8 +13,12 @@ const repositories = require("./repositories");
 const modifiers = require("./modifiers");
 const schema = require("./schema");
 
+const noir = require("pino-noir");
+
 const app = express();
-const pino = pinoMiddleware();
+const pino = pinoMiddleware({
+  serializers: noir(["req.headers.authorization"], "[Redacted]"),
+});
 const logger = pino.logger;
 
 const db = require("./db");

--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -34,6 +34,7 @@
     "node-jose": "latest",
     "pg": "latest",
     "pg-hstore": "latest",
+    "pino-noir": "latest",
     "wait-for-postgres": "latest"
   },
   "engines": {

--- a/eq-author-api/yarn.lock
+++ b/eq-author-api/yarn.lock
@@ -4612,6 +4612,11 @@ pino-http@^4.0.0:
     pino "^5.0.0"
     pino-std-serializers "^2.1.0"
 
+pino-noir@latest:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/pino-noir/-/pino-noir-2.2.1.tgz#2f9bb51a8eacda976b26f412ed5af468d8f0106c"
+  integrity sha512-qGIG4fYMqokNb5Ho21YNH9uB4NELYTb9oADiuzoL2+n1gs6QyoUKaTN+7eqT4VDC6syvcyark3YP9o2UmCk32A==
+
 pino-std-serializers@^2.1.0, pino-std-serializers@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.3.0.tgz#34eeaab97c055c28e22c0542ae55978e7e427786"


### PR DESCRIPTION
### What is the context of this PR?
The stops the `authorization` header from being logged out

### How to review 
The `authorization` header should show as `[Redacted]` in the logs
