### PR TITLE
Fix CI pushing docker images with incorrect tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ cache:
 
 before_script:
   - set -e
-  - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
+  - export TAG=`if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
   - export TAG=${TAG//\//-}
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+  - echo "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
+  - echo "TAG=$TAG"
 
 script:
   - pushd eq-author; ./scripts/ci.sh; popd;


### PR DESCRIPTION
### What is the context of this PR?
We noticed that the 797 branch pushed its container image to docker hub with the `latest` tag. This is incorrect and could lead to some undesirable behaviour when trying to run Author using docker.

The branch should push up an image tagged with the branch name.

### How to review 
Observe in the travis logs that the branch name and tag are outputted in the console.
If the branch is master then the tag should be "latest".
When the branch is some other branch then the tag should reflect the branch name.
