### PR TITLE
Discussion - Store everything in one place

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -18,26 +18,13 @@ if (process.env.DYNAMO_QUESTIONNAIRE_VERSION_TABLE_NAME) {
     process.env.DYNAMO_QUESTIONNAIRE_VERSION_TABLE_NAME;
 }
 
-const baseQuestionnaireSchema = {
-  id: {
-    type: String,
-    hashKey: true,
-    required: true,
-  },
-  title: {
-    type: String,
-  },
-  createdBy: {
-    type: String,
-  },
-  version: {
-    type: Number,
-  },
-};
-
 const questionnanaireSchema = new dynamoose.Schema(
   {
-    ...baseQuestionnaireSchema,
+    id: {
+      type: String,
+      hashKey: true,
+      required: true,
+    },
     latestVersion: {
       type: Date,
       required: true,
@@ -51,7 +38,20 @@ const questionnanaireSchema = new dynamoose.Schema(
 
 const questionnaireVersionsSchema = new dynamoose.Schema(
   {
-    ...baseQuestionnaireSchema,
+    id: {
+      type: String,
+      hashKey: true,
+      required: true,
+    },
+    title: {
+      type: String,
+    },
+    createdBy: {
+      type: String,
+    },
+    version: {
+      type: Number,
+    },
     description: {
       type: String,
     },


### PR DESCRIPTION
### What is the context of this PR?
Store everything in one place and only use list for merging and knowing which questionnaires have not been deleted.

This removes the title bug and we no longer have any fields duplicated. This comes at the cost of `(questionnaire count) + 1` dynamo reads for the list query which we can run in parallel.

This would also allow us to audit permissions as we would any other change.

### How to review
1. Have a discussion about this and agree an approach.