### PR TITLE
Fix bug where empty tag set if not on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ cache:
 
 before_script:
   - set -e
-  - export TAG=`if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
+  - if [ "$TRAVIS_BRANCH" == "latest" ]; then echo "Building branches named latest not allowed as it would overwrite the stable docker image. Please rename your branch." && exit 1; fi;
+  - export TAG=`if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" != "master" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
   - export TAG=${TAG//\//-}
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - echo "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"


### PR DESCRIPTION
### What is the context of this PR?
There was a bug in the existing logic where the tag used when pushing up docker images would be empty if a branch other than master was built. This was observed in a [recent build of the 797 feature branch on Travis](https://travis-ci.com/ONSdigital/eq-author-app/builds/102790810#L476).

This change sets the tag to be the branch name if the branch being built is not master and it is not a pull request.

### How to review 
Change should look sensible. When master is built, tag should be "latest".
On this PR the tag should be "980-fix-pushing-docker-images-with-incorrect-tag"
When merged into 797 the tag should be "797-replace-relational-database-with-json-document"
