### PR TITLE
Bug - Moving answers causes UI error

### DIFF
--- a/eq-author/cypress/support/errors.js
+++ b/eq-author/cypress/support/errors.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/unambiguous */
+Cypress.on(`window:before:load`, win => {
+  cy.stub(win.console, `error`, msg => {
+    cy.now(`task`, `error`, msg);
+    throw new Error(msg);
+  });
+});

--- a/eq-author/cypress/support/index.js
+++ b/eq-author/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
+import "./errors";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/eq-author/src/App/questionPage/Design/QuestionPageEditor/AnswersEditor/index.js
+++ b/eq-author/src/App/questionPage/Design/QuestionPageEditor/AnswersEditor/index.js
@@ -1,9 +1,8 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import { propType } from "graphql-anywhere";
 import styled, { keyframes, css } from "styled-components";
 import { TransitionGroup } from "react-transition-group";
-import { delay } from "lodash";
 
 import getIdForObject from "utils/getIdForObject";
 
@@ -59,6 +58,7 @@ export const UnwrappedAnswersEditor = ({
   const hasNewAnswers = useRef(false);
   const answerElements = useRef([]);
   const prevAnswers = useRef(answers);
+  const animationTimeout = useRef();
 
   if (prevAnswers.current !== answers) {
     prevAnswers.current = answers;
@@ -78,6 +78,18 @@ export const UnwrappedAnswersEditor = ({
 
     answerElements.current[index] = node.getBoundingClientRect().height;
   };
+
+  useEffect(
+    () => {
+      return () => {
+        if (animationTimeout.current) {
+          clearTimeout(animationTimeout.current);
+          animationTimeout.current = null;
+        }
+      };
+    },
+    [animationTimeout]
+  );
 
   const handleMove = (answer, index, direction) => {
     const isUp = direction === UP;
@@ -104,7 +116,7 @@ export const UnwrappedAnswersEditor = ({
     setIsTransitioning(true);
     setAnswerStyles(newAnswerStyles);
     moveAnswer({ id: answer.id, position: indexB });
-    delay(() => {
+    animationTimeout.current = setTimeout(() => {
       setIsTransitioning(false);
     }, MOVE_DURATION);
   };


### PR DESCRIPTION
### What is the context of this PR?
This fixes the issue described in #274 

It also adds so cypress will error if a console.error is produced during the test.

Closes #274 

### How to review 
1. Prove that you see a console error when the `builder_spec` when moving answers
1. Prove that the test fails when you have the first commit
1. Prove that the test passes when it is fixed in the second commit
