### PR TITLE
Add env to switch between DynamoDB and local filesystem.

### DIFF
--- a/eq-author-api/README.md
+++ b/eq-author-api/README.md
@@ -30,17 +30,18 @@ In most cases sensible defaults have been selected.
 
 ## Environment Variables
 
-| Name                    | Description                                                                        | Required |
-| ----------------------- | ---------------------------------------------------------------------------------- | -------- |
-| `RUNNER_SESSION_URL`    | Authentication URL for survey runner                                               | Yes      |
-| `PUBLISHER_URL`         | URL that produces valid survey runner JSON                                         | Yes      |
-| `DB_CONNECTION_URI`     | Connection string for database                                                     | Yes      |
-| `SECRETS_S3_BUCKET`     | Name of S3 bucket where secrets are stored                                         | No       |
-| `KEYS_FILE`             | Name of the keys file to use inside the bucket                                     | No       |
-| `AUTH_HEADER_KEY`       | Name of the header values that contains the Auth token                             | No       |
-| `EQ_AUTHOR_API_VERSION` | The current Author API version. This is what gets reported on the /status endpoint | No       |
-| `PORT`                  | The port which express listens on (defaults to `4000`)                             | No       |
-| `NODE_ENV`              | Sets the environment the code is running in                                        | No       |
+| Name                    | Description                                                                                                                                          | Required |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `RUNNER_SESSION_URL`    | Authentication URL for survey runner                                                                                                                 | Yes      |
+| `PUBLISHER_URL`         | URL that produces valid survey runner JSON                                                                                                           | Yes      |
+| `DB_CONNECTION_URI`     | Connection string for database                                                                                                                       | Yes      |
+| `SECRETS_S3_BUCKET`     | Name of S3 bucket where secrets are stored                                                                                                           | No       |
+| `KEYS_FILE`             | Name of the keys file to use inside the bucket                                                                                                       | No       |
+| `AUTH_HEADER_KEY`       | Name of the header values that contains the Auth token                                                                                               | No       |
+| `EQ_AUTHOR_API_VERSION` | The current Author API version. This is what gets reported on the /status endpoint                                                                   | No       |
+| `PORT`                  | The port which express listens on (defaults to `4000`)                                                                                               | No       |
+| `NODE_ENV`              | Sets the environment the code is running in                                                                                                          | No       |
+| `DATASTORE`             | Sets place we store the data, allows us to have the data stored locally in JSON files which makes debugging easier (for this set it to `filesystem`) | No       |
 
 ## Run using Docker
 

--- a/eq-author-api/utils/datastore.js
+++ b/eq-author-api/utils/datastore.js
@@ -1,90 +1,17 @@
+let datastore;
+if (process.env.DATASTORE === "filesystem") {
+  datastore = require("./datastoreFileSystem");
+} else {
+  datastore = require("./datastoreDynamo");
+}
+
 const {
-  QuestionnaireModel,
-  QuestionnaireVersionsModel,
-} = require("../db/models/DynamoDB");
-const { omit, isEqual } = require("lodash");
-
-const saveModel = model =>
-  new Promise((resolve, reject) => {
-    model.save(err => {
-      if (err) {
-        reject(err);
-      }
-      resolve();
-    });
-  });
-
-const createQuestionnaire = async questionnaire => {
-  await saveModel(
-    new QuestionnaireModel(omit(questionnaire, "sections", "metadata"))
-  );
-  await saveModel(
-    new QuestionnaireVersionsModel({
-      ...questionnaire,
-      updatedAt: Date.now(),
-    })
-  );
-
-  return questionnaire;
-};
-
-const saveQuestionnaire = async questionnaire => {
-  let equal = isEqual(
-    {
-      metadata: [],
-      sections: [],
-      ...questionnaire.originalItem(),
-    },
-    {
-      ...questionnaire,
-    }
-  );
-  if (equal) {
-    return questionnaire;
-  }
-  if (questionnaire.updatedAt) {
-    questionnaire.updatedAt = Date.now();
-  }
-
-  return saveModel(questionnaire);
-};
-
-const deleteQuestionnaire = id => {
-  return new Promise((resolve, reject) => {
-    QuestionnaireModel.delete({ id: id }, function(err) {
-      if (err) {
-        reject(err);
-      }
-      resolve();
-    });
-  });
-};
-
-const getQuestionnaire = id => {
-  return new Promise((resolve, reject) => {
-    QuestionnaireVersionsModel.queryOne({ id: { eq: id } })
-      .descending()
-      .exec((err, questionnaire) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(questionnaire);
-      });
-  });
-};
-
-const listQuestionnaires = () => {
-  return new Promise((resolve, reject) => {
-    QuestionnaireModel.scan()
-      .all()
-      .exec((err, questionnaires) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(questionnaires);
-      });
-  });
-};
+  createQuestionnaire,
+  saveQuestionnaire,
+  deleteQuestionnaire,
+  getQuestionnaire,
+  listQuestionnaires,
+} = datastore;
 
 module.exports = {
   createQuestionnaire,

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -1,0 +1,95 @@
+const {
+  QuestionnaireModel,
+  QuestionnaireVersionsModel,
+} = require("../db/models/DynamoDB");
+const { omit, isEqual } = require("lodash");
+
+const saveModel = model =>
+  new Promise((resolve, reject) => {
+    model.save(err => {
+      if (err) {
+        reject(err);
+      }
+      resolve();
+    });
+  });
+
+const createQuestionnaire = async questionnaire => {
+  await saveModel(
+    new QuestionnaireModel(omit(questionnaire, "sections", "metadata"))
+  );
+  await saveModel(
+    new QuestionnaireVersionsModel({
+      ...questionnaire,
+      updatedAt: Date.now(),
+    })
+  );
+
+  return questionnaire;
+};
+
+const saveQuestionnaire = async questionnaire => {
+  let equal = isEqual(
+    {
+      metadata: [],
+      sections: [],
+      ...questionnaire.originalItem(),
+    },
+    {
+      ...questionnaire,
+    }
+  );
+  if (equal) {
+    return questionnaire;
+  }
+  if (questionnaire.updatedAt) {
+    questionnaire.updatedAt = Date.now();
+  }
+
+  return saveModel(questionnaire);
+};
+
+const deleteQuestionnaire = id => {
+  return new Promise((resolve, reject) => {
+    QuestionnaireModel.delete({ id: id }, function(err) {
+      if (err) {
+        reject(err);
+      }
+      resolve();
+    });
+  });
+};
+
+const getQuestionnaire = id => {
+  return new Promise((resolve, reject) => {
+    QuestionnaireVersionsModel.queryOne({ id: { eq: id } })
+      .descending()
+      .exec((err, questionnaire) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(questionnaire);
+      });
+  });
+};
+
+const listQuestionnaires = () => {
+  return new Promise((resolve, reject) => {
+    QuestionnaireModel.scan()
+      .all()
+      .exec((err, questionnaires) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(questionnaires);
+      });
+  });
+};
+
+module.exports = {
+  createQuestionnaire,
+  saveQuestionnaire,
+  deleteQuestionnaire,
+  getQuestionnaire,
+  listQuestionnaires,
+};

--- a/eq-author-api/utils/datastoreFileSystem.js
+++ b/eq-author-api/utils/datastoreFileSystem.js
@@ -1,0 +1,58 @@
+const { omit, reject } = require("lodash");
+const fs = require("fs").promises;
+const stringify = require("json-stable-stringify");
+
+const createQuestionnaire = async questionnaire => {
+  await fs.writeFile(
+    `data/${questionnaire.id}.json`,
+    stringify(questionnaire, { space: 4 })
+  );
+  const questionnaireList = JSON.parse(
+    await fs.readFile(`data/QuestionnaireList.json`, "utf8")
+  );
+  questionnaireList.push({
+    ...omit(questionnaire, "sections", "metadata"),
+  });
+  await fs.writeFile(
+    `data/QuestionnaireList.json`,
+    stringify(questionnaireList, { space: 4 })
+  );
+  return questionnaire;
+};
+
+const saveQuestionnaire = async questionnaire => {
+  await fs.writeFile(
+    `data/${questionnaire.id}.json`,
+    stringify(questionnaire, { space: 4 })
+  );
+  return questionnaire;
+};
+
+const deleteQuestionnaire = async id => {
+  const originalList = JSON.parse(
+    await fs.readFile(`data/QuestionnaireList.json`, "utf8")
+  );
+  await fs.writeFile(
+    `data/QuestionnaireList.json`,
+    stringify(reject(originalList, { id }))
+  );
+};
+
+const getQuestionnaire = async id => {
+  const questionnaire = JSON.parse(
+    await fs.readFile(`data/${id}.json`, "utf8")
+  );
+  return Promise.resolve(questionnaire);
+};
+
+const listQuestionnaires = async () => {
+  return JSON.parse(await fs.readFile(`data/QuestionnaireList.json`, "utf8"));
+};
+
+module.exports = {
+  createQuestionnaire,
+  saveQuestionnaire,
+  deleteQuestionnaire,
+  getQuestionnaire,
+  listQuestionnaires,
+};

--- a/eq-author/cypress/integration/authenticated/dashboard_spec.js
+++ b/eq-author/cypress/integration/authenticated/dashboard_spec.js
@@ -87,17 +87,16 @@ describe("dashboard", () => {
       cy.login();
     });
 
-      it("should delete the questionnaire", () => {
-        cy.get(testId("btn-delete-questionnaire")).click();
-        cy.get(testId("btn-delete-modal")).click();
-        cy.contains("You have no questionnaires").should("be.visible");
-      });
+    it("should delete the questionnaire", () => {
+      cy.get(testId("btn-delete-questionnaire")).click();
+      cy.get(testId("btn-delete-modal")).click();
+      cy.contains("You have no questionnaires").should("be.visible");
+    });
 
-      it("should display toast when questionnaire is deleted", () => {
-        cy.get(testId("btn-delete-questionnaire")).click();
-        cy.get(testId("btn-delete-modal")).click();
-        cy.contains("Questionnaire deleted").should("be.visible");
-      });
+    it("should display toast when questionnaire is deleted", () => {
+      cy.get(testId("btn-delete-questionnaire")).click();
+      cy.get(testId("btn-delete-modal")).click();
+      cy.contains("Questionnaire deleted").should("be.visible");
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Currently without a decent way of interacting with dynamoDB this is a workaround so that an environment variable can be set so that in dev we can manage the questionnaires as json files as before DynamoDB. This makes testing questionnaires a lot easier.

### How to review 
- Make sure tests pass
- Add 'DATASTORE=filesystem' to your environment variables in the api docker-compose.yml and ensure that author now goes back to writing to json files in the data folder
