### PR TITLE
Bug - Fix rendering of nested flexboxes in Chrome 72

### DIFF
--- a/eq-author/src/components/BaseLayout/index.js
+++ b/eq-author/src/components/BaseLayout/index.js
@@ -26,7 +26,7 @@ const Main = styled.main`
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 4em);
+  min-height: 0;
 `;
 
 const Title = styled.h1`

--- a/eq-author/src/components/ContentPicker/ContentPicker.js
+++ b/eq-author/src/components/ContentPicker/ContentPicker.js
@@ -12,6 +12,7 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-height: 0;
 `;
 
 const ActionButtons = styled(ButtonGroup)`

--- a/eq-author/src/components/ContentPicker/ContentPickerSingle.js
+++ b/eq-author/src/components/ContentPicker/ContentPickerSingle.js
@@ -10,6 +10,7 @@ const openStyle = css`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-height: 0;
 `;
 
 export const PickerWrapper = styled.div`

--- a/eq-author/src/components/ContentPicker/GroupContentPicker.js
+++ b/eq-author/src/components/ContentPicker/GroupContentPicker.js
@@ -13,6 +13,7 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-height: 0;
 `;
 
 const ActionButtons = styled(ButtonGroup)`

--- a/eq-author/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
+++ b/eq-author/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
@@ -23,6 +23,7 @@ exports[`Content Picker Single PickerWrapper should render with additional style
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  min-height: 0;
   margin-bottom: 3px;
 }
 

--- a/eq-author/src/components/ContentPickerModal/index.js
+++ b/eq-author/src/components/ContentPickerModal/index.js
@@ -94,6 +94,7 @@ const ContentWrapper = styled.div`
   flex: 1 1 auto;
   flex-direction: column;
   justify-content: center;
+  min-height: 0;
 `;
 
 const ErrorText = styled.span`


### PR DESCRIPTION
### What is the context of this PR?
This resolves the issue where Chrome was not matching the web standard and defaulting the `min-height` of a nested flexbox item to `0`. To improve compatibility they changed the default to `auto`. This broke the places where we had nested flex boxes

There is more information and references in #189 

Closes #189 

### How to review 
1. Ensure that you can scroll the main app
2. Ensure that the ContentPicker does not overflow as described in #189
