### PR TITLE
Fix JSON formatting when writing to filesystem.

### DIFF
--- a/eq-author-api/utils/datastoreFileSystem.js
+++ b/eq-author-api/utils/datastoreFileSystem.js
@@ -34,7 +34,7 @@ const deleteQuestionnaire = async id => {
   );
   await fs.writeFile(
     `data/QuestionnaireList.json`,
-    stringify(reject(originalList, { id }))
+    stringify(reject(originalList, { id }), { space: 4 })
   );
 };
 


### PR DESCRIPTION
### What is the context of this PR?
When deleting a questionnaire the QuestionniareList.json is written to and formatted in one long line that is difficult to read. This is a small fix to make sure it writes the file out in a much more readable format

### How to review 
- Tests pass
- When deleting a questionnaire the QuestionnaireList.json does not revert to one long line
