### PR TITLE
Fix validation bug

### DIFF
--- a/eq-author-api/constants/validationTypes.js
+++ b/eq-author-api/constants/validationTypes.js
@@ -14,23 +14,6 @@ const VALIDATION_TYPES = [
   MAX_DURATION,
 ];
 
-const MIN_VALUE_INPUT = "minValueInput";
-const MAX_VALUE_INPUT = "maxValueInput";
-const EARLIEST_DATE_INPUT = "earliestDateInput";
-const LATEST_DATE_INPUT = "latestDateInput";
-const MIN_DURATION_INPUT = "minDurationInput";
-const MAX_DURATION_INPUT = "maxDurationInput";
-
-const VALIDATION_INPUT_TYPES = [
-  MIN_VALUE_INPUT,
-  MAX_VALUE_INPUT,
-  EARLIEST_DATE_INPUT,
-  LATEST_DATE_INPUT,
-  MIN_DURATION_INPUT,
-  MAX_DURATION_INPUT,
-];
-
 module.exports = {
   VALIDATION_TYPES,
-  VALIDATION_INPUT_TYPES,
 };

--- a/eq-author/src/tests/utils/flushPromises.js
+++ b/eq-author/src/tests/utils/flushPromises.js
@@ -1,3 +1,3 @@
 const flushPromises = () => new Promise(setTimeout);
 
-export default flushPromises;
+export default () => flushPromises().then(flushPromises);


### PR DESCRIPTION
### What is the context of this PR?
There was a bug found that was introduced in https://github.com/ONSdigital/eq-author-app/pull/214 where trying to toggle a validation or update it would not update the questionnaires data. This was because the function changed in that PR caused a new object to be returned instead of the reference of the entity within the questionnaire. This PR reverts this change and allows you to toggle and update the questionnaire.

### How to review 
You can update the validations on a questionnaire and tests pass.
