### PR TITLE
Fix piping not decorating currency answers.

### DIFF
--- a/eq-author/src/components/ContentPicker/shapeTree.js
+++ b/eq-author/src/components/ContentPicker/shapeTree.js
@@ -4,7 +4,7 @@ const shapeTree = answers =>
   reduce(
     answers,
     (result, value) => {
-      const answer = pick(value, ["id", "displayName"]);
+      const answer = pick(value, ["id", "displayName", "type"]);
       const page = pick(value.page, ["id", "displayName"]);
       const section = pick(value.page.section, ["id", "displayName"]);
 

--- a/eq-author/src/components/ContentPicker/shapeTree.test.js
+++ b/eq-author/src/components/ContentPicker/shapeTree.test.js
@@ -4,6 +4,7 @@ const answerTree = [
   {
     id: "6",
     displayName: "Date 1",
+    type: "Date",
     page: {
       id: "1",
       displayName: "Page (1.1)",
@@ -16,6 +17,7 @@ const answerTree = [
   {
     id: "7",
     displayName: "Date 2",
+    type: "Date",
     page: {
       id: "6",
       displayName: "Page (1.2)",
@@ -28,6 +30,7 @@ const answerTree = [
   {
     id: "2",
     displayName: "Date 3",
+    type: "Date",
     page: {
       id: "2",
       displayName: "Page (2.1)",
@@ -40,6 +43,7 @@ const answerTree = [
   {
     id: "3",
     displayName: "Date 4",
+    type: "Date",
     page: {
       id: "5",
       displayName: "Page (3.1)",
@@ -52,6 +56,7 @@ const answerTree = [
   {
     id: "9",
     displayName: "Date 5",
+    type: "Date",
     page: {
       id: "5",
       displayName: "Page (3.1)",
@@ -75,6 +80,7 @@ const expectedAnswerTree = [
           {
             id: "6",
             displayName: "Date 1",
+            type: "Date",
           },
         ],
       },
@@ -85,6 +91,7 @@ const expectedAnswerTree = [
           {
             id: "7",
             displayName: "Date 2",
+            type: "Date",
           },
         ],
       },
@@ -101,6 +108,7 @@ const expectedAnswerTree = [
           {
             id: "2",
             displayName: "Date 3",
+            type: "Date",
           },
         ],
       },
@@ -117,10 +125,12 @@ const expectedAnswerTree = [
           {
             id: "3",
             displayName: "Date 4",
+            type: "Date",
           },
           {
             id: "9",
             displayName: "Date 5",
+            type: "Date",
           },
         ],
       },

--- a/eq-author/src/graphql/fragments/available-answers.graphql
+++ b/eq-author/src/graphql/fragments/available-answers.graphql
@@ -1,6 +1,7 @@
 fragment AvailableAnswers on Answer {
   id
   displayName
+  type
   page {
     id
     displayName


### PR DESCRIPTION
### What is the context of this PR?
There was a defect where the £ symbol was not being added to piped currency answers.
I tracked down the cause being that the type was not being added to the piping data attributes.

The type is required at present and used by publisher in order to determine how to correctly render the piped output in runner.
A change was made to shapeTree to ensure that the type property is present on answers when selecting values to pipe.

### How to review 
- Checkout master and ensure that when you pipe in a currency answer the £ symbol is not displayed, only the value.
- Checkout this branch and ensure that when you pipe in a currency answer then the answer is rendered correctly when previewed in survey runner.
- Observe that `data-type={{answer.type}}` is present in the HTML that gets persisted in question titles, descriptions etc. when piping in answer values.
- Check that other answer types e.g. Date, Date Range etc. exhibit similar behaviour.