### PR TITLE
Fix validation on update

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -94,7 +94,7 @@ const getValidation = ctx => id => {
       if (validation[type]) {
         validation[type].answerId = validation.answerId;
       }
-      return validation[type];
+      return { ...validation[type], validationType: type };
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
The front end wasn't being updated when the validation rule using a previous answer was being changed. It was because the validation type could not be resolved. This was causing the app to get in an odd state if you did not refresh after each change. This change adds the validation type on to the object when a validation rule is updated

### How to review 
- Tests pass
- Make sure changing validation works using a previous answer and the page updates without a refresh
