### PR TITLE
DynamoDB - Deleted means gone

### DIFF
--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -2,14 +2,22 @@ const { getQuestionnaire } = require("../utils/datastore");
 
 module.exports = async (req, res, next) => {
   const questionnaireId = req.header("questionnaireId");
-  if (questionnaireId) {
-    req.questionnaire = await getQuestionnaire(questionnaireId);
-    if (!req.questionnaire.metadata) {
-      req.questionnaire.metadata = [];
-    }
-    if (!req.questionnaire.sections) {
-      req.questionnaire.sections = [];
-    }
+  if (!questionnaireId) {
+    next();
+    return;
+  }
+  const questionnaire = await getQuestionnaire(questionnaireId);
+  req.questionnaire = questionnaire;
+  if (!questionnaire) {
+    next();
+    return;
+  }
+
+  if (!questionnaire.metadata) {
+    questionnaire.metadata = [];
+  }
+  if (!questionnaire.sections) {
+    questionnaire.sections = [];
   }
   next();
 };

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -37,7 +37,21 @@ const createQuestionnaire = async questionnaire => {
   return result;
 };
 
-const getQuestionnaire = id => {
+const getQuestionnaireFromList = id => {
+  return new Promise((resolve, reject) => {
+    QuestionnaireModel.queryOne({ id: { eq: id } }).exec(
+      (err, questionnaire) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(questionnaire);
+      }
+    );
+  });
+};
+
+const getLatestQuestionnaire = id => {
   return new Promise((resolve, reject) => {
     QuestionnaireVersionsModel.queryOne({ id: { eq: id } })
       .descending()
@@ -45,6 +59,12 @@ const getQuestionnaire = id => {
       .exec((err, questionnaire) => {
         if (err) {
           reject(err);
+          return;
+        }
+
+        if (!questionnaire) {
+          resolve(null);
+          return;
         }
 
         if (!questionnaire.sections) {
@@ -57,6 +77,14 @@ const getQuestionnaire = id => {
         resolve(questionnaire);
       });
   });
+};
+
+const getQuestionnaire = async id => {
+  const listVersion = await getQuestionnaireFromList(id);
+  if (!listVersion) {
+    return null;
+  }
+  return getLatestQuestionnaire(id);
 };
 
 const MAX_UPDATE_TIMES = 3;
@@ -112,8 +140,9 @@ const deleteQuestionnaire = id => {
     QuestionnaireModel.delete({ id: id }, function(err) {
       if (err) {
         reject(err);
+      } else {
+        resolve();
       }
-      resolve();
     });
   });
 };
@@ -125,8 +154,9 @@ const listQuestionnaires = () => {
       .exec((err, questionnaires) => {
         if (err) {
           reject(err);
+        } else {
+          resolve(questionnaires);
         }
-        resolve(questionnaires);
       });
   });
 };

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -133,6 +133,10 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
       location,
     } = this.props;
 
+    if (!loading && !questionnaire) {
+      return <Redirect to="/" />;
+    }
+
     return (
       <BaseLayout questionnaire={questionnaire}>
         <Titled title={this.getTitle}>

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -19,6 +19,7 @@ import { Routes, buildSectionPath } from "utils/UrlUtils";
 import Loading from "components/Loading";
 import RoutingPageRoute from "App/questionPage/Routing";
 import QuestionConfirmationRoute from "App/questionConfirmation/Design";
+import NotFoundPage from "App/NotFoundPage";
 
 import withCreatePage from "enhancers/withCreatePage";
 import withCreateSection from "enhancers/withCreateSection";
@@ -134,7 +135,7 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
     } = this.props;
 
     if (!loading && !questionnaire) {
-      return <Redirect to="/" />;
+      return <NotFoundPage />;
     }
 
     return (


### PR DESCRIPTION
### What is the context of this PR?
Fix issue where you could read and modify delete questionnaires. This was because we were deleting them from the list but you could still get to them if you knew their id (separate tab or using browser back).

### How to review 
1. Create a questionnaire.
2. Open the list page in a separate tab.
3. Delete the questionnaire from the list tab.
4. You should no longer be able to edit the questionnaire. On refresh it should take you to 404 as well.
