### PR TITLE
WIP - Blow up cypress when graphql errors

### DIFF
--- a/eq-author/src/apollo/createApolloErrorLink.js
+++ b/eq-author/src/apollo/createApolloErrorLink.js
@@ -2,8 +2,11 @@ import { onError } from "apollo-link-error";
 import { apiDownError } from "redux/saving/actions";
 
 export default getStore =>
-  onError(({ networkError }) => {
-    if (networkError) {
+  onError(({ networkError, graphQLErrors }) => {
+    if (networkError || graphQLErrors) {
       getStore().dispatch(apiDownError());
+      const error =
+        networkError || graphQLErrors.map(e => e.message).join("\n");
+      throw new Error(`Graphql Error detected: ${error}`);
     }
   });

--- a/eq-author/src/components/withEntityEditor/index.js
+++ b/eq-author/src/components/withEntityEditor/index.js
@@ -56,7 +56,7 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
     }
 
     handleChange = ({ name, value }, cb) => {
-      if (fp.get(name, value, this.entity) === value) {
+      if (fp.get(name, this.entity) === value) {
         return;
       }
 

--- a/eq-author/src/components/withEntityEditor/index.test.js
+++ b/eq-author/src/components/withEntityEditor/index.test.js
@@ -309,4 +309,11 @@ describe("withEntityEditor", () => {
       instance.handleChange({ name: "title", value: "New title" });
     }).not.toThrow();
   });
+
+  it("should not call update if the change contained no change", () => {
+    wrapper.simulate("change", { name: "alias", value: entity.alias });
+    wrapper.simulate("update");
+
+    expect(handleUpdate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
This change is to throw an error when a network or server error occurs. This in turn causes cypress to blow up.

This is to catch errors that have been occurring in cypress but not causing our tests to fail.

### How to review 
Don't yet but help to fix all the failing tests would be appreciated.
