### PR TITLE
Make the versions a shadow table

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -33,57 +33,58 @@ const baseQuestionnaireSchema = {
   version: {
     type: Number,
   },
+  description: {
+    type: String,
+  },
+  legalBasis: {
+    type: String,
+  },
+  navigation: {
+    type: Boolean,
+  },
+  surveyId: {
+    type: String,
+  },
+  theme: {
+    type: String,
+  },
+  summary: {
+    type: Boolean,
+  },
+  sections: {
+    type: Array,
+    required: true,
+  },
+  metadata: {
+    type: Array,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    required: true,
+  },
 };
 
 const questionnanaireSchema = new dynamoose.Schema(
   {
     ...baseQuestionnaireSchema,
-    latestVersion: {
+    updatedAt: {
       type: Date,
       required: true,
     },
   },
   {
     throughput: throughput,
-    timestamps: true,
   }
 );
 
 const questionnaireVersionsSchema = new dynamoose.Schema(
   {
     ...baseQuestionnaireSchema,
-    description: {
-      type: String,
-    },
-    legalBasis: {
-      type: String,
-    },
-    navigation: {
-      type: Boolean,
-    },
-    surveyId: {
-      type: String,
-    },
-    theme: {
-      type: String,
-    },
-    summary: {
-      type: Boolean,
-    },
-    createdAt: {
-      type: Date,
-    },
     updatedAt: {
       type: Date,
       required: true,
       rangeKey: true,
-    },
-    sections: {
-      type: Array,
-      required: true,
-    },
-    metadata: {
-      type: Array,
     },
   },
   {

--- a/eq-author-api/middleware/loadQuestionnaire.test.js
+++ b/eq-author-api/middleware/loadQuestionnaire.test.js
@@ -33,6 +33,6 @@ describe("loadQuestionnaire", () => {
     await new Promise(resolve => {
       loadQuestionnaire(req, res, resolve);
     });
-    expect(req.questionnaire).toEqual(null);
+    expect(req.questionnaire).toEqual(undefined);
   });
 });

--- a/eq-author-api/tests/utils/executeQuery.js
+++ b/eq-author-api/tests/utils/executeQuery.js
@@ -18,6 +18,18 @@ Resulted in:
 ${response.errors.map(e => e.message).join("\n----\n")}
     `);
   }
+  // Required because dynamoose transaction does not update the questionnaireModel's
+  // originalItem and so its out of sync which causes us to have to re-query the questionnaire
+  if (
+    ctx.questionnaire &&
+    ctx.questionnaire.originalItem &&
+    ctx.questionnaire.updateAt !== ctx.questionnaire.originalItem().updatedAt
+  ) {
+    ctx.questionnaire.$__.originalItem = JSON.parse(
+      JSON.stringify(ctx.questionnaire)
+    );
+  }
+
   return response;
 }
 


### PR DESCRIPTION
### What is the context of this PR?
Change the way we use the versions table so we the latest version of any questionnaire on the questionnaires table and all versions of a questionnaire on the versions table.

This means we read and save all data from the questionnaire table (no title bug) and we no longer have to perform a scan to get the latest questionnaire. We can just look it up by id.

This change makes adding questionnaire type and short name easier as 

### How to review 
1. Ensure that the questionnaires are being saved as expected - latest in the questionnaires table and all versions (including latest) in the versions table.