### PR TITLE
Cursor no longer jumps to end of input on input

### DIFF
--- a/eq-author/src/App/MetadataModal/MetadataTable/Controls/KeySelect.js
+++ b/eq-author/src/App/MetadataModal/MetadataTable/Controls/KeySelect.js
@@ -83,7 +83,6 @@ class KeySelect extends Component {
         stateReducer={this.stateReducer}
         onStateChange={this.handleStateChange}
         selectedItem={{ value }}
-        inputValue={value}
       >
         {({ getInputProps, isOpen, openMenu, ...otherProps }) => (
           <div>

--- a/eq-author/src/App/MetadataModal/MetadataTable/Controls/__snapshots__/KeySelect.test.js.snap
+++ b/eq-author/src/App/MetadataModal/MetadataTable/Controls/__snapshots__/KeySelect.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`KeySelect should render 1`] = `
 <Typeahead
-  inputValue=""
   onStateChange={[Function]}
   selectedItem={
     Object {


### PR DESCRIPTION
### What is the context of this PR?
As shown in the below issue, when editing a key field on metadata the cursor would jump to the end of the input whenever the input was changed.

### How to review 
Tests continue to pass and the bug has been observed to be fixed.

fixes https://github.com/ONSdigital/eq-author-app/issues/209