### PR TITLE
Fix UUID regex to be backwards compatable

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageConfirmationNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageConfirmationNavItem.test.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
 
-import fakeId from "tests/utils/fakeId";
-
 import { UnwrappedPageConfirmationNavItem as PageConfirmationNavItem } from "./PageConfirmationNavItem";
 
 describe("PageConfirmationNavItem", () => {
@@ -10,18 +8,18 @@ describe("PageConfirmationNavItem", () => {
 
   beforeEach(() => {
     props = {
-      questionnaireId: fakeId("1"),
-      sectionId: fakeId("2"),
+      questionnaireId: "1",
+      sectionId: "2",
       page: {
-        id: fakeId("3"),
+        id: "3",
         confirmation: {
-          id: fakeId("4"),
+          id: "4",
           displayName: "Confirmation display name",
         },
       },
       match: {
         params: {
-          questionnaireId: fakeId("1"),
+          questionnaireId: "1",
           tab: "design",
         },
       },

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.test.js
@@ -1,10 +1,9 @@
 import React from "react";
 import { shallow } from "enzyme";
-import fakeId from "tests/utils/fakeId";
 import { UnwrappedPageNavItem } from "./PageNavItem";
 
 const page = {
-  id: fakeId("3"),
+  id: "3",
   displayName: "Page title",
 };
 
@@ -14,14 +13,14 @@ describe("PageNavItem", () => {
   beforeEach(() => {
     component = shallow(
       <UnwrappedPageNavItem
-        questionnaireId={fakeId("1")}
-        sectionId={fakeId("2")}
+        questionnaireId={"1"}
+        sectionId={"2"}
         title="Title"
         page={page}
         match={{
           params: {
-            questionnaireId: fakeId("1"),
-            sectionId: fakeId("2"),
+            questionnaireId: "1",
+            sectionId: "2",
             pageId: page.id,
           },
         }}

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
@@ -1,19 +1,18 @@
 import { shallow } from "enzyme";
 import React from "react";
-import fakeId from "tests/utils/fakeId";
 
 import { UnwrappedSectionNavItem as SectionNavItem } from "./SectionNavItem";
 
 describe("SectionNavItem", () => {
-  const page = { id: fakeId("2"), title: "Page", displayName: "Page" };
+  const page = { id: "2", title: "Page", displayName: "Page" };
   const section = {
-    id: fakeId("3"),
+    id: "3",
     title: "Section",
     displayName: "Section",
     pages: [page],
   };
   const questionnaire = {
-    id: fakeId("1"),
+    id: "1",
     title: "Questionnaire",
     displayName: "Questionnaire",
     sections: [section],

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/PageConfirmationNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/PageConfirmationNavItem.test.js.snap
@@ -8,7 +8,7 @@ exports[`PageConfirmationNavItem should render design 1`] = `
     <PageConfirmationNavItem__StyledNavLink
       data-test="question-confirmation-link"
       icon={[Function]}
-      to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/444444444444444444444444444444444444/design"
+      to="/questionnaire/1/2/3/4/design"
     >
       Confirmation display name
     </PageConfirmationNavItem__StyledNavLink>
@@ -24,7 +24,7 @@ exports[`PageConfirmationNavItem should render preview 1`] = `
     <PageConfirmationNavItem__StyledNavLink
       data-test="question-confirmation-link"
       icon={[Function]}
-      to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/444444444444444444444444444444444444/preview"
+      to="/questionnaire/1/2/3/4/preview"
     >
       Confirmation display name
     </PageConfirmationNavItem__StyledNavLink>

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/PageNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/PageNavItem.test.js.snap
@@ -9,7 +9,7 @@ exports[`PageNavItem should render 1`] = `
     data-test="nav-page-link"
     icon={[Function]}
     title="Page title"
-    to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333"
+    to="/questionnaire/1/2/3"
   >
     Page title
   </NavLink>

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
@@ -12,7 +12,7 @@ exports[`SectionNavItem should render 1`] = `
     exact={true}
     icon={[Function]}
     title="Section"
-    to="/questionnaire/111111111111111111111111111111111111/333333333333333333333333333333333333/design"
+    to="/questionnaire/1/3/design"
   >
     Section
   </NavLink>
@@ -20,15 +20,15 @@ exports[`SectionNavItem should render 1`] = `
     questionnaire={
       Object {
         "displayName": "Questionnaire",
-        "id": "111111111111111111111111111111111111",
+        "id": "1",
         "sections": Array [
           Object {
             "displayName": "Section",
-            "id": "333333333333333333333333333333333333",
+            "id": "3",
             "pages": Array [
               Object {
                 "displayName": "Page",
-                "id": "222222222222222222222222222222222222",
+                "id": "2",
                 "title": "Page",
               },
             ],
@@ -41,11 +41,11 @@ exports[`SectionNavItem should render 1`] = `
     section={
       Object {
         "displayName": "Section",
-        "id": "333333333333333333333333333333333333",
+        "id": "3",
         "pages": Array [
           Object {
             "displayName": "Page",
-            "id": "222222222222222222222222222222222222",
+            "id": "2",
             "title": "Page",
           },
         ],

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -8,26 +8,26 @@ exports[`QuestionnaireDesignPage should render 1`] = `
 <BaseLayout
   questionnaire={
     Object {
-      "id": "333333333333333333333333333333333333",
+      "id": "3",
       "sections": Array [
         Object {
-          "id": "222222222222222222222222222222222222",
+          "id": "2",
           "pages": Array [
             Object {
               "answers": Array [
                 Object {
-                  "id": "111111111111111111111111111111111111",
+                  "id": "1",
                   "label": "",
                   "options": Array [
                     Object {
-                      "id": "111111111111111111111111111111111111",
+                      "id": "1",
                     },
                   ],
                 },
               ],
               "description": "",
               "guidance": "",
-              "id": "111111111111111111111111111111111111",
+              "id": "1",
               "position": 0,
               "title": "",
               "type": "General",
@@ -60,26 +60,26 @@ exports[`QuestionnaireDesignPage should render 1`] = `
           onAddSection={[MockFunction]}
           questionnaire={
             Object {
-              "id": "333333333333333333333333333333333333",
+              "id": "3",
               "sections": Array [
                 Object {
-                  "id": "222222222222222222222222222222222222",
+                  "id": "2",
                   "pages": Array [
                     Object {
                       "answers": Array [
                         Object {
-                          "id": "111111111111111111111111111111111111",
+                          "id": "1",
                           "label": "",
                           "options": Array [
                             Object {
-                              "id": "111111111111111111111111111111111111",
+                              "id": "1",
                             },
                           ],
                         },
                       ],
                       "description": "",
                       "guidance": "",
-                      "id": "111111111111111111111111111111111111",
+                      "id": "1",
                       "position": 0,
                       "title": "",
                       "type": "General",
@@ -100,32 +100,32 @@ exports[`QuestionnaireDesignPage should render 1`] = `
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/design"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/design"
           />
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/design"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/design"
           />
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/routing"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/routing"
           />
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})?/preview"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)?/preview"
           />
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/:confirmationId([a-f0-9-]{36})/design"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/:confirmationId([a-f0-9-]+)/design"
           />
           <Route
             component={[Function]}
             exact={true}
-            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/:confirmationId([a-f0-9-]{36})/preview"
+            path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/:confirmationId([a-f0-9-]+)/preview"
           />
           <Route
             path="*"
@@ -141,7 +141,7 @@ exports[`QuestionnaireDesignPage should render 1`] = `
 exports[`QuestionnaireDesignPage should render redirect when finished loading 1`] = `
 <Redirect
   push={false}
-  to="/questionnaire/333333333333333333333333333333333333/222222222222222222222222222222222222/design"
+  to="/questionnaire/3/2/design"
 />
 `;
 

--- a/eq-author/src/App/QuestionnaireDesignPage/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { shallow } from "enzyme";
-import fakeId from "tests/utils/fakeId";
 
 import { UnwrappedQuestionnaireDesignPage as QuestionnaireDesignPage } from ".";
 
@@ -10,13 +9,13 @@ describe("QuestionnaireDesignPage", () => {
   let match;
 
   const answer = {
-    id: fakeId("1"),
+    id: "1",
     label: "",
-    options: [{ id: fakeId("1") }],
+    options: [{ id: "1" }],
   };
 
   const page = {
-    id: fakeId("1"),
+    id: "1",
     description: "",
     guidance: "",
     title: "",
@@ -26,13 +25,13 @@ describe("QuestionnaireDesignPage", () => {
   };
 
   const section = {
-    id: fakeId("2"),
+    id: "2",
     title: "",
     pages: [page],
   };
 
   const questionnaire = {
-    id: fakeId("3"),
+    id: "3",
     title: "hello world",
     sections: [section],
   };

--- a/eq-author/src/App/QuestionnaireDesignPage/withCreateQuestionConfirmation.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/withCreateQuestionConfirmation.test.js
@@ -1,14 +1,13 @@
-import fakeId from "tests/utils/fakeId";
 import { mapMutateToProps } from "./withCreateQuestionConfirmation";
 
 describe("withCreateQuestionConfirmation", () => {
   let mutate, ownProps, questionnaireId, sectionId, pageId, confirmationId;
 
   beforeEach(() => {
-    questionnaireId = fakeId("1");
-    sectionId = fakeId("2");
-    pageId = fakeId("3");
-    confirmationId = fakeId("4");
+    questionnaireId = "1";
+    sectionId = "2";
+    pageId = "3";
+    confirmationId = "4";
 
     mutate = jest.fn().mockResolvedValue({
       data: {

--- a/eq-author/src/App/QuestionnairesPage/QuestionnaireLink.test.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnaireLink.test.js
@@ -1,17 +1,16 @@
 import React from "react";
 import { shallow } from "enzyme";
-import fakeId from "tests/utils/fakeId";
 
 import QuestionnaireLink from "./QuestionnaireLink";
 
 const questionnaire = {
-  id: fakeId("1"),
+  id: "1",
   title: "Foo",
   createdAt: "2017/01/02",
   sections: [
     {
-      id: fakeId("2"),
-      pages: [{ id: fakeId("3") }],
+      id: "2",
+      pages: [{ id: "3" }],
     },
   ],
   createdBy: {

--- a/eq-author/src/App/QuestionnairesPage/__snapshots__/QuestionnaireLink.test.js.snap
+++ b/eq-author/src/App/QuestionnairesPage/__snapshots__/QuestionnaireLink.test.js.snap
@@ -3,6 +3,6 @@
 exports[`QuestionnaireLink should render 1`] = `
 <QuestionnaireLink__StyledLink
   disabled={false}
-  to="/questionnaire/111111111111111111111111111111111111/design"
+  to="/questionnaire/1/design"
 />
 `;

--- a/eq-author/src/App/QuestionnairesPage/withCreateQuestionnaire.test.js
+++ b/eq-author/src/App/QuestionnairesPage/withCreateQuestionnaire.test.js
@@ -5,14 +5,13 @@ import {
 } from "App/QuestionnairesPage/withCreateQuestionnaire";
 import { buildPagePath } from "utils/UrlUtils";
 import getQuestionnaireList from "graphql/getQuestionnaireList.graphql";
-import fakeId from "tests/utils/fakeId";
 
 describe("withCreateQuestionnaire", () => {
   let history, mutate, results, user;
 
-  const page = { id: fakeId("3") };
-  const section = { id: fakeId("2"), pages: [page] };
-  const questionnaire = { id: fakeId("1"), sections: [section] };
+  const page = { id: "3" };
+  const section = { id: "2", pages: [page] };
+  const questionnaire = { id: "1", sections: [section] };
 
   beforeEach(() => {
     results = {
@@ -70,8 +69,8 @@ describe("withCreateQuestionnaire", () => {
     let proxy, readQuery, writeQuery, data, questionnaire1Id, questionnaire2Id;
 
     beforeEach(() => {
-      questionnaire1Id = fakeId("1");
-      questionnaire2Id = fakeId("2");
+      questionnaire1Id = "1";
+      questionnaire2Id = "2";
       data = {
         questionnaires: [{ id: questionnaire2Id }, { id: questionnaire1Id }],
       };
@@ -86,7 +85,7 @@ describe("withCreateQuestionnaire", () => {
     });
 
     it("should update the getQuestionnaireList query with new questionnaire.", () => {
-      const newQuestionnaire = { id: fakeId("3") };
+      const newQuestionnaire = { id: "3" };
 
       updateQuestionnaireList(proxy, {
         data: { createQuestionnaire: newQuestionnaire },

--- a/eq-author/src/App/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/__snapshots__/index.test.js.snap
@@ -37,17 +37,17 @@ exports[`containers/AppContainer Routes should render  1`] = `
     />
     <RedirectRoute
       from="/questionnaire/:questionnaireId/design/:sectionId/:pageId"
-      to="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/design"
+      to="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/design"
     />
     <RedirectRoute
       from="/questionnaire/:questionnaireId/design/:sectionId"
-      to="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/design"
+      to="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/design"
     />
     <PrivateRoute
       component={[Function]}
       exact={false}
       isSignedIn={true}
-      path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})?/:pageId([a-f0-9-]{36})?/:confirmationId([a-f0-9-]{36})?/:tab?"
+      path="/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)?/:pageId([a-f0-9-]+)?/:confirmationId([a-f0-9-]+)?/:tab?"
     />
     <Route
       component={[Function]}

--- a/eq-author/src/App/questionConfirmation/Design/withDeleteQuestionConfirmation.test.js
+++ b/eq-author/src/App/questionConfirmation/Design/withDeleteQuestionConfirmation.test.js
@@ -1,14 +1,13 @@
 import { mapMutateToProps } from "./withDeleteQuestionConfirmation";
-import fakeId from "tests/utils/fakeId";
 
 describe("withDeleteQuestionConfirmation", () => {
   let mutate, ownProps, questionnaireId, sectionId, pageId, confirmationId;
 
   beforeEach(() => {
-    questionnaireId = fakeId("1");
-    sectionId = fakeId("2");
-    pageId = fakeId("3");
-    confirmationId = fakeId("4");
+    questionnaireId = "1";
+    sectionId = "2";
+    pageId = "3";
+    confirmationId = "4";
 
     mutate = jest.fn().mockResolvedValue({
       data: {

--- a/eq-author/src/App/questionPage/Design/EditorLayout/Tabs/__snapshots__/tabs.test.js.snap
+++ b/eq-author/src/App/questionPage/Design/EditorLayout/Tabs/__snapshots__/tabs.test.js.snap
@@ -5,7 +5,7 @@ exports[`components/Tabs should enable the Routing tab when prop is passed 1`] =
   activeClassName="active"
   data-test="routing"
   key="routing"
-  to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/routing"
+  to="/questionnaire/1/2/3/routing"
 >
   <IconText
     hideText={false}
@@ -21,7 +21,7 @@ exports[`components/Tabs should enable the preview tab when prop is passed 1`] =
   activeClassName="active"
   data-test="preview"
   key="preview"
-  to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/preview"
+  to="/questionnaire/1/2/3/preview"
 >
   <IconText
     hideText={false}
@@ -41,7 +41,7 @@ exports[`components/Tabs should render a confirmation link when provided 1`] = `
       activeClassName="active"
       data-test="design"
       key="design"
-      to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/444444444444444444444444444444444444/design"
+      to="/questionnaire/1/2/3/4/design"
     >
       <IconText
         hideText={false}
@@ -90,7 +90,7 @@ exports[`components/Tabs should render link to section if params are for a secti
       activeClassName="active"
       data-test="design"
       key="design"
-      to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/design"
+      to="/questionnaire/1/2/design"
     >
       <IconText
         hideText={false}
@@ -139,7 +139,7 @@ exports[`components/Tabs should render with design tab enabled by default 1`] = 
       activeClassName="active"
       data-test="design"
       key="design"
-      to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/333333333333333333333333333333333333/design"
+      to="/questionnaire/1/2/3/design"
     >
       <IconText
         hideText={false}

--- a/eq-author/src/App/questionPage/Design/EditorLayout/Tabs/tabs.test.js
+++ b/eq-author/src/App/questionPage/Design/EditorLayout/Tabs/tabs.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { shallow } from "enzyme";
-import fakeId from "tests/utils/fakeId";
 import { UnwrappedTabs, Tab, activeClassName } from "./";
 
 describe("components/Tabs", () => {
@@ -10,9 +9,9 @@ describe("components/Tabs", () => {
     props = {
       match: {
         params: {
-          questionnaireId: fakeId("1"),
-          sectionId: fakeId("2"),
-          pageId: fakeId("3"),
+          questionnaireId: "1",
+          sectionId: "2",
+          pageId: "3",
         },
       },
       children: "Tab Content",
@@ -31,7 +30,7 @@ describe("components/Tabs", () => {
   });
 
   it("should render a confirmation link when provided", () => {
-    props.match.params.confirmationId = fakeId("4");
+    props.match.params.confirmationId = "4";
     const wrapper = shallow(<UnwrappedTabs {...props} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/eq-author/src/App/questionPage/Design/index.test.js
+++ b/eq-author/src/App/questionPage/Design/index.test.js
@@ -10,8 +10,6 @@ import flushPromises from "tests/utils/flushPromises";
 import createRouterContext from "react-router-test-context";
 import PropTypes from "prop-types";
 
-import fakeId from "tests/utils/fakeId";
-
 import movePageQuery from "graphql/getQuestionnaire.graphql";
 
 describe("QuestionPageRoute", () => {
@@ -28,9 +26,9 @@ describe("QuestionPageRoute", () => {
   beforeEach(() => {
     childContextTypes = { router: PropTypes.object };
 
-    questionnaireId = fakeId("1");
-    sectionId = fakeId("2");
-    pageId = fakeId("3");
+    questionnaireId = "1";
+    sectionId = "2";
+    pageId = "3";
 
     movePageMock = {
       request: {
@@ -80,7 +78,7 @@ describe("QuestionPageRoute", () => {
                   },
                   {
                     __typename: "QuestionPage",
-                    id: fakeId("4"),
+                    id: "4",
                     title: "blah",
                     alias: "blah-alias",
                     displayName: "blah",
@@ -381,9 +379,7 @@ describe("QuestionPageRoute", () => {
     });
 
     it("should allow answers to be added", () => {
-      const onAddAnswer = jest.fn(() =>
-        Promise.resolve(() => ({ id: fakeId("1") }))
-      );
+      const onAddAnswer = jest.fn(() => Promise.resolve(() => ({ id: "1" })));
       const wrapper = render(
         {
           loading: false,

--- a/eq-author/src/App/questionPage/Design/withDeletePage.test.js
+++ b/eq-author/src/App/questionPage/Design/withDeletePage.test.js
@@ -1,6 +1,5 @@
 import { mapMutateToProps, createUpdater } from "./withDeletePage";
 import fragment from "graphql/sectionFragment.graphql";
-import fakeId from "tests/utils/fakeId";
 
 describe("withDeletePage", () => {
   let history, mutate, result, ownProps, onAddPage, raiseToast;
@@ -12,31 +11,28 @@ describe("withDeletePage", () => {
     afterDeleteSection;
 
   beforeEach(() => {
-    sectionId = fakeId("9");
-    questionnaireId = fakeId("1");
+    sectionId = "9";
+    questionnaireId = "1";
     deletedPage = {
-      id: fakeId("2"),
+      id: "2",
       sectionId,
       position: 1,
     };
 
     currentPage = {
-      id: fakeId("1"),
+      id: "1",
       sectionId,
       position: 0,
     };
 
     beforeDeleteSection = {
       id: sectionId,
-      pages: [currentPage, deletedPage, { id: fakeId("3"), position: 2 }],
+      pages: [currentPage, deletedPage, { id: "3", position: 2 }],
     };
 
     afterDeleteSection = {
       ...beforeDeleteSection,
-      pages: [
-        { ...currentPage, position: 0 },
-        { id: fakeId("3"), position: 1 },
-      ],
+      pages: [{ ...currentPage, position: 0 }, { id: "3", position: 1 }],
     };
 
     history = {
@@ -94,11 +90,11 @@ describe("withDeletePage", () => {
     it("should update position value of all pages", () => {
       const cache = {
         section: {
-          id: fakeId("1"),
+          id: "1",
           pages: [
-            { id: fakeId("1"), position: 0 },
+            { id: "1", position: 0 },
             deletedPage,
-            { id: fakeId("3"), position: 2 },
+            { id: "3", position: 2 },
           ],
         },
       };
@@ -112,8 +108,8 @@ describe("withDeletePage", () => {
       updater(proxy, result);
 
       expect(cache.section.pages).toEqual([
-        { id: fakeId("1"), position: 0 },
-        { id: fakeId("3"), position: 1 },
+        { id: "1", position: 0 },
+        { id: "3", position: 1 },
       ]);
     });
   });

--- a/eq-author/src/App/questionPage/Design/withDuplicatePage.test.js
+++ b/eq-author/src/App/questionPage/Design/withDuplicatePage.test.js
@@ -1,7 +1,6 @@
 import { mapMutateToProps, createUpdater } from "./withDuplicatePage";
 import { buildPagePath } from "utils/UrlUtils";
 import fragment from "graphql/sectionFragment.graphql";
-import fakeId from "tests/utils/fakeId";
 
 describe("withDuplicatePage", () => {
   let ownProps,
@@ -17,7 +16,7 @@ describe("withDuplicatePage", () => {
   beforeEach(() => {
     match = {
       params: {
-        questionnaireId: fakeId("1"),
+        questionnaireId: "1",
       },
     };
 
@@ -31,14 +30,14 @@ describe("withDuplicatePage", () => {
       match,
     };
 
-    sectionId = fakeId("2");
+    sectionId = "2";
     args = {
       sectionId,
-      pageId: fakeId("3"),
+      pageId: "3",
       position: 0,
     };
 
-    dupePageId = fakeId("4");
+    dupePageId = "4";
 
     result = {
       data: {
@@ -144,9 +143,9 @@ describe("withDuplicatePage", () => {
 
     it("should correctly update position values for all pages in a section", () => {
       const cacheName = `Section${sectionId}`;
-      const pageAId = fakeId("a");
-      const pageBId = fakeId("b");
-      const pageCId = fakeId("c");
+      const pageAId = "a";
+      const pageBId = "b";
+      const pageCId = "c";
       const sections = {
         [cacheName]: {
           id: args.sectionId,
@@ -172,7 +171,7 @@ describe("withDuplicatePage", () => {
         position: 2,
       });
 
-      const dupePageId = fakeId("d");
+      const dupePageId = "d";
       // order: A, C, B
       updater(proxy, {
         data: {

--- a/eq-author/src/App/questionPage/Design/withMovePage.test.js
+++ b/eq-author/src/App/questionPage/Design/withMovePage.test.js
@@ -1,6 +1,5 @@
 import { mapMutateToProps, createUpdater } from "./withMovePage";
 import { buildPagePath } from "utils/UrlUtils";
-import fakeId from "tests/utils/fakeId";
 import fragment from "graphql/fragments/movePage.graphql";
 
 describe("withMovePage", () => {
@@ -9,7 +8,7 @@ describe("withMovePage", () => {
   beforeEach(() => {
     match = {
       params: {
-        questionnaireId: fakeId("1"),
+        questionnaireId: "1",
       },
     };
 
@@ -24,13 +23,13 @@ describe("withMovePage", () => {
 
     args = {
       from: {
-        id: fakeId("1"),
-        sectionId: fakeId("1"),
+        id: "1",
+        sectionId: "1",
         position: 0,
       },
       to: {
-        id: fakeId("1"),
-        sectionId: fakeId("2"),
+        id: "1",
+        sectionId: "2",
         position: 1,
       },
     };
@@ -101,12 +100,12 @@ describe("withMovePage", () => {
 
       fromSection = {
         id: args.from.sectionId,
-        pages: [page, { id: fakeId("2"), position: 1 }],
+        pages: [page, { id: "2", position: 1 }],
       };
 
       toSection = {
         id: args.to.sectionId,
-        pages: [{ id: fakeId("3"), position: 0 }],
+        pages: [{ id: "3", position: 0 }],
       };
 
       proxy = {
@@ -143,9 +142,9 @@ describe("withMovePage", () => {
     });
 
     it("should correctly update position values for all pages in a section", () => {
-      const pageAId = fakeId("a");
-      const pageBId = fakeId("b");
-      const pageCId = fakeId("c");
+      const pageAId = "a";
+      const pageBId = "b";
+      const pageCId = "c";
       const cacheName = `Section${args.from.sectionId}`;
       const sections = {
         [cacheName]: {

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
@@ -75,9 +75,9 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
             expression={
               Object {
                 "condition": "Equal",
-                "id": "111111111111111111111111111111111111",
+                "id": "1",
                 "left": Object {
-                  "id": "222222222222222222222222222222222222",
+                  "id": "2",
                   "type": "Radio",
                 },
                 "right": null,

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.test.js
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.test.js
@@ -7,7 +7,6 @@ import {
   SELECTED_ANSWER_DELETED,
 } from "constants/routing-left-side";
 import { byTestAttr } from "tests/utils/selectors";
-import fakeId from "tests/utils/fakeId";
 
 import RoutingAnswerContentPicker from "./RoutingAnswerContentPicker";
 import { UnwrappedBinaryExpressionEditor as BinaryExpressionEditor } from "./";
@@ -26,9 +25,9 @@ describe("BinaryExpressionEditor", () => {
       updateBinaryExpression: jest.fn(),
       isOnlyExpression: false,
       expression: {
-        id: fakeId("1"),
+        id: "1",
         left: {
-          id: fakeId("2"),
+          id: "2",
           type: RADIO,
         },
         condition: "Equal",
@@ -37,9 +36,9 @@ describe("BinaryExpressionEditor", () => {
       canAddAndCondition: true,
       match: {
         params: {
-          questionnaireId: fakeId("1"),
-          sectionId: fakeId("2"),
-          pageId: fakeId("3"),
+          questionnaireId: "1",
+          sectionId: "2",
+          pageId: "3",
         },
       },
     };

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -8,12 +8,11 @@ import flushPromises from "tests/utils/flushPromises";
 import createRouterContext from "react-router-test-context";
 import PropTypes from "prop-types";
 import { byTestAttr } from "tests/utils/selectors";
-import fakeId from "tests/utils/fakeId";
 
 import GET_QUESTIONNAIRE_QUERY from "graphql/getQuestionnaire.graphql";
 
-const questionnaireId = fakeId("1");
-const sectionId = fakeId("2");
+const questionnaireId = "1";
+const sectionId = "2";
 
 const moveSectionMock = {
   request: {
@@ -48,7 +47,7 @@ const moveSectionMock = {
             pages: [
               {
                 __typename: "QuestionPage",
-                id: fakeId("3"),
+                id: "3",
                 title: "bar",
                 alias: "bar alias",
                 displayName: "bar",
@@ -56,7 +55,7 @@ const moveSectionMock = {
               },
               {
                 __typename: "QuestionPage",
-                id: fakeId("4"),
+                id: "4",
                 title: "blah",
                 alias: "blah alias",
                 displayName: "blah",
@@ -74,7 +73,7 @@ const moveSectionMock = {
           },
           {
             __typename: "Section",
-            id: fakeId("3"),
+            id: "3",
             title: "foo",
             alias: "foo-alias",
             displayName: "foo",
@@ -85,7 +84,7 @@ const moveSectionMock = {
             pages: [
               {
                 __typename: "QuestionPage",
-                id: fakeId("5"),
+                id: "5",
                 title: "bar",
                 alias: "bar alias",
                 displayName: "bar",
@@ -93,7 +92,7 @@ const moveSectionMock = {
               },
               {
                 __typename: "QuestionPage",
-                id: fakeId("6"),
+                id: "6",
                 title: "blah",
                 alias: "blah alias",
                 displayName: "blah",

--- a/eq-author/src/App/section/Design/withDeleteSection.test.js
+++ b/eq-author/src/App/section/Design/withDeleteSection.test.js
@@ -4,7 +4,6 @@ import {
   handleDeletion,
 } from "./withDeleteSection";
 import fragment from "graphql/questionnaireFragment.graphql";
-import fakeId from "tests/utils/fakeId";
 
 describe("withDeleteSection", () => {
   let history, mutate, result, ownProps, onAddSection, raiseToast;
@@ -12,22 +11,22 @@ describe("withDeleteSection", () => {
 
   beforeEach(() => {
     deletedPage = {
-      id: fakeId("2"),
-      sectionId: fakeId("2"),
+      id: "2",
+      sectionId: "2",
     };
 
     currentPage = {
-      id: fakeId("1"),
-      sectionId: fakeId("1"),
+      id: "1",
+      sectionId: "1",
     };
 
     currentSection = {
       id: currentPage.sectionId,
-      pages: [currentPage, { id: fakeId("3") }],
+      pages: [currentPage, { id: "3" }],
     };
 
     questionnaire = {
-      id: fakeId("1"),
+      id: "1",
       title: "My Questionnaire",
       sections: [
         currentSection,

--- a/eq-author/src/App/section/Design/withDuplicateSection.test.js
+++ b/eq-author/src/App/section/Design/withDuplicateSection.test.js
@@ -1,6 +1,5 @@
 import { mapMutateToProps } from "./withDuplicateSection";
 import { buildSectionPath } from "utils/UrlUtils";
-import fakeId from "tests/utils/fakeId";
 
 describe("withDuplicateSection", () => {
   let ownProps, history, match, props, mutate, args, result, dupeSectionId;
@@ -8,7 +7,7 @@ describe("withDuplicateSection", () => {
   beforeEach(() => {
     match = {
       params: {
-        questionnaireId: fakeId("1"),
+        questionnaireId: "1",
       },
     };
 
@@ -23,12 +22,12 @@ describe("withDuplicateSection", () => {
     };
 
     args = {
-      questionnaireId: fakeId("3"),
-      sectionId: fakeId("2"),
+      questionnaireId: "3",
+      sectionId: "2",
       position: 0,
     };
 
-    dupeSectionId = fakeId("4");
+    dupeSectionId = "4";
 
     result = {
       data: {

--- a/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`PreviewSectionRoute should redirect to design if section introduction is not enabled 1`] = `
 <Redirect
   push={false}
-  to="/questionnaire/111111111111111111111111111111111111/222222222222222222222222222222222222/design"
+  to="/questionnaire/1/2/design"
 />
 `;
 
@@ -31,7 +31,7 @@ exports[`PreviewSectionRoute should show the section intro preview when it is fi
   <SectionIntroPreview
     introduction={
       Object {
-        "id": "111111111111111111111111111111111111",
+        "id": "1",
         "introductionContent": "",
         "introductionTitle": "",
       }

--- a/eq-author/src/App/section/Preview/index.test.js
+++ b/eq-author/src/App/section/Preview/index.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { shallow } from "enzyme";
-import fakeId from "tests/utils/fakeId";
 
 import { UnwrappedPreviewSectionRoute as PreviewSectionRoute } from "./";
 
@@ -10,7 +9,7 @@ describe("PreviewSectionRoute", () => {
       <PreviewSectionRoute
         loading
         match={{
-          params: { questionnaireId: fakeId("1"), sectionId: fakeId("2") },
+          params: { questionnaireId: "1", sectionId: "2" },
         }}
         data={null}
       />
@@ -23,7 +22,7 @@ describe("PreviewSectionRoute", () => {
       <PreviewSectionRoute
         loading={false}
         match={{
-          params: { questionnaireId: fakeId("1"), sectionId: fakeId("2") },
+          params: { questionnaireId: "1", sectionId: "2" },
         }}
         data={null}
       />
@@ -36,15 +35,15 @@ describe("PreviewSectionRoute", () => {
       <PreviewSectionRoute
         loading={false}
         match={{
-          params: { questionnaireId: fakeId("1"), sectionId: fakeId("2") },
+          params: { questionnaireId: "1", sectionId: "2" },
         }}
         data={{
           section: {
-            id: fakeId("1"),
+            id: "1",
             alias: "",
             title: "",
             introduction: {
-              id: fakeId("1"),
+              id: "1",
               introductionTitle: "",
               introductionContent: "",
             },
@@ -60,11 +59,11 @@ describe("PreviewSectionRoute", () => {
       <PreviewSectionRoute
         loading={false}
         match={{
-          params: { questionnaireId: fakeId("1"), sectionId: fakeId("2") },
+          params: { questionnaireId: "1", sectionId: "2" },
         }}
         data={{
           section: {
-            id: fakeId("1"),
+            id: "1",
             alias: "",
             title: "",
             introduction: null,

--- a/eq-author/src/enhancers/withCreatePage.test.js
+++ b/eq-author/src/enhancers/withCreatePage.test.js
@@ -5,20 +5,19 @@ import {
 } from "./withCreatePage";
 import fragment from "graphql/sectionFragment.graphql";
 import { buildPagePath } from "utils/UrlUtils";
-import fakeId from "tests/utils/fakeId";
 
 describe("containers/QuestionnaireDesignPage/withCreatePage", () => {
   const page = {
-    id: fakeId("3"),
+    id: "3",
     title: "My Page",
   };
   const section = {
-    id: fakeId("2"),
+    id: "2",
     title: "My Section",
     pages: [page],
   };
   const questionnaire = {
-    id: fakeId("1"),
+    id: "1",
     title: "My Questionnaire",
     sections: [section],
   };
@@ -31,7 +30,7 @@ describe("containers/QuestionnaireDesignPage/withCreatePage", () => {
     };
 
     newPage = {
-      id: fakeId("8"),
+      id: "8",
       title: "New Page",
       position: 1,
       section: {
@@ -77,9 +76,9 @@ describe("containers/QuestionnaireDesignPage/withCreatePage", () => {
     });
 
     it("should update position value of all pages", () => {
-      const pageAId = fakeId("a");
-      const pageBId = fakeId("b");
-      const pageCId = fakeId("c");
+      const pageAId = "a";
+      const pageBId = "b";
+      const pageCId = "c";
 
       const cache = {
         section: {

--- a/eq-author/src/enhancers/withCreateSection.test.js
+++ b/eq-author/src/enhancers/withCreateSection.test.js
@@ -5,11 +5,10 @@ import {
 } from "./withCreateSection";
 import fragment from "graphql/questionnaireFragment.graphql";
 import { buildSectionPath } from "utils/UrlUtils";
-import fakeId from "tests/utils/fakeId";
 
 describe("withCreateSection", () => {
   const questionnaire = {
-    id: fakeId("1"),
+    id: "1",
     title: "My Questionnaire",
     sections: [],
   };
@@ -22,11 +21,11 @@ describe("withCreateSection", () => {
     };
 
     newPage = {
-      id: fakeId("5"),
+      id: "5",
     };
 
     newSection = {
-      id: fakeId("4"),
+      id: "4",
       title: "New Section",
       pages: [newPage],
     };

--- a/eq-author/src/tests/utils/fakeId.js
+++ b/eq-author/src/tests/utils/fakeId.js
@@ -1,8 +1,0 @@
-export default fill => {
-  if (fill.length > 1) {
-    throw new Error("Only expecting a single character to be fill");
-  }
-  const a = new Array(36);
-  a.fill(fill);
-  return a.join("");
-};

--- a/eq-author/src/utils/UrlUtils.js
+++ b/eq-author/src/utils/UrlUtils.js
@@ -12,13 +12,13 @@ export const generatePath = curry((path, params) => compile(path)(params));
 export const Routes = {
   HOME: "/",
   SIGN_IN: "/sign-in",
-  QUESTIONNAIRE: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})?/:pageId([a-f0-9-]{36})?/:confirmationId([a-f0-9-]{36})?/:tab?`,
-  SECTION: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/design`,
-  PAGE: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/design`,
-  PAGE_PREVIEW: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})?/preview`,
-  CONFIRMATION: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/:confirmationId([a-f0-9-]{36})/design`,
-  CONFIRMATION_PREVIEW: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/:confirmationId([a-f0-9-]{36})/preview`,
-  ROUTING: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]{36})/:pageId([a-f0-9-]{36})/routing`,
+  QUESTIONNAIRE: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)?/:pageId([a-f0-9-]+)?/:confirmationId([a-f0-9-]+)?/:tab?`,
+  SECTION: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/design`,
+  PAGE: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/design`,
+  PAGE_PREVIEW: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)?/preview`,
+  CONFIRMATION: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/:confirmationId([a-f0-9-]+)/design`,
+  CONFIRMATION_PREVIEW: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/:confirmationId([a-f0-9-]+)/preview`,
+  ROUTING: `/questionnaire/:questionnaireId/:sectionId([a-f0-9-]+)/:pageId([a-f0-9-]+)/routing`,
 };
 
 export const buildSectionPath = generatePath(Routes.SECTION);

--- a/eq-author/src/utils/UrlUtils.test.js
+++ b/eq-author/src/utils/UrlUtils.test.js
@@ -10,12 +10,10 @@ import {
   isOnSection,
 } from "utils/UrlUtils";
 
-import fakeId from "tests/utils/fakeId";
-
-const questionnaireId = fakeId("1");
-const sectionId = fakeId("2");
-const pageId = fakeId("3");
-const confirmationId = fakeId("4");
+const questionnaireId = "1";
+const sectionId = "2";
+const pageId = "3";
+const confirmationId = "4";
 
 describe("buildQuestionnairePath", () => {
   it("builds a valid path", () => {


### PR DESCRIPTION
### What is the context of this PR?
This PR is to change the current UUID regex to allow it to be backwards compatible with the old ID and URLs. This will then be changed at some point in a refactor.

### How to review 
- Check tests pass
- Check that current survey ids are accepted