### PR TITLE
Fix routing error

### DIFF
--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/__snapshots__/index.test.js.snap
@@ -71,6 +71,7 @@ exports[`RuleEditor should render 1`] = `
       onChange={[Function]}
       value={
         Object {
+          "id": "1",
           "logical": null,
           "page": Object {
             "displayName": "Page",

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/fragment.graphql
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/fragment.graphql
@@ -3,6 +3,7 @@
 fragment RuleEditor on RoutingRule2 {
   id
   destination {
+    id
     logical
     page {
       id

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/index.test.js
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/index.test.js
@@ -28,6 +28,7 @@ describe("RuleEditor", () => {
           ],
         },
         destination: {
+          id: "1",
           page: {
             id: "pageId",
             displayName: "Page",

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/fragment.graphql
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/fragment.graphql
@@ -6,6 +6,7 @@ fragment RoutingEditor on Routing2 {
     ...RuleEditor
   }
   else {
+    id
     logical
     page {
       id


### PR DESCRIPTION
### What is the context of this PR?
There is an error in pre-prod that is unable to load a routing rule if it has been changed, navigated to a different tab and back again. We found that it wasn't returning the destination ID so this PR fixes that.

### How to review 
- Tests pass
- Can change a routing rule else destination, navigate to the design tab and back again and the routing rule is loaded correctly
