### PR TITLE
Add Hotjar

### DIFF
--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -25,42 +25,55 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Author</title>
-  </head>
-  <script type="text/javascript">
-    window.config = {};
-    window.config.REACT_APP_API_URL="";
-    window.config.REACT_APP_FIREBASE_API_KEY="";
-    window.config.REACT_APP_FIREBASE_PROJECT_ID="";
-    window.config.REACT_APP_FUNCTIONAL_TEST="";
-    window.config.REACT_APP_LAUNCH_URL="";
-    window.config.REACT_APP_FULLSTORY_ORG="";
-    window.config.REACT_APP_SENTRY_DSN="";
-    window.config.REACT_APP_AUTH_TYPE="";
-  </script>
-  <script type="text/javascript">
-    if (window.config.REACT_APP_FULLSTORY_ORG) {
-      window['_fs_debug'] = false;
-      window['_fs_host'] = 'fullstory.com';
-      window['_fs_org'] = window.config.REACT_APP_FULLSTORY_ORG;
-      window['_fs_namespace'] = 'FS';
-      (function (m, n, e, t, l, o, g, y) {
-        if (e in m) { if (m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); } return; }
-        g = m[e] = function (a, b) { g.q ? g.q.push([a, b]) : g._api(a, b); }; g.q = [];
-        o = n.createElement(t); o.async = 1; o.src = 'https://' + _fs_host + '/s/fs.js';
-        y = n.getElementsByTagName(t)[0]; y.parentNode.insertBefore(o, y);
-        g.identify = function (i, v) { g(l, { uid: i }); if (v) g(l, v) }; g.setUserVars = function (v) { g(l, v) };
-        g.identifyAccount = function (i, v) { o = 'account'; v = v || {}; v.acctId = i; g(o, v) };
-        g.clearUserCookie = function (c, d, i) {
-          if (!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')) {
-            d = n.domain; while (1) {
-            n.cookie = 'fs_uid=;domain=' + d +
-              ';path=/;expires=' + new Date(0).toUTCString(); i = d.indexOf('.'); if (i < 0) break; d = d.slice(i + 1)
+    <script type="text/javascript">
+      window.config = {};
+      window.config.REACT_APP_API_URL="";
+      window.config.REACT_APP_FIREBASE_API_KEY="";
+      window.config.REACT_APP_FIREBASE_PROJECT_ID="";
+      window.config.REACT_APP_FUNCTIONAL_TEST="";
+      window.config.REACT_APP_LAUNCH_URL="";
+      window.config.REACT_APP_FULLSTORY_ORG="";
+      window.config.REACT_APP_SENTRY_DSN="";
+      window.config.REACT_APP_AUTH_TYPE="";
+      window.config.REACT_APP_HOT_JAR_ID="";
+    </script>
+    <script type="text/javascript">
+      if (window.config.REACT_APP_HOT_JAR_ID) {
+        (function(h,o,t,j,a,r){
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:window.config.REACT_APP_HOT_JAR_ID,hjsv:6};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      }
+    </script>
+    <script type="text/javascript">
+      if (window.config.REACT_APP_FULLSTORY_ORG) {
+        window['_fs_debug'] = false;
+        window['_fs_host'] = 'fullstory.com';
+        window['_fs_org'] = window.config.REACT_APP_FULLSTORY_ORG;
+        window['_fs_namespace'] = 'FS';
+        (function (m, n, e, t, l, o, g, y) {
+          if (e in m) { if (m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); } return; }
+          g = m[e] = function (a, b) { g.q ? g.q.push([a, b]) : g._api(a, b); }; g.q = [];
+          o = n.createElement(t); o.async = 1; o.src = 'https://' + _fs_host + '/s/fs.js';
+          y = n.getElementsByTagName(t)[0]; y.parentNode.insertBefore(o, y);
+          g.identify = function (i, v) { g(l, { uid: i }); if (v) g(l, v) }; g.setUserVars = function (v) { g(l, v) };
+          g.identifyAccount = function (i, v) { o = 'account'; v = v || {}; v.acctId = i; g(o, v) };
+          g.clearUserCookie = function (c, d, i) {
+            if (!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')) {
+              d = n.domain; while (1) {
+              n.cookie = 'fs_uid=;domain=' + d +
+                ';path=/;expires=' + new Date(0).toUTCString(); i = d.indexOf('.'); if (i < 0) break; d = d.slice(i + 1)
+              }
             }
-          }
-        };
-      })(window, document, window['_fs_namespace'], 'script', 'user');
-    }
-  </script>
+          };
+        })(window, document, window['_fs_namespace'], 'script', 'user');
+      }
+    </script>
+  </head>
   <body>
     <div id="root"></div>
     <div id="toast"></div>

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -20,6 +20,8 @@ const config = {
     window.config.REACT_APP_SENTRY_DSN || process.env.REACT_APP_SENTRY_DSN,
   REACT_APP_AUTH_TYPE:
     window.config.REACT_APP_AUTH_TYPE || process.env.REACT_APP_AUTH_TYPE,
+  REACT_APP_HOT_JAR_ID:
+    window.config.REACT_APP_HOT_JAR_ID || process.env.REACT_APP_HOT_JAR_ID,
 };
 
 export default config;


### PR DESCRIPTION
### What is the context of this PR?
Adds hotjar tracking script which is enabled when a hot jar environment variable is provided as part of the docker launch.

This also tidies up the `script` tags that were sitting between the `head` and the `body` tags and being interpreted as being in the head by Chrome. So they now all correctly sit in the `head`.

### How to review 
1. Ensure that the tracking code is as per hotjar documentation. (see me for account details)
1. Ensure the hotjar script runs when the hot jar id is provided as `REACT_APP_HOT_JAR_ID`. The easiest way to see this is in `author` to run `yarn build && docker build .`. Then you can run the container: `docker run -p 3003:3000 -e REACT_APP_HOT_JAR_ID=123 [[container id from docker build]]`. If you now hit http://localhost:3003 it should make calls to request hotjar sources.
