### PR TITLE
Break out of formatting in RTE

### DIFF
--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -116,6 +116,8 @@
     "downshift": "latest",
     "draft-convert": "latest",
     "draft-js": "latest",
+    "draft-js-block-breakout-plugin": "latest",
+    "draft-js-plugins-editor": "latest",
     "draft-js-raw-content-state": "latest",
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",

--- a/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -122,62 +122,9 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
         selectionIsCollapsed={true}
         visible={false}
       />
-      <DraftEditor
+      <PluginEditor
         ariaLabel="I am a label"
         ariaLabelledBy="label-test"
-        blockRenderMap={
-          Immutable.Map {
-            "ordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ol
-                className="public-DraftStyleDefault-ol"
-              />,
-            },
-            "header-six": Object {
-              "element": "h6",
-            },
-            "header-four": Object {
-              "element": "h4",
-            },
-            "header-one": Object {
-              "element": "h1",
-            },
-            "unordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ul
-                className="public-DraftStyleDefault-ul"
-              />,
-            },
-            "atomic": Object {
-              "element": "figure",
-            },
-            "unstyled": Object {
-              "aliasedElements": Array [
-                "p",
-              ],
-              "element": "div",
-            },
-            "header-two": Object {
-              "element": "h2",
-            },
-            "code-block": Object {
-              "element": "pre",
-              "wrapper": <pre
-                className="public-DraftStyleDefault-pre"
-              />,
-            },
-            "blockquote": Object {
-              "element": "blockquote",
-            },
-            "header-five": Object {
-              "element": "h5",
-            },
-            "header-three": Object {
-              "element": "h3",
-            },
-          }
-        }
-        blockRendererFn={[Function]}
         blockStyleFn={[Function]}
         customStyleMap={
           Object {
@@ -186,6 +133,17 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
             },
           }
         }
+        decorators={
+          Array [
+            Object {
+              "component": [Function],
+              "strategy": [Function],
+            },
+          ]
+        }
+        defaultBlockRenderMap={true}
+        defaultKeyBindings={true}
+        defaultKeyCommands={true}
         editorState={
           EditorState {
             "_immutable": Immutable.Record {
@@ -276,12 +234,16 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
             },
           }
         }
-        keyBindingFn={[Function]}
         onChange={[Function]}
         placeholder=""
-        readOnly={false}
+        plugins={
+          Array [
+            Object {
+              "handleReturn": [Function],
+            },
+          ]
+        }
         spellCheck={true}
-        stripPastedStyles={false}
       />
     </RichTextEditor__Input>
   </Field>
@@ -410,62 +372,9 @@ exports[`components/RichTextEditor should render 1`] = `
         selectionIsCollapsed={true}
         visible={false}
       />
-      <DraftEditor
+      <PluginEditor
         ariaLabel="I am a label"
         ariaLabelledBy="label-test"
-        blockRenderMap={
-          Immutable.Map {
-            "ordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ol
-                className="public-DraftStyleDefault-ol"
-              />,
-            },
-            "header-six": Object {
-              "element": "h6",
-            },
-            "header-four": Object {
-              "element": "h4",
-            },
-            "header-one": Object {
-              "element": "h1",
-            },
-            "unordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ul
-                className="public-DraftStyleDefault-ul"
-              />,
-            },
-            "atomic": Object {
-              "element": "figure",
-            },
-            "unstyled": Object {
-              "aliasedElements": Array [
-                "p",
-              ],
-              "element": "div",
-            },
-            "header-two": Object {
-              "element": "h2",
-            },
-            "code-block": Object {
-              "element": "pre",
-              "wrapper": <pre
-                className="public-DraftStyleDefault-pre"
-              />,
-            },
-            "blockquote": Object {
-              "element": "blockquote",
-            },
-            "header-five": Object {
-              "element": "h5",
-            },
-            "header-three": Object {
-              "element": "h3",
-            },
-          }
-        }
-        blockRendererFn={[Function]}
         blockStyleFn={[Function]}
         customStyleMap={
           Object {
@@ -474,6 +383,17 @@ exports[`components/RichTextEditor should render 1`] = `
             },
           }
         }
+        decorators={
+          Array [
+            Object {
+              "component": [Function],
+              "strategy": [Function],
+            },
+          ]
+        }
+        defaultBlockRenderMap={true}
+        defaultKeyBindings={true}
+        defaultKeyCommands={true}
         editorState={
           EditorState {
             "_immutable": Immutable.Record {
@@ -566,12 +486,16 @@ exports[`components/RichTextEditor should render 1`] = `
         }
         handlePastedText={[Function]}
         handleReturn={[Function]}
-        keyBindingFn={[Function]}
         onChange={[Function]}
         placeholder=""
-        readOnly={false}
+        plugins={
+          Array [
+            Object {
+              "handleReturn": [Function],
+            },
+          ]
+        }
         spellCheck={true}
-        stripPastedStyles={false}
       />
     </RichTextEditor__Input>
   </Field>
@@ -757,62 +681,9 @@ exports[`components/RichTextEditor should render existing content 1`] = `
 "
         visible={false}
       />
-      <DraftEditor
+      <PluginEditor
         ariaLabel="I am a label"
         ariaLabelledBy="label-test"
-        blockRenderMap={
-          Immutable.Map {
-            "ordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ol
-                className="public-DraftStyleDefault-ol"
-              />,
-            },
-            "header-six": Object {
-              "element": "h6",
-            },
-            "header-four": Object {
-              "element": "h4",
-            },
-            "header-one": Object {
-              "element": "h1",
-            },
-            "unordered-list-item": Object {
-              "element": "li",
-              "wrapper": <ul
-                className="public-DraftStyleDefault-ul"
-              />,
-            },
-            "atomic": Object {
-              "element": "figure",
-            },
-            "unstyled": Object {
-              "aliasedElements": Array [
-                "p",
-              ],
-              "element": "div",
-            },
-            "header-two": Object {
-              "element": "h2",
-            },
-            "code-block": Object {
-              "element": "pre",
-              "wrapper": <pre
-                className="public-DraftStyleDefault-pre"
-              />,
-            },
-            "blockquote": Object {
-              "element": "blockquote",
-            },
-            "header-five": Object {
-              "element": "h5",
-            },
-            "header-three": Object {
-              "element": "h3",
-            },
-          }
-        }
-        blockRendererFn={[Function]}
         blockStyleFn={[Function]}
         customStyleMap={
           Object {
@@ -821,6 +692,17 @@ exports[`components/RichTextEditor should render existing content 1`] = `
             },
           }
         }
+        decorators={
+          Array [
+            Object {
+              "component": [Function],
+              "strategy": [Function],
+            },
+          ]
+        }
+        defaultBlockRenderMap={true}
+        defaultKeyBindings={true}
+        defaultKeyCommands={true}
         editorState={
           EditorState {
             "_immutable": Immutable.Record {
@@ -962,12 +844,16 @@ exports[`components/RichTextEditor should render existing content 1`] = `
         }
         handlePastedText={[Function]}
         handleReturn={[Function]}
-        keyBindingFn={[Function]}
         onChange={[Function]}
         placeholder=""
-        readOnly={false}
+        plugins={
+          Array [
+            Object {
+              "handleReturn": [Function],
+            },
+          ]
+        }
         spellCheck={true}
-        stripPastedStyles={false}
       />
     </RichTextEditor__Input>
   </Field>

--- a/eq-author/src/components/RichTextEditor/entities/PipedValue.js
+++ b/eq-author/src/components/RichTextEditor/entities/PipedValue.js
@@ -8,7 +8,7 @@ import replaceEntityText from "components/RichTextEditor/utils/replaceEntityText
 import { Modifier } from "draft-js";
 import { bindKey } from "lodash";
 
-export const ENTITY_TYPE = "PIPED-DATA";
+export const ENTITY_TYPE = "PIPEDDATA";
 
 export const filterConfig = {
   type: ENTITY_TYPE,

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -4616,6 +4616,11 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decorate-component-with-props@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decorate-component-with-props/-/decorate-component-with-props-1.1.0.tgz#b496c814c6a2aba0cf2ad26e44cbedb8ead42f15"
+  integrity sha512-tTYQojixN64yK3/WBODMfvss/zbmyUx9HQXhzSxZiSiofeekVeRyyuToy9BCiTMrVEIKWxTcla2t3y5qdaUF7Q==
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -4982,6 +4987,24 @@ draft-convert@latest:
   dependencies:
     immutable "~3.7.4"
     invariant "^2.2.1"
+
+draft-js-block-breakout-plugin@latest:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/draft-js-block-breakout-plugin/-/draft-js-block-breakout-plugin-2.0.1.tgz#a38e3bd68d9538d7af15d4d966844d6e6d2ad850"
+  integrity sha1-o4471o2VONevFdTZZoRNbm0q2FA=
+  dependencies:
+    immutable "~3.7.4"
+
+draft-js-plugins-editor@latest:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/draft-js-plugins-editor/-/draft-js-plugins-editor-2.1.1.tgz#7c9aedd696737c6ddf45d47c978bd764ef33f688"
+  integrity sha512-fKGe71irNvFHJ5L/lUrh+3vPkBNq0de6x+cgiZUJ9zQERc5KPBtGXIFiarLFVHyrRTCPq+K6xmgfFSAERaFHPw==
+  dependencies:
+    decorate-component-with-props "^1.0.2"
+    find-with-regex "^1.1.3"
+    immutable "~3.7.4"
+    prop-types "^15.5.8"
+    union-class-names "^1.0.0"
 
 draft-js-raw-content-state@latest:
   version "1.2.7"
@@ -6095,6 +6118,11 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-with-regex@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
+  integrity sha512-zkEVQ1H3PIQL/19ADKt1lCQU4QGM3OneiderUcFgn5EgTm/TnoUh7HxPAwP8w/vXxWSLC6KtpbDQpypJ5+majw==
 
 firebase@latest:
   version "5.8.0"
@@ -14108,6 +14136,11 @@ unified@^7.0.0, unified@^7.0.2:
     trough "^1.0.0"
     vfile "^3.0.0"
     x-is-string "^0.1.0"
+
+union-class-names@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-class-names/-/union-class-names-1.0.0.tgz#9259608adacc39094a2b0cfe16c78e6200617847"
+  integrity sha1-kllgitrMOQlKKwz+FseOYgBheEc=
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
This implements breaking out of formatting in rich text editors.

We have switched to using a wrapper around DraftJS called [DraftJS Plugins](https://www.draft-js-plugins.com/) which provides a nice interface for building plugins on top of DraftJS. This allowed us to use the [breakout plugin](https://github.com/icelab/draft-js-block-breakout-plugin/).

We have taken the [defaults of the breakout plugin](https://github.com/icelab/draft-js-block-breakout-plugin/#options). This includes breaking out of headings on one enter and breaking out of lists on two enters. 

### Note
~~It seems to require hard refreshing after switching to the branch - don't rely on simple browser refresh or hot reload.~~
This has a bug at the moment so its back in progress.

### How to review 
1. Ensure that RTE breaks out of formatting as expected.
2. Ensure that other RTE functionality is maintained.
