### PR TITLE
Fix travis build

### DIFF
--- a/eq-author/scripts/run_tests.sh
+++ b/eq-author/scripts/run_tests.sh
@@ -30,7 +30,7 @@ function finish {
 trap finish INT KILL TERM EXIT
 
 # Start env
-docker-compose -f "$docker_compose" up -d
+docker-compose -f "$docker_compose" up -d --no-recreate --no-build
 ./node_modules/.bin/wait-on http-get://localhost:14000/status
 ./node_modules/.bin/wait-on http-get://localhost:13000
 

--- a/eq-author/scripts/test_docker-compose.yml
+++ b/eq-author/scripts/test_docker-compose.yml
@@ -27,6 +27,7 @@ services:
   eq-author-api:
     image: "onsdigital/eq-author-api:${TAG:-latest}"
     environment:
+      DATASTORE: filesystem
       DB_CONNECTION_URI: postgres://postgres:mysecretpassword@eq-author-db:5432/postgres
     depends_on:
       - eq-author-db


### PR DESCRIPTION
### What is the context of this PR?
We had an issue where travis was timing out because of the docker-compose up command not producing any output within a specified time.

docker-compose up attempts to pull, build and start the services. At the point where the integration tests are being run on travis the containers should already have been built.
This change explicitly tells docker-compose not to attempt to re-create and build the containers and pulls only the database container.

### How to review 
Should reach integration tests and start the cypress testing on travis.
