### PR TITLE
Added functionality to give content picker a selected state.

### DIFF
--- a/eq-author/src/App/questionPage/Design/Validation/DateValidation.js
+++ b/eq-author/src/App/questionPage/Design/Validation/DateValidation.js
@@ -76,6 +76,7 @@ export class UnwrappedDateValidation extends React.Component {
         this.props.validation.previousAnswer,
         "displayName"
       )}
+      selectedId={get(this.props.validation.previousAnswer, "id")}
       path={`answer.validation.${this.props.readKey}.availablePreviousAnswers`}
     />
   );

--- a/eq-author/src/App/questionPage/Design/Validation/NumericValidation.js
+++ b/eq-author/src/App/questionPage/Design/Validation/NumericValidation.js
@@ -35,6 +35,7 @@ export class UnwrappedNumericValidation extends React.Component {
           this.props.validation.previousAnswer,
           "displayName"
         )}
+        selectedId={get(this.props.validation.previousAnswer, "id")}
         path={`answer.validation.${
           this.props.readKey
         }.availablePreviousAnswers`}

--- a/eq-author/src/App/questionPage/Routing/DestinationSelector/RoutingDestinationContentPicker.js
+++ b/eq-author/src/App/questionPage/Routing/DestinationSelector/RoutingDestinationContentPicker.js
@@ -60,7 +60,6 @@ export const UnwrappedRoutingDestinationContentPicker = ({
     data,
     "questionPage.availableRoutingDestinations"
   );
-
   return (
     <ContentPickerSelect
       name="routingDestination"
@@ -71,6 +70,7 @@ export const UnwrappedRoutingDestinationContentPicker = ({
         loading,
         destinationData
       )}
+      selectedObj={selected || undefined}
       {...otherProps}
     />
   );

--- a/eq-author/src/App/questionPage/Routing/DestinationSelector/__snapshots__/RoutingDestinationContentPicker.test.js.snap
+++ b/eq-author/src/App/questionPage/Routing/DestinationSelector/__snapshots__/RoutingDestinationContentPicker.test.js.snap
@@ -17,6 +17,11 @@ exports[`RoutingDestinationContentPicker displayName should correctly render log
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="End of questionnaire"
+  selectedObj={
+    Object {
+      "logical": "EndOfQuestionnaire",
+    }
+  }
 />
 `;
 
@@ -37,6 +42,14 @@ exports[`RoutingDestinationContentPicker displayName should correctly render pag
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="page name"
+  selectedObj={
+    Object {
+      "page": Object {
+        "displayName": "page name",
+        "id": "1",
+      },
+    }
+  }
 />
 `;
 
@@ -57,6 +70,14 @@ exports[`RoutingDestinationContentPicker displayName should correctly render sec
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="section name"
+  selectedObj={
+    Object {
+      "section": Object {
+        "displayName": "section name",
+        "id": "1",
+      },
+    }
+  }
 />
 `;
 
@@ -82,6 +103,11 @@ exports[`RoutingDestinationContentPicker displayName should render first page di
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="page name"
+  selectedObj={
+    Object {
+      "logical": "NextPage",
+    }
+  }
 />
 `;
 
@@ -107,6 +133,11 @@ exports[`RoutingDestinationContentPicker displayName should render first page di
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="section name"
+  selectedObj={
+    Object {
+      "logical": "NextPage",
+    }
+  }
 />
 `;
 
@@ -127,6 +158,11 @@ exports[`RoutingDestinationContentPicker displayName should render with no displ
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName=""
+  selectedObj={
+    Object {
+      "logical": "NextPage",
+    }
+  }
 />
 `;
 
@@ -147,5 +183,10 @@ exports[`RoutingDestinationContentPicker should render 1`] = `
   name="routingDestination"
   onSubmit={[MockFunction]}
   selectedContentDisplayName="End of questionnaire"
+  selectedObj={
+    Object {
+      "logical": "NextPage",
+    }
+  }
 />
 `;

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
@@ -26,6 +26,7 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
         id="RoutingCondition1"
         onSubmit={[Function]}
         path="questionPage.availableRoutingAnswers"
+        selectedId="2"
       />
     </Column>
     <Column

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
@@ -199,6 +199,7 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
                 this.props.expression
               )}
               onSubmit={this.handleLeftSideChange}
+              selectedId={get("left.id", this.props.expression)}
             />
           </Column>
           <Column gutters={false} cols={1}>

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/fragment.graphql
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/fragment.graphql
@@ -6,7 +6,6 @@ fragment RoutingEditor on Routing2 {
     ...RuleEditor
   }
   else {
-    id
     logical
     page {
       id

--- a/eq-author/src/components/ContentPicker/ContentPicker.js
+++ b/eq-author/src/components/ContentPicker/ContentPicker.js
@@ -5,8 +5,9 @@ import { isNil } from "lodash";
 
 import ButtonGroup from "components/buttons/ButtonGroup";
 import Button from "components/buttons/Button";
-
 import ContentPickerSingle from "components/ContentPicker/ContentPickerSingle";
+
+import setSelectedElement from "./setSelectedElement";
 
 const ContentWrapper = styled.div`
   display: flex;
@@ -19,6 +20,7 @@ const ActionButtons = styled(ButtonGroup)`
   padding: 1em 0;
   flex: 0 0 auto;
 `;
+
 export default class ContentPicker extends React.Component {
   static propTypes = {
     onSubmit: PropTypes.func,
@@ -28,6 +30,7 @@ export default class ContentPicker extends React.Component {
         id: PropTypes.string.isRequired,
       })
     ).isRequired,
+    selectedId: PropTypes.string,
     config: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,
@@ -38,7 +41,16 @@ export default class ContentPicker extends React.Component {
   };
 
   state = {
-    selectedItems: [],
+    selectedItems: this.props.selectedId
+      ? [
+          ...setSelectedElement(
+            this.props.config,
+            this.props.selectedId,
+            this.props.data
+          ),
+        ]
+      : [],
+    openLevel: this.props.selectedId ? this.props.config.length - 1 : null,
   };
 
   getDataAtLevel(level) {
@@ -83,7 +95,7 @@ export default class ContentPicker extends React.Component {
       const data = this.getDataAtLevel(level);
 
       const isDisabled = level > selectedItems.length || !data.length;
-      const isHidden = level > openLevel;
+      const isHidden = openLevel !== null && level > openLevel;
       const isOpen = level === openLevel || config.length === 1;
 
       const selectedItem = selectedItems[level];
@@ -118,6 +130,7 @@ export default class ContentPicker extends React.Component {
     const { config } = this.props;
     const { selectedItems } = this.state;
     const selectedItem = selectedItems[config.length - 1];
+
     return (
       <React.Fragment>
         <ContentWrapper>{this.renderPickers()}</ContentWrapper>

--- a/eq-author/src/components/ContentPicker/ContentPicker.test.js
+++ b/eq-author/src/components/ContentPicker/ContentPicker.test.js
@@ -193,6 +193,22 @@ describe("Content Picker", () => {
       wrapper.find(PAGE_PICKER_SELECTOR).simulate("titleClick");
       expect(wrapper.find(PAGE_PICKER_SELECTOR).prop("open")).toBe(true);
     });
+
+    it("should begin with a selected value if a selectedId is passed in", () => {
+      const wrapper = createWrapper({
+        data: generateMockPiping(),
+        selectedId: "Answer 96",
+      });
+      expect(wrapper.find(SECTION_PICKER_SELECTOR).prop("open")).toBe(false);
+      expect(wrapper.find(PAGE_PICKER_SELECTOR).prop("open")).toBe(false);
+      expect(wrapper.find(ANSWER_PICKER_SELECTOR).prop("open")).toBe(true);
+      expect(wrapper.state("selectedItems")).toContainEqual({
+        __typename: "BasicAnswer",
+        displayName: "Answer 96",
+        id: "Answer 96",
+        type: "Currency",
+      });
+    });
   });
 
   describe("contentPicker data management", () => {

--- a/eq-author/src/components/ContentPicker/ContentPickerSingle.js
+++ b/eq-author/src/components/ContentPicker/ContentPickerSingle.js
@@ -58,6 +58,7 @@ const ContentPickerSingle = ({
               onClick={() => onOptionClick(option)}
               disabled={childKey && (option[childKey] || []).length === 0}
               data-test="picker-option"
+              aria-pressed={selectedOption === option.id}
             >
               {option.displayName}
             </PickerOption>

--- a/eq-author/src/components/ContentPicker/GroupContentPicker.js
+++ b/eq-author/src/components/ContentPicker/GroupContentPicker.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { isNil } from "lodash";
+import { isNil, findIndex, forEach } from "lodash";
 
 import ButtonGroup from "components/buttons/ButtonGroup";
 import Button from "components/buttons/Button";
@@ -21,6 +21,33 @@ const ActionButtons = styled(ButtonGroup)`
   flex: 0 0 auto;
 `;
 
+const generateDefaultState = (selectedObj, config) => {
+  if (!selectedObj) {
+    return {
+      openLevel: null,
+      selectedItem: null,
+    };
+  }
+  let openLevel;
+  let selectedItem;
+  forEach(selectedObj, value => {
+    if (value === null) {
+      return;
+    }
+    if (typeof value !== "object") {
+      openLevel = null;
+    } else {
+      openLevel = findIndex(config, ({ id }) => id === value.__typename);
+    }
+    selectedItem = value;
+    return false;
+  });
+  return {
+    openLevel,
+    selectedItem,
+  };
+};
+
 export default class GroupContentPicker extends React.Component {
   static propTypes = {
     onSubmit: PropTypes.func,
@@ -34,12 +61,20 @@ export default class GroupContentPicker extends React.Component {
         groupKey: PropTypes.string,
       })
     ).isRequired,
+    selectedObj: PropTypes.shape({
+      section: PropTypes.shape({
+        id: PropTypes.string,
+        displayName: PropTypes.string,
+      }),
+      page: PropTypes.shape({
+        id: PropTypes.string,
+        displayName: PropTypes.string,
+      }),
+      logical: PropTypes.string,
+    }),
   };
 
-  state = {
-    openLevel: null,
-    selectedItem: null,
-  };
+  state = generateDefaultState(this.props.selectedObj, this.props.config);
 
   handleTitleClick = level => {
     this.setState(state => {

--- a/eq-author/src/components/ContentPicker/GroupContentPicker.test.js
+++ b/eq-author/src/components/ContentPicker/GroupContentPicker.test.js
@@ -4,8 +4,8 @@ import ContentPickerButton from "components/ContentPicker/ContentPickerButton";
 import GroupContentPicker from "components/ContentPicker/GroupContentPicker";
 import { byTestAttr } from "tests/utils/selectors";
 
-const PAGES_PICKER = byTestAttr("pages-picker");
-const SECTIONS_PICKER = byTestAttr("sections-picker");
+const QUESTIONPAGE_PICKER = byTestAttr("QuestionPage-picker");
+const SECTION_PICKER = byTestAttr("Section-picker");
 const END_OF_Q_PICKER = byTestAttr("endOfQuestionnaire-picker");
 
 const data = {
@@ -51,13 +51,13 @@ const data = {
 
 const config = [
   {
-    id: "pages",
+    id: "QuestionPage",
     title: "Other pages in this section",
     groupKey: "questionPages",
     expandable: true,
   },
   {
-    id: "sections",
+    id: "Section",
     title: "Other sections",
     groupKey: "sections",
     expandable: true,
@@ -104,22 +104,68 @@ describe("GroupContentPicker", () => {
       },
     });
 
-    expect(wrapper.find(PAGES_PICKER).prop("disabled")).toBe(true);
+    expect(wrapper.find(QUESTIONPAGE_PICKER).prop("disabled")).toBe(true);
     expect(wrapper.find(END_OF_Q_PICKER).prop("disabled")).toBe(true);
   });
 
   it("should hide pickers below open picker", () => {
     const wrapper = createWrapper();
 
-    wrapper.find(PAGES_PICKER).simulate("titleClick");
-    expect(wrapper.find(PAGES_PICKER).prop("hidden")).toBe(false);
-    expect(wrapper.find(SECTIONS_PICKER).prop("hidden")).toBe(true);
+    wrapper.find(QUESTIONPAGE_PICKER).simulate("titleClick");
+    expect(wrapper.find(QUESTIONPAGE_PICKER).prop("hidden")).toBe(false);
+    expect(wrapper.find(SECTION_PICKER).prop("hidden")).toBe(true);
     expect(wrapper.find(END_OF_Q_PICKER).prop("hidden")).toBe(true);
 
-    wrapper.find(SECTIONS_PICKER).simulate("titleClick");
-    expect(wrapper.find(PAGES_PICKER).prop("hidden")).toBe(false);
-    expect(wrapper.find(SECTIONS_PICKER).prop("hidden")).toBe(false);
+    wrapper.find(SECTION_PICKER).simulate("titleClick");
+    expect(wrapper.find(QUESTIONPAGE_PICKER).prop("hidden")).toBe(false);
+    expect(wrapper.find(SECTION_PICKER).prop("hidden")).toBe(false);
     expect(wrapper.find(END_OF_Q_PICKER).prop("hidden")).toBe(true);
+  });
+
+  it("should start open if section preselected", () => {
+    const wrapper = createWrapper({
+      selectedObj: {
+        page: null,
+        section: {
+          id: "1",
+          displayName: "Section 1",
+          __typename: "Section",
+        },
+        logical: null,
+      },
+    });
+
+    expect(wrapper.find(QUESTIONPAGE_PICKER).prop("hidden")).toBe(false);
+    expect(wrapper.find(SECTION_PICKER).prop("hidden")).toBe(false);
+    expect(wrapper.find(END_OF_Q_PICKER).prop("hidden")).toBe(true);
+
+    expect(wrapper.state("selectedItem")).toMatchObject({
+      displayName: "Section 1",
+      id: "1",
+    });
+  });
+
+  it("should start open if page preselected", () => {
+    const wrapper = createWrapper({
+      selectedObj: {
+        page: {
+          id: "1",
+          displayName: "Page 1",
+          __typename: "QuestionPage",
+        },
+        section: null,
+        logical: null,
+      },
+    });
+
+    expect(wrapper.find(QUESTIONPAGE_PICKER).prop("hidden")).toBe(false);
+    expect(wrapper.find(SECTION_PICKER).prop("hidden")).toBe(true);
+    expect(wrapper.find(END_OF_Q_PICKER).prop("hidden")).toBe(true);
+
+    expect(wrapper.state("selectedItem")).toMatchObject({
+      displayName: "Page 1",
+      id: "1",
+    });
   });
 
   describe("Buttons", () => {
@@ -147,14 +193,16 @@ describe("GroupContentPicker", () => {
 
     it("submit button should call onSubmit from ContentPickerSingle", () => {
       const wrapper = createWrapper();
-      wrapper.find(PAGES_PICKER).simulate("titleClick");
-      wrapper.find(PAGES_PICKER).simulate("optionClick", data.questionPages[0]);
+      wrapper.find(QUESTIONPAGE_PICKER).simulate("titleClick");
+      wrapper
+        .find(QUESTIONPAGE_PICKER)
+        .simulate("optionClick", data.questionPages[0]);
       wrapper.find(byTestAttr("submit-button")).simulate("click");
       expect(onSubmit).toHaveBeenCalledWith({
         id: "1",
         displayName: "Page 1",
         config: {
-          id: "pages",
+          id: "QuestionPage",
           title: "Other pages in this section",
           groupKey: "questionPages",
           expandable: true,

--- a/eq-author/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
+++ b/eq-author/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
@@ -55,6 +55,7 @@ exports[`Content Picker Single should render 1`] = `
     open={false}
   >
     <PickerOption
+      aria-pressed={true}
       data-test="picker-option"
       key="1"
       onClick={[Function]}
@@ -63,6 +64,7 @@ exports[`Content Picker Single should render 1`] = `
       Option 1
     </PickerOption>
     <PickerOption
+      aria-pressed={false}
       data-test="picker-option"
       key="2"
       onClick={[Function]}
@@ -71,6 +73,7 @@ exports[`Content Picker Single should render 1`] = `
       Option Label 2
     </PickerOption>
     <PickerOption
+      aria-pressed={false}
       data-test="picker-option"
       key="3"
       onClick={[Function]}

--- a/eq-author/src/components/ContentPicker/__snapshots__/GroupContentPicker.test.js.snap
+++ b/eq-author/src/components/ContentPicker/__snapshots__/GroupContentPicker.test.js.snap
@@ -20,10 +20,10 @@ exports[`GroupContentPicker should render full content picker 1`] = `
           },
         ]
       }
-      data-test="pages-picker"
+      data-test="QuestionPage-picker"
       disabled={false}
       hidden={false}
-      key="pages"
+      key="QuestionPage"
       onOptionClick={[Function]}
       onTitleClick={[Function]}
       open={false}
@@ -47,10 +47,10 @@ exports[`GroupContentPicker should render full content picker 1`] = `
           },
         ]
       }
-      data-test="sections-picker"
+      data-test="Section-picker"
       disabled={false}
       hidden={false}
-      key="sections"
+      key="Section"
       onOptionClick={[Function]}
       onTitleClick={[Function]}
       open={false}

--- a/eq-author/src/components/ContentPicker/index.js
+++ b/eq-author/src/components/ContentPicker/index.js
@@ -52,7 +52,7 @@ export const QuestionContentPicker = props => (
 
 const routingDestinationConfig = [
   {
-    id: "pages",
+    id: "QuestionPage",
     title: "Other pages in this section",
     groupKey: "questionPages",
     expandable: true,
@@ -64,7 +64,7 @@ const routingDestinationConfig = [
     },
   },
   {
-    id: "sections",
+    id: "Section",
     title: "Other sections",
     groupKey: "sections",
     expandable: true,

--- a/eq-author/src/components/ContentPicker/setSelectedElement.js
+++ b/eq-author/src/components/ContentPicker/setSelectedElement.js
@@ -1,0 +1,38 @@
+const getDesiredPath = (
+  entity,
+  selectedId,
+  config,
+  selectedDepth,
+  currentDepth = 0,
+  path = []
+) => {
+  if (currentDepth === selectedDepth && entity.id === selectedId) {
+    return [...path, entity];
+  }
+
+  const { childKey } = config[currentDepth];
+  const children = childKey ? entity[childKey] : [];
+
+  for (let i = 0; i < children.length; i++) {
+    const result = getDesiredPath(
+      children[i],
+      selectedId,
+      config,
+      selectedDepth,
+      currentDepth + 1,
+      [...path, entity]
+    );
+    if (result) {
+      return result;
+    }
+  }
+};
+
+export default (config, selectedId, data) => {
+  return getDesiredPath(
+    { parent: data },
+    selectedId,
+    [{ childKey: "parent" }, ...config],
+    config.length
+  ).slice(1);
+};

--- a/eq-author/src/components/ContentPicker/setSelectedElement.test.js
+++ b/eq-author/src/components/ContentPicker/setSelectedElement.test.js
@@ -1,0 +1,47 @@
+import setSelectedElement from "./setSelectedElement";
+import generateMockPiping from "tests/utils/generateMockPiping";
+
+describe("setSelectedElement", () => {
+  it("Should get the selected items when asking for the data 3 levels deep", () => {
+    const data = generateMockPiping(3, 3, 1);
+    const config = [
+      {
+        id: "section",
+        title: "Section",
+        childKey: "pages",
+      },
+      {
+        id: "page",
+        title: "Question",
+        childKey: "answers",
+      },
+      {
+        id: "answer",
+        title: "Answer",
+      },
+    ];
+    const selectedItems = setSelectedElement(config, "Answer 8", data);
+    expect(selectedItems).toMatchObject([
+      data[2],
+      data[2].pages[1],
+      data[2].pages[1].answers[0],
+    ]);
+  });
+  it("Should get the selected items when asking for the data 2 levels deep", () => {
+    const data = generateMockPiping(3, 3, 1);
+    const config = [
+      {
+        id: "section",
+        title: "Section",
+        childKey: "pages",
+      },
+      {
+        id: "page",
+        title: "Question",
+      },
+    ];
+
+    const selectedItems = setSelectedElement(config, "Page 6", data);
+    expect(selectedItems).toMatchObject([data[1], data[1].pages[2]]);
+  });
+});

--- a/eq-author/src/components/ContentPickerModal/index.js
+++ b/eq-author/src/components/ContentPickerModal/index.js
@@ -134,6 +134,18 @@ class ContentPickerModal extends React.Component {
         id: PropTypes.string.isRequired,
       })
     ),
+    selectedObj: PropTypes.shape({
+      section: PropTypes.shape({
+        id: PropTypes.string,
+        displayName: PropTypes.string,
+      }),
+      page: PropTypes.shape({
+        id: PropTypes.string,
+        displayName: PropTypes.string,
+      }),
+      logical: PropTypes.string,
+    }),
+    selectedId: PropTypes.string,
     destinationData: PropTypes.shape({
       logicalDestinations: PropTypes.arrayOf(propType(LogicalDestination)),
       questionPages: PropTypes.arrayOf(propType(QuestionPageDestination)),
@@ -193,6 +205,7 @@ class ContentPickerModal extends React.Component {
             data={this.props.answerData}
             onSubmit={this.handleAnswerSubmit}
             onClose={this.props.onClose}
+            selectedId={this.props.selectedId}
           />
         </React.Fragment>
       );
@@ -264,6 +277,7 @@ class ContentPickerModal extends React.Component {
             data={this.props.destinationData}
             onSubmit={this.props.onSubmit}
             onClose={this.props.onClose}
+            selectedObj={this.props.selectedObj}
           />
         </React.Fragment>
       );

--- a/eq-author/src/components/ContentPickerSelect/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/ContentPickerSelect/__snapshots__/index.test.js.snap
@@ -259,6 +259,8 @@ Object {
   "onClose": [Function],
   "onSubmit": [Function],
   "questionData": undefined,
+  "selectedId": undefined,
+  "selectedObj": undefined,
 }
 `;
 
@@ -275,6 +277,8 @@ Object {
   "onClose": [Function],
   "onSubmit": [Function],
   "questionData": undefined,
+  "selectedId": undefined,
+  "selectedObj": undefined,
 }
 `;
 
@@ -291,6 +295,8 @@ Object {
   "onClose": [Function],
   "onSubmit": [Function],
   "questionData": undefined,
+  "selectedId": undefined,
+  "selectedObj": undefined,
 }
 `;
 

--- a/eq-author/src/components/ContentPickerSelect/index.js
+++ b/eq-author/src/components/ContentPickerSelect/index.js
@@ -92,9 +92,10 @@ export class UnwrappedContentPickerSelect extends Component {
       metadataData,
       destinationData,
       contentTypes,
+      selectedId,
+      selectedObj,
       ...otherProps
     } = this.props;
-
     const isDisabled = loading || !isNil(error) || disabled;
     return (
       <React.Fragment>
@@ -116,6 +117,8 @@ export class UnwrappedContentPickerSelect extends Component {
           questionData={questionData}
           destinationData={destinationData}
           contentTypes={contentTypes}
+          selectedId={selectedId}
+          selectedObj={selectedObj}
         />
       </React.Fragment>
     );
@@ -129,6 +132,18 @@ UnwrappedContentPickerSelect.propTypes = {
   data: PropTypes.shape({
     questionnaire: CustomPropTypes.questionnaire,
   }),
+  selectedObj: PropTypes.shape({
+    section: PropTypes.shape({
+      id: PropTypes.string,
+      displayName: PropTypes.string,
+    }),
+    page: PropTypes.shape({
+      id: PropTypes.string,
+      displayName: PropTypes.string,
+    }),
+    logical: PropTypes.string,
+  }),
+  selectedId: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   selectedContentDisplayName: PropTypes.string,
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
### What is the context of this PR?
This Pr implements an improvement to the content picker in the UI. It allows it to have a selected state on opening meaning that if a answer has already been selected the picker should open onto that answer instead of being at the top of the tree.

### How to review 
On either Routing or Validation previous answer select, set a previous answer then when you close and re-open the content picker the selected state should still be selected. Also ne tests pass. 
