### PR TITLE
Create a new version of questionnaire on each mutation

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -70,6 +70,9 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
     summary: {
       type: Boolean,
     },
+    createdAt: {
+      type: Date,
+    },
     updatedAt: {
       type: Date,
       required: true,

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -85,7 +85,6 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
   },
   {
     throughput: throughput,
-    timestamps: true,
   }
 );
 
@@ -102,4 +101,5 @@ const QuestionnaireVersionsModel = dynamoose.model(
 module.exports = {
   QuestionnaireModel,
   QuestionnaireVersionsModel,
+  dynamoose,
 };

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -62,8 +62,9 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
       type: Boolean,
     },
     updatedAt: {
-      type: String,
+      type: Number,
       required: true,
+      rangeKey: true,
     },
     sections: {
       type: Array,

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -35,10 +35,19 @@ const baseQuestionnaireSchema = {
   },
 };
 
-const questionnanaireSchema = new dynamoose.Schema(baseQuestionnaireSchema, {
-  throughput: throughput,
-  timestamps: true,
-});
+const questionnanaireSchema = new dynamoose.Schema(
+  {
+    ...baseQuestionnaireSchema,
+    latestVersion: {
+      type: Date,
+      required: true,
+    },
+  },
+  {
+    throughput: throughput,
+    timestamps: true,
+  }
+);
 
 const questionnaireVersionsSchema = new dynamoose.Schema(
   {

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -71,7 +71,7 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
       type: Boolean,
     },
     updatedAt: {
-      type: Number,
+      type: Date,
       required: true,
       rangeKey: true,
     },

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -109,7 +109,7 @@ const saveQuestionnaire = async (versionModel, count = 0, patch) => {
 
     const newVersion = new Date();
 
-    const result = await dynamoose.transaction([
+    await dynamoose.transaction([
       QuestionnaireVersionsModel.transaction.create({
         ...versionModel,
         updatedAt: newVersion,

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -68,21 +68,6 @@ const getQuestionnaire = id => {
   });
 };
 
-const getLatestVersion = id => {
-  return new Promise((resolve, reject) => {
-    QuestionnaireModel.queryOne({ id: { eq: id } })
-      .descending()
-      .consistent()
-      .exec((err, questionnaire) => {
-        if (err) {
-          reject(err);
-        }
-
-        resolve(questionnaire);
-      });
-  });
-};
-
 const MAX_UPDATE_TIMES = 3;
 const saveQuestionnaire = async (versionModel, count = 0, patch) => {
   if (count === MAX_UPDATE_TIMES) {
@@ -104,8 +89,7 @@ const saveQuestionnaire = async (versionModel, count = 0, patch) => {
   }
 
   try {
-    const questionnaireModel = await getLatestVersion(versionModel.id);
-    const originalLatestVersion = questionnaireModel.latestVersion;
+    const originalLatestVersion = originalQuestionnaireVersion.updatedAt;
 
     const newVersion = new Date();
 

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -128,11 +128,7 @@ const saveQuestionnaire = async (versionModel, count = 0, patch) => {
         }
       ),
     ]);
-
-    console.log(result);
   } catch (e) {
-    console.error(e);
-
     if (!e.code || e.code !== "ConditionalCheckFailedException") {
       throw e;
     }

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -113,7 +113,7 @@ const saveQuestionnaire = async (versionModel, count = 0, patch) => {
       ),
     ]);
   } catch (e) {
-    if (!e.code || e.code !== "ConditionalCheckFailedException") {
+    if (!e.code || e.code !== "TransactionCanceledException") {
       throw e;
     }
 

--- a/eq-author/cypress/integration/authenticated/metadata_spec.js
+++ b/eq-author/cypress/integration/authenticated/metadata_spec.js
@@ -92,6 +92,7 @@ describe("Metadata", () => {
     cy.get(testId("metadata-delete-row")).as("deleteMetadataBtn");
     cy.get("@deleteMetadataBtn").should("be.visible");
     cy.get("@deleteMetadataBtn").click();
+    cy.get(testId("metadata-table-row")).should("have.length", 0);
     cy.contains("Done").click();
   });
 });

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -206,20 +206,22 @@ class RichTextEditor extends React.Component {
     ) {
       const { editorState } = this.state;
       const anchorOffset = editorState.getSelection().get("anchorOffset");
-      const valueUpdatedES = EditorState.push(
+      let selectionUpdated = EditorState.push(
         editorState,
         convert.convertFromHTML({ htmlToEntity: htmlToPipedEntity })(
           this.props.value
         ),
         "insert-characters"
       );
-      const selectionUpdated = EditorState.forceSelection(
-        valueUpdatedES,
-        valueUpdatedES.getSelection().merge({
-          anchorOffset,
-          focusOffset: anchorOffset,
-        })
-      );
+      if (this.state.focused) {
+        selectionUpdated = EditorState.forceSelection(
+          selectionUpdated,
+          selectionUpdated.getSelection().merge({
+            anchorOffset,
+            focusOffset: anchorOffset,
+          })
+        );
+      }
 
       this.handleChange(selectionUpdated);
     }


### PR DESCRIPTION
### What is the context of this PR?
Calculates the difference between either:
    a) the original version, or
    b) the latest version, if a newer version exists.
Patches the latest version with diff created by current mutation.

e.g. 
v1 - originalItem
v2 - latest
v3 - questionnaire

In the above case it should diff questionnaire with latest, if a new version has been written since the original read operation.


### How to review 
Tests are green. Changes look sensible.
