### PR TITLE
Stop sending empty updates

### DIFF
--- a/eq-author/src/components/withEntityEditor/index.js
+++ b/eq-author/src/components/withEntityEditor/index.js
@@ -56,7 +56,7 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
     }
 
     handleChange = ({ name, value }, cb) => {
-      if (fp.get(name, value, this.entity) === value) {
+      if (fp.get(name, this.entity) === value) {
         return;
       }
 

--- a/eq-author/src/components/withEntityEditor/index.test.js
+++ b/eq-author/src/components/withEntityEditor/index.test.js
@@ -309,4 +309,11 @@ describe("withEntityEditor", () => {
       instance.handleChange({ name: "title", value: "New title" });
     }).not.toThrow();
   });
+
+  it("should not call update if the change contained no change", () => {
+    wrapper.simulate("change", { name: "alias", value: entity.alias });
+    wrapper.simulate("update");
+
+    expect(handleUpdate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
This fixes an issue where we would send updates unnecessarily because of a bug in wEE. 

### How to review 
1. Create a page
1. Set the title to some value
1. Blur the field
1. Focus and blur the field
1. A second update should not be sent. With this PR it isn't

