### PR TITLE
Fix issue where unable to add page at correct position

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -323,11 +323,18 @@ const Resolvers = {
       return remappedPage;
     },
 
-    createQuestionPage: async (root, { input }, ctx) => {
-      const section = find(ctx.questionnaire.sections, { id: input.sectionId });
-      const page = createPage(input);
-
-      section.pages.push(page);
+    createQuestionPage: async (
+      root,
+      { input: { position, ...pageInput } },
+      ctx
+    ) => {
+      const section = find(ctx.questionnaire.sections, {
+        id: pageInput.sectionId,
+      });
+      const page = createPage(pageInput);
+      const insertionPosition =
+        typeof position === "number" ? position : section.pages.length;
+      section.pages.splice(insertionPosition, 0, page);
       await saveQuestionnaire(ctx.questionnaire);
       return page;
     },

--- a/eq-author-api/schema/tests/page.test.js
+++ b/eq-author-api/schema/tests/page.test.js
@@ -50,6 +50,32 @@ describe("page", () => {
         position: 0,
       });
     });
+
+    it("should create at a given position", async () => {
+      questionnaire = await buildQuestionnaire({
+        sections: [
+          {
+            pages: [{}],
+          },
+        ],
+      });
+      const section = questionnaire.sections[0];
+
+      const createdPage = await createQuestionPage(questionnaire, {
+        title: "Title",
+        description: "Description",
+        sectionId: section.id,
+        position: 0,
+      });
+
+      const readPage = await queryQuestionPage(questionnaire, createdPage.id);
+
+      expect(readPage).toMatchObject({
+        title: "Title",
+        description: "Description",
+        position: 0,
+      });
+    });
   });
 
   describe("mutate", () => {


### PR DESCRIPTION
### What is the context of this PR?
The position provided should be used to determine where to add the page
it was being ignored and persisted to the question page incorrectly.

This change uses it to insert the page at the right position and inserts
at the end if no position is provided.

### How to review 
1. Starting from a section with one page.
2. Add a page.
3. It should be added as the first page of the section and persist in that position after refresh.

In #182 this is not true but should be after this change.