### PR TITLE
Bug - Flakey section duplication test

### DIFF
--- a/eq-author/cypress/integration/authenticated/duplicate_spec.js
+++ b/eq-author/cypress/integration/authenticated/duplicate_spec.js
@@ -37,6 +37,7 @@ describe("Duplicate", () => {
       addQuestionnaire("section duplication");
       navigateToFirstSection();
       typeIntoDraftEditor(testId("txt-section-title", "testid"), "Section 1");
+      cy.get(testId("side-nav")).should("contain", "Section 1");
       cy.get(testId("btn-duplicate-section")).click();
     });
 


### PR DESCRIPTION
### What is the context of this PR?
Test was hitting duplicate button before the update had finished so the duplicate was running on out of date information

I could not reproduce this locally but can see what has happened in this run https://dashboard.cypress.io/#/projects/hma77k/runs/2421/specs

Clicking duplicate on a section called "Untitled Section" means that the copy is also called "Untitled Section"

### How to review 
1. See if the test changes make sense. 
2. See this pass in travis. (I could not reproduce this locally)