### PR TITLE
Ignore timestamps in patches

### DIFF
--- a/eq-author-api/app.js
+++ b/eq-author-api/app.js
@@ -11,8 +11,6 @@ const createAuthMiddleware = require("./middleware/auth");
 const loadQuestionnaire = require("./middleware/loadQuestionnaire");
 const runQuestionnaireMigrations = require("./middleware/runQuestionnaireMigrations");
 const schema = require("./schema");
-const migrations = require("./migrations");
-
 const noir = require("pino-noir");
 
 const { PORT = 4000 } = process.env;
@@ -48,7 +46,7 @@ app.use(
   cors(),
   createAuthMiddleware(logger),
   loadQuestionnaire,
-  runQuestionnaireMigrations(logger)(migrations)
+  runQuestionnaireMigrations(logger)(require("./migrations"))
 );
 
 const server = new ApolloServer({

--- a/eq-author-api/migrations/addVersion.js
+++ b/eq-author-api/migrations/addVersion.js
@@ -1,6 +1,6 @@
 //This is an auto-generated file.  Do NOT modify the method signature.
 
-module.exports = questionnaire => {
+module.exports = function addVersion(questionnaire) {
   questionnaire.version = 1;
   return questionnaire;
 };

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -1,3 +1,10 @@
 const addVersion = require("./addVersion");
 
-module.exports = [addVersion];
+const migrations = [addVersion];
+
+const currentVersion = migrations.length;
+
+module.exports = {
+  migrations,
+  currentVersion,
+};

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -29,6 +29,7 @@ const {
 } = require("../../src/businessLogic/createValidation");
 const uuid = require("uuid");
 const deepMap = require("deep-map");
+const { currentVersion } = require("../../migrations");
 
 const createAnswer = require("../../src/businessLogic/createAnswer");
 const onAnswerCreated = require("../../src/businessLogic/onAnswerCreated");
@@ -160,6 +161,7 @@ const createNewQuestionnaire = input => ({
   metadata: [],
   sections: [createSection()],
   summary: false,
+  version: currentVersion,
   ...input,
 });
 

--- a/eq-author-api/scripts/createMigration.js
+++ b/eq-author-api/scripts/createMigration.js
@@ -1,5 +1,6 @@
 const fs = require("fs").promises;
 const chalk = require("chalk");
+const { camelCase } = require("lodash");
 
 if (process.argv.length < 3) {
   /* eslint-disable-next-line no-console */
@@ -11,12 +12,29 @@ if (process.argv.length < 3) {
   process.exit(1);
 }
 
-const name = process.argv[2];
+const name = camelCase(process.argv[2]);
 const filename = `${name}.js`;
+const template = `//This is an auto-generated file.  Do NOT modify the method signature.
 
-fs.readFile("scripts/migration.template.js").then(data => {
-  fs.writeFile(`migrations/${filename}`, data);
+module.exports = function ${name}(questionnaire) {
+  /**
+    [Insert migration here]
+   **/
+  return questionnaire;
+};
+`;
+
+const testTemplate = `const ${name} = require("./${filename}");
+
+describe("${name}", () => {
+  it.todo("should...");
 });
+
+`;
+
+fs.writeFile(`migrations/${filename}`, template);
+
+fs.writeFile(`migrations/${name}.test.js`, testTemplate);
 
 /* eslint-disable-next-line no-console */
 console.info(

--- a/eq-author-api/scripts/migration.template.js
+++ b/eq-author-api/scripts/migration.template.js
@@ -1,8 +1,0 @@
-//This is an auto-generated file.  Do NOT modify the method signature.
-
-module.exports = questionnaire => {
-  /**
-    [Insert migration here]
-   **/
-  return questionnaire;
-};

--- a/eq-author/cypress/support/commands.js
+++ b/eq-author/cypress/support/commands.js
@@ -69,6 +69,8 @@ Cypress.Commands.add("deleteQuestionnaire", title => {
     cy.contains(new RegExp(`^${title}`))
       .closest("tr")
       .within(() => {
+        cy.get(testId("btn-delete-questionnaire")).should("be.visible");
+        cy.get(testId("btn-delete-questionnaire")).should("be.enabled");
         cy.get(testId("btn-delete-questionnaire")).click();
       });
   });


### PR DESCRIPTION
### What is the context of this PR?
Improvements to https://github.com/ONSdigital/eq-author-app/pull/252:
 - Reduces number of database requests by ignoring timestamps in patches
 - Sets current version when creating a new questionnaire 

### How to review 
- Ensure tests pass
- Ensure version is updated as expected