### PR TITLE
Bug - Unable to update other options

### DIFF
--- a/eq-author/src/App/questionPage/Design/answers/withUpdateOption.js
+++ b/eq-author/src/App/questionPage/Design/answers/withUpdateOption.js
@@ -1,10 +1,31 @@
 import updateOptionMutation from "graphql/updateOption.graphql";
 import { graphql } from "react-apollo";
+import { filter } from "graphql-anywhere";
+import gql from "graphql-tag";
+
+const updateOptionInput = gql`
+  {
+    id
+    label
+    description
+    value
+    qCode
+    additionalAnswer {
+      id
+      description
+      guidance
+      label
+      secondaryLabel
+      qCode
+      properties
+    }
+  }
+`;
 
 export const mapMutateToProps = ({ mutate }) => ({
   onUpdateOption: option =>
     mutate({
-      variables: { input: option },
+      variables: { input: filter(updateOptionInput, option) },
     }),
 });
 

--- a/eq-author/src/App/questionPage/Design/answers/withUpdateOption.test.js
+++ b/eq-author/src/App/questionPage/Design/answers/withUpdateOption.test.js
@@ -9,7 +9,11 @@ describe("enhancers > withUpdateOption", () => {
     beforeEach(() => {
       mutate = jest.fn();
       props = mapMutateToProps({ mutate });
-      option = jest.fn();
+      option = {
+        id: "1",
+        foo: "bar",
+        additionalAnswer: { id: "2", bar: "baz" },
+      };
     });
 
     it("should have an onUpdateOption prop", () => {
@@ -19,7 +23,7 @@ describe("enhancers > withUpdateOption", () => {
     it("should call mutate", () => {
       props.onUpdateOption(option);
       expect(mutate).toHaveBeenCalledWith({
-        variables: { input: option },
+        variables: { input: { id: "1", additionalAnswer: { id: "2" } } },
       });
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
Fix issue where not able to update other answer labels or description as it tried to send the answer type of the additional answer which is no longer allowed.

### Recreation steps
1. Create a questionnaire
2. Add a checkbox answer
3. Add an "other" option
4. Change the other label or description
5. Blur the field - the red bar should show. And the change is not persisted (you can check with a refresh)

### How to review 
1. That this PR resolves the issue.
