### PR TITLE
Stop crashing on invalid questionnaire id

### DIFF
--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -2,14 +2,10 @@ const { getQuestionnaire } = require("../utils/datastore");
 
 module.exports = async (req, res, next) => {
   const questionnaireId = req.header("questionnaireId");
-  if (questionnaireId) {
-    req.questionnaire = await getQuestionnaire(questionnaireId);
-    if (!req.questionnaire.metadata) {
-      req.questionnaire.metadata = [];
-    }
-    if (!req.questionnaire.sections) {
-      req.questionnaire.sections = [];
-    }
+  if (!questionnaireId) {
+    next();
+    return;
   }
+  req.questionnaire = await getQuestionnaire(questionnaireId);
   next();
 };

--- a/eq-author-api/middleware/loadQuestionnaire.test.js
+++ b/eq-author-api/middleware/loadQuestionnaire.test.js
@@ -1,0 +1,38 @@
+const loadQuestionnaire = require("./loadQuestionnaire");
+const { buildQuestionnaire } = require("../tests/utils/questionnaireBuilder");
+
+describe("loadQuestionnaire", () => {
+  it("should add a found questionnaire to the middleware", async () => {
+    const questionnaire = await buildQuestionnaire({});
+    const req = {
+      header: jest.fn().mockReturnValue(questionnaire.id),
+    };
+    const res = {};
+    await new Promise(resolve => {
+      loadQuestionnaire(req, res, resolve);
+    });
+    expect(req.questionnaire).toEqual(questionnaire);
+  });
+
+  it("should not add a questionnaire to the req when no header is provided", async () => {
+    const req = {
+      header: jest.fn().mockReturnValue(null),
+    };
+    const res = {};
+    await new Promise(resolve => {
+      loadQuestionnaire(req, res, resolve);
+    });
+    expect(req.questionnaire).toEqual(undefined);
+  });
+
+  it("should not add a questionnaire to the req when the questionnaire is not found", async () => {
+    const req = {
+      header: jest.fn().mockReturnValue("missingId"),
+    };
+    const res = {};
+    await new Promise(resolve => {
+      loadQuestionnaire(req, res, resolve);
+    });
+    expect(req.questionnaire).toEqual(null);
+  });
+});

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -54,6 +54,12 @@ const getQuestionnaire = id => {
       .exec((err, questionnaire) => {
         if (err) {
           reject(err);
+          return;
+        }
+
+        if (!questionnaire) {
+          resolve(null);
+          return;
         }
 
         if (!questionnaire.sections) {


### PR DESCRIPTION
### What is the context of this PR?
This fix changes it so when a questionnaire cannot found that the
`ctx.questionnaire` is null in the resolvers. This means that we see
a graphql error in the UI.

Before this change it was blowing up in the express middleware and so
the server was crashing and the requests were left pending.

### How to review 
1. Access a questionnaire that doesn't exist e.g. http://localhost:3000/#/questionnaire/12341421143/design. The server will crash
2. After this change it should no longer crash the server.