### PR TITLE
Fix flaky test

### DIFF
--- a/eq-author/src/tests/utils/flushPromises.js
+++ b/eq-author/src/tests/utils/flushPromises.js
@@ -1,3 +1,3 @@
 const flushPromises = () => new Promise(setTimeout);
 
-export default flushPromises;
+export default () => flushPromises().then(flushPromises);


### PR DESCRIPTION
### What is the context of this PR?
The mocked provider is sometimes returning things after the first `setTimeout`. It is following the approved pattern but it seems unreliable here. https://www.apollographql.com/docs/react/recipes/testing.html

This has affected 3 PRs on top of 797. More investigation is needed.

This was affecting:
https://github.com/ONSdigital/eq-author-app/blob/4c3e08fcafaceff69cd5fc7188a59b22c5aae84a/eq-author/src/App/section/Design/index.test.js#L230
https://github.com/ONSdigital/eq-author-app/blob/4c3e08fcafaceff69cd5fc7188a59b22c5aae84a/eq-author/src/App/section/Design/index.test.js#L253

### How to review 
1. The section design test suite should pass successfully locally 10 times in a row.
2. Rest of CI run is unaffetced.