### PR TITLE
Enable questionnaire endpoint for pre-prod

### DIFF
--- a/eq-publisher/src/main.js
+++ b/eq-publisher/src/main.js
@@ -56,16 +56,14 @@ app.use(
   })
 );
 
-if (process.env.NODE_ENV === "development") {
-  app.get(
-    "/graphql/:questionnaireId",
-    logger,
-    createAuthToken,
-    setAuthHeaders,
-    fetchData(api),
-    respondWithData
-  );
-}
+app.get(
+  "/graphql/:questionnaireId",
+  logger,
+  createAuthToken,
+  setAuthHeaders,
+  fetchData(api),
+  respondWithData
+);
 
 app.get(
   "/publish/:questionnaireId",


### PR DESCRIPTION
### What is the context of this PR?
This will enable the endpoint that will allow us to fetch questionnaires outside of development. This is to allow for us to take a dump from preprod of the questionnaires so that we can test them and then eventually move them into dynamoDB

### How to review 
Make sure tests still pass
