### PR TITLE
Fix flakey duplicate questionnaire spec

### DIFF
--- a/eq-author/cypress/integration/authenticated/duplicate_spec.js
+++ b/eq-author/cypress/integration/authenticated/duplicate_spec.js
@@ -71,6 +71,9 @@ describe("Duplicate", () => {
         });
 
       cy.contains(duplicateTitle).should("be.visible");
+      cy.contains(duplicateTitle).should($title => {
+        expect($title.attr("disabled")).not.to.equal("disabled");
+      });
     });
 
     afterEach(() => {


### PR DESCRIPTION
### What is the context of this PR?
Sometimes the afterEach of deleting a questionnaire would fail. It would
report that the delete button was disabled. This was occurring only in
the duplicate questionnaire spec.

This was because the optimistic update in the UI shows a row and so the
assertion was passing but the server was not actually finished. This
meant the after each was trying to delete an optimistic response which
is not possible.

Now, to resolve this instead we wait for the link to be enabled which
means the server has responded. This means it can then be deleted by the
afterEach.

### How to review 
1. Ensure that this branch goes green
2. Test this locally - it was easy to recreate by changing your network to "Fast 3G" in Chrome dev tools whilst cypress is running only this test. It should fail on 797 but pass with this change.
