### PR TITLE
Bug - Rendering of duration

### DIFF
--- a/eq-author/src/App/questionPage/Design/Validation/Duration.js
+++ b/eq-author/src/App/questionPage/Design/Validation/Duration.js
@@ -1,10 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 
 import { Number, Select } from "components/Forms";
 import { Grid, Column } from "components/Grid";
 
 import { DAYS, MONTHS, YEARS } from "constants/durations";
+
+export const DurationNumber = styled(Number)`
+  width: 100%;
+`;
 
 const UNITS = [DAYS, MONTHS, YEARS];
 
@@ -17,7 +22,7 @@ const Duration = ({
 }) => (
   <Grid>
     <Column cols={2}>
-      <Number
+      <DurationNumber
         id={`${name}-value`}
         name={`${name}.value`}
         value={value}

--- a/eq-author/src/App/questionPage/Design/Validation/Duration.test.js
+++ b/eq-author/src/App/questionPage/Design/Validation/Duration.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Duration from "./Duration";
-import { Number, Select } from "components/Forms";
+import Duration, { DurationNumber } from "./Duration";
+import { Select } from "components/Forms";
 
 import { DAYS, MONTHS, YEARS } from "constants/durations";
 const UNITS = [DAYS, MONTHS, YEARS];
@@ -31,7 +31,7 @@ describe("Duration", () => {
   });
 
   it("should correctly change and update duration value", () => {
-    const value = wrapper.find(Number);
+    const value = wrapper.find(DurationNumber);
     value.simulate("change", "event");
     expect(props.onChange).toHaveBeenCalledWith("event");
     value.simulate("blur", "event");

--- a/eq-author/src/App/questionPage/Design/Validation/__snapshots__/Duration.test.js.snap
+++ b/eq-author/src/App/questionPage/Design/Validation/__snapshots__/Duration.test.js.snap
@@ -8,16 +8,13 @@ exports[`Duration should render 1`] = `
   <Column
     cols={2}
   >
-    <Number
-      data-test="number-input"
-      default={0}
+    <Duration__DurationNumber
       id="foobar-value"
       max={99999}
       min={0}
       name="foobar.value"
       onBlur={[MockFunction]}
       onChange={[MockFunction]}
-      step={1}
       value={3}
     />
   </Column>


### PR DESCRIPTION
### What is the context of this PR?
The input was overlaping the dropdown. This was because the default
width of the number input was changed. So this change takes it to
stretch to the width of the column.

### How to review 
1. Ensure there is no overlap in the min/max duration validation modal
2. Ensure there is no overlap in the earliest/latest date validation moal