### PR TITLE
Use JSON schema for validation

### DIFF
--- a/eq-author-api/middleware/validateQuestionnaire.js
+++ b/eq-author-api/middleware/validateQuestionnaire.js
@@ -9,7 +9,6 @@ module.exports = logger => (req, res, next) => {
   const before = performance.now();
   req.validationErrors = validateQuestionnaire(req.questionnaire);
   const after = performance.now();
-  console.log(JSON.stringify(req.validationErrors, null, 2));
   logger.info("Validation took %dms", after - before);
 
   return next();

--- a/eq-author-api/middleware/validateQuestionnaire.js
+++ b/eq-author-api/middleware/validateQuestionnaire.js
@@ -9,6 +9,7 @@ module.exports = logger => (req, res, next) => {
   const before = performance.now();
   req.validationErrors = validateQuestionnaire(req.questionnaire);
   const after = performance.now();
+  console.log(JSON.stringify(req.validationErrors));
   logger.info("Validation took %dms", after - before);
 
   return next();

--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -12,6 +12,7 @@
     "dynamodb-admin": "AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy DYNAMO_ENDPOINT=http://localhost:8050 dynamodb-admin"
   },
   "dependencies": {
+    "ajv": "^6.10.0",
     "apollo-server-express": "latest",
     "cheerio": "latest",
     "cors": "latest",

--- a/eq-author-api/src/validation/customKeywords/index.js
+++ b/eq-author-api/src/validation/customKeywords/index.js
@@ -1,0 +1,8 @@
+const previousAnswer = require("./previousAnswer");
+
+module.exports = ajv => {
+  return [previousAnswer].reduce(
+    (ajv, keyword) => ajv.addKeyword(keyword.keyword, keyword),
+    ajv
+  );
+};

--- a/eq-author-api/src/validation/customKeywords/previousAnswer.js
+++ b/eq-author-api/src/validation/customKeywords/previousAnswer.js
@@ -1,0 +1,62 @@
+const getPreviousAnswers = (
+  sectionIndex,
+  pageIndex,
+  answerIndex,
+  questionnaire
+) => {
+  // Everything in all previous sections
+  const prevSections = questionnaire.sections.slice(0, sectionIndex);
+  const prevPages = prevSections.reduce((p, s) => [...p, ...s.pages], []);
+  const prevAnswers = prevPages.reduce((a, p) => [...a, ...p.answers], []);
+
+  const selectedSection = questionnaire.sections[sectionIndex];
+
+  // Answers in previous pages in section
+  const prevSectionPages = selectedSection.pages.slice(0, pageIndex);
+  const prevSectionPagesAnswers = prevSectionPages.reduce(
+    (a, p) => [...a, ...p.answers],
+    []
+  );
+
+  const selectedPage = selectedSection.pages[pageIndex];
+  // Previous answers on page
+  const prevAnswersOnPage = selectedPage.answers.slice(0, answerIndex);
+
+  return [...prevAnswers, ...prevSectionPagesAnswers, ...prevAnswersOnPage];
+};
+
+const getIndex = text => {
+  const indexStr = /^\w+\[(\d+)\]$/.exec(text)[1];
+  if (!indexStr) {
+    return undefined;
+  }
+  return parseInt(indexStr, 10);
+};
+
+module.exports = {
+  keyword: "previous",
+  type: "string",
+  validate: (
+    argument,
+    previousAnswerId,
+    closeSchema,
+    path,
+    entity,
+    fieldName,
+    questionnaire
+  ) => {
+    const [, sectionPath, pagePath, answerPath] = path.split(".");
+    const sectionIndex = getIndex(sectionPath);
+    const pageIndex = getIndex(pagePath);
+    const answerIndex = getIndex(answerPath);
+
+    const previousAnswers = getPreviousAnswers(
+      sectionIndex,
+      pageIndex,
+      answerIndex,
+      questionnaire
+    );
+    const prevAnswer = previousAnswers.find(a => a.id === previousAnswerId);
+    return Boolean(prevAnswer);
+  },
+};

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -1,69 +1,8 @@
 const Ajv = require("ajv");
 const schemas = require("./schemas");
+const customKeywords = require("./customKeywords");
 
-const ajv = new Ajv();
-
-const getPreviousAnswers = (
-  sectionIndex,
-  pageIndex,
-  answerIndex,
-  questionnaire
-) => {
-  // Everything in all previous sections
-  const prevSections = questionnaire.sections.slice(0, sectionIndex);
-  const prevPages = prevSections.reduce((p, s) => [...p, ...s.pages], []);
-  const prevAnswers = prevPages.reduce((a, p) => [...a, ...p.answers], []);
-
-  const selectedSection = questionnaire.sections[sectionIndex];
-
-  // Answers in previous pages in section
-  const prevSectionPages = selectedSection.pages.slice(0, pageIndex);
-  const prevSectionPagesAnswers = prevSectionPages.reduce(
-    (a, p) => [...a, ...p.answers],
-    []
-  );
-
-  const selectedPage = selectedSection.pages[pageIndex];
-  // Previous answers on page
-  const prevAnswersOnPage = selectedPage.answers.slice(0, answerIndex);
-
-  return [...prevAnswers, ...prevSectionPagesAnswers, ...prevAnswersOnPage];
-};
-
-const getIndex = text => {
-  const indexStr = /^\w+\[(\d+)\]$/.exec(text)[1];
-  if (!indexStr) {
-    return undefined;
-  }
-  return parseInt(indexStr, 10);
-};
-
-ajv.addKeyword("previous", {
-  type: "string",
-  validate: (
-    argument,
-    previousAnswerId,
-    closeSchema,
-    path,
-    entity,
-    fieldName,
-    questionnaire
-  ) => {
-    const [, sectionPath, pagePath, answerPath] = path.split(".");
-    const sectionIndex = getIndex(sectionPath);
-    const pageIndex = getIndex(pagePath);
-    const answerIndex = getIndex(answerPath);
-
-    const previousAnswers = getPreviousAnswers(
-      sectionIndex,
-      pageIndex,
-      answerIndex,
-      questionnaire
-    );
-    const prevAnswer = previousAnswers.find(a => a.id === previousAnswerId);
-    return Boolean(prevAnswer);
-  },
-});
+const ajv = customKeywords(new Ajv({ allErrors: true }));
 
 const validate = ajv.addSchema(schemas.slice(1)).compile(schemas[0]);
 

--- a/eq-author-api/src/validation/schemas/definitions.json
+++ b/eq-author-api/src/validation/schemas/definitions.json
@@ -1,0 +1,12 @@
+{
+  "$id": "http://example.com/schemas/definitions.json",
+  "definitions": {
+    "populatedString": {
+      "type": "string",
+      "pattern": "\\w+",
+      "message": {
+        "pattern": "Must be populated"
+      }
+    }
+  }
+}

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -1,0 +1,62 @@
+{
+  "$id": "http://example.com/schemas/entities.json",
+  "definitions": {
+    "answer": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "label": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "object",
+          "required": ["minValue"],
+          "properties": {
+            "minValue": {
+              "type": "object",
+              "properties": {
+                "previousAnswer": {
+                  "type": "string",
+                  "previous": "answer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["id", "label", "validation"]
+    },
+    "page": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": {
+          "$ref": "definitions.json#/definitions/populatedString"
+        },
+        "answers": {
+          "type": "array",
+          "items": {
+            "$ref": "entities.json#/definitions/answer"
+          }
+        } 
+      },
+      "required": ["id", "title", "answers"]
+    },
+    "section": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": {
+          "type": "string"
+        },
+        "pages": {
+          "type": "array",
+          "items": {
+            "$ref": "entities.json#/definitions/page"
+          }
+        } 
+      },
+      "required": ["id", "title", "pages"]
+    }
+  }
+}

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -9,22 +9,67 @@
           "type": "string"
         },
         "validation": {
-          "type": "object",
-          "required": ["minValue"],
+          "type": ["object", "null"],
           "properties": {
             "minValue": {
               "type": "object",
               "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "entityType": {
+                  "enum": [
+                    "Custom",
+                    "PreviousAnswer",
+                    "Metadata",
+                    "Now"
+                  ]
+                },
                 "previousAnswer": {
-                  "type": "string",
-                  "previous": "answer"
+                  "type": ["string", "null"]
+                },
+                "custom": {
+                  "type": ["number", "null"]
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "enabled": { "const": true },
+                      "entityType": { "enum": ["Custom"] }
+                    }
+                  },
+                  "then": {
+                    "properties": {
+                      "custom": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "enabled": { "const": true },
+                      "entityType": { "enum": ["PreviousAnswer"] }
+                    }
+                  },
+                  "then": {
+                    "properties": {
+                      "previousAnswer": {
+                        "type": "string",
+                        "previous": "answer"
+                      }
+                    }
+                  }
+                }
+              ]
             }
           }
         }
       },
-      "required": ["id", "label", "validation"]
+      "required": ["id", "label"]
     },
     "page": {
       "type": "object",

--- a/eq-author-api/src/validation/schemas/index.js
+++ b/eq-author-api/src/validation/schemas/index.js
@@ -1,0 +1,5 @@
+const schema = require("./schema.json");
+const entities = require("./entities.json");
+const definitions = require("./definitions.json");
+
+module.exports = [schema, entities, definitions];

--- a/eq-author-api/src/validation/schemas/schema.json
+++ b/eq-author-api/src/validation/schemas/schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "http://example.com/schemas/schema.json",
+  "type": "object",
+  "properties": {
+    "sections": {
+      "type": "array",
+      "items": {
+        "$ref": "entities.json#/definitions/section"
+      }
+    }
+  }
+}

--- a/eq-author-api/yarn.lock
+++ b/eq-author-api/yarn.lock
@@ -334,6 +334,16 @@ acorn@^6.0.1, acorn@^6.0.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.6.tgz#cd75181670d5b99bdb1b1c993941d3a239ab1f56"
   integrity sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==
 
+ajv@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^6.5.3, ajv@^6.6.1:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96"


### PR DESCRIPTION
### What is the context of this PR?
This implements validation using json schema instead. This uses [ajv](https://ajv.js.org/) which supports the latest json schema version (draft 07)

Time for validation is still quick (<1ms for most requests and <3ms for all requests) even on QPSES and ASHE.

### How to review 
1. Compare the differences between our implementation and json schema. To see which you feel will be easier to manage as it grows.

### To Do
- [ ] -  Transform the result so we can easily read it in resolvers.
