### PR TITLE
Fixed metadata key field to only accept desired inputs

### DIFF
--- a/eq-author/src/App/MetadataModal/MetadataTable/Controls/KeySelect.test.js
+++ b/eq-author/src/App/MetadataModal/MetadataTable/Controls/KeySelect.test.js
@@ -1,13 +1,22 @@
 import React from "react";
-import { shallow } from "enzyme";
-import Downshift from "downshift";
+import { shallow, mount } from "enzyme";
 
 import KeySelect, { removeUsedKeys } from "./KeySelect";
+import Typeahead from "components/Forms/Typeahead";
 
-const render = (props = {}) => shallow(<KeySelect {...props} />);
+const render = (props = {}) => mount(<KeySelect {...props} />);
 
 describe("KeySelect", () => {
   let props, wrapper;
+  const callStateChange = changes =>
+    wrapper.find(Typeahead).prop("onStateChange")(changes);
+
+  const simulateInputBlur = () =>
+    wrapper
+      .find("[data-test='key-input']")
+      .last()
+      .simulate("blur");
+
   beforeEach(() => {
     props = {
       name: "test",
@@ -20,90 +29,74 @@ describe("KeySelect", () => {
   });
 
   it("should render", () => {
-    expect(wrapper).toMatchSnapshot();
+    expect(shallow(<KeySelect {...props} />)).toMatchSnapshot();
   });
 
   it("correctly handles custom input changes", () => {
     const input = "custom_value";
-    wrapper.simulate("stateChange", { inputValue: input });
 
+    callStateChange({ inputValue: input });
     expect(wrapper.state("value")).toEqual(input);
-    expect(props.onChange).toHaveBeenCalledWith({
-      name: props.name,
-      value: input,
-    });
+
+    simulateInputBlur();
+    expect(props.onChange).toHaveBeenCalledWith(
+      {
+        name: props.name,
+        value: input,
+      },
+      expect.any(Function)
+    );
   });
 
   it("correctly handles selection from list", () => {
     const input = "tx_id";
-    wrapper.simulate("stateChange", { selectedItem: { value: input } });
 
-    expect(wrapper.state("value")).toEqual(input);
-    expect(props.onChange).toHaveBeenCalledWith({
-      name: props.name,
-      value: input,
+    callStateChange({
+      inputValue: input,
+      selectedItem: { value: input },
     });
+    expect(wrapper.state("value")).toEqual(input);
+
+    simulateInputBlur();
+    expect(props.onChange).toHaveBeenCalledWith(
+      {
+        name: props.name,
+        value: input,
+      },
+      expect.any(Function)
+    );
   });
 
   it("allows empty string as input", () => {
     const input = "";
-    wrapper.simulate("stateChange", { inputValue: input });
+    callStateChange({ inputValue: input });
 
     expect(wrapper.state("value")).toEqual(input);
-    expect(props.onChange).toHaveBeenCalledWith({
-      name: props.name,
-      value: input,
-    });
+
+    simulateInputBlur();
+    expect(props.onChange).toHaveBeenCalledWith(
+      {
+        name: props.name,
+        value: input,
+      },
+      expect.any(Function)
+    );
   });
 
-  it("correctly calls onUpdate when input blurred", () => {
-    const instance = wrapper.instance();
-    instance.stateReducer(
-      {},
+  it("cannot enter undesired input", () => {
+    const input = "Test Value";
+
+    callStateChange({ inputValue: input });
+    expect(wrapper.state("value")).toEqual("");
+
+    simulateInputBlur();
+    expect(props.onChange).toHaveBeenCalledWith(
       {
-        type: Downshift.stateChangeTypes.blurInput,
-      }
+        name: props.name,
+        value: "",
+      },
+      expect.any(Function)
     );
-    expect(props.onUpdate).toHaveBeenCalled();
-  });
-
-  it("correctly calls onUpdate when clicking outside of input", () => {
-    const instance = wrapper.instance();
-    instance.stateReducer(
-      {},
-      {
-        type: Downshift.stateChangeTypes.mouseUp,
-      }
-    );
-
-    expect(props.onUpdate).toHaveBeenCalled();
-  });
-
-  it("correctly calls onChange when hitting enter", () => {
-    const instance = wrapper.instance();
-    instance.stateReducer(
-      {},
-      {
-        type: Downshift.stateChangeTypes.keyDownEnter,
-      }
-    );
-
-    expect(props.onChange).toHaveBeenCalled();
-  });
-
-  it("correctly calls onChange when item selected", () => {
-    const instance = wrapper.instance();
-    const selectedItem = "tx_id";
-
-    instance.stateReducer(
-      {},
-      {
-        type: Downshift.stateChangeTypes.clickItem,
-        selectedItem: { value: selectedItem },
-      }
-    );
-
-    expect(props.onChange).toHaveBeenCalled();
   });
 
   it("correctly removes used keys", () => {

--- a/eq-author/src/App/MetadataModal/MetadataTable/Controls/__snapshots__/KeySelect.test.js.snap
+++ b/eq-author/src/App/MetadataModal/MetadataTable/Controls/__snapshots__/KeySelect.test.js.snap
@@ -8,7 +8,6 @@ exports[`KeySelect should render 1`] = `
       "value": "",
     }
   }
-  stateReducer={[Function]}
 >
   <Component />
 </Typeahead>


### PR DESCRIPTION
### What is the context of this PR?
Set up the key select field on the metadata modal on only accept input that matches ^[a-zA-Z0-9-_]+$.

### How to review 
Tests pass and yo can't enter spaces or punctuation into the key select for metadata.

fixes https://github.com/ONSdigital/eq-author-app/issues/208