### PR TITLE
Bug - Errors thrown in routing

### DIFF
--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -52,6 +52,7 @@
       "!config/**/*",
       "!coverage/**/*",
       "!tests/**/*",
+      "!**/tests/**/*",
       "!scripts/*",
       "!middleware/import.js",
       "!app.js",

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -21,7 +21,6 @@ const { queryPage } = require("../../tests/utils/questionnaireBuilder/page");
 
 describe("routing", () => {
   describe("A Routing", () => {
-    // Passes intermittently
     it("should create a full routing tree when creating a routing", async () => {
       let config = {
         metadata: [{}],
@@ -58,7 +57,10 @@ describe("routing", () => {
       const result = await queryPage(questionnaire, page.id);
       expect(
         result.routing.rules[0].expressionGroup.expressions[0].left.id
-      ).toBeTruthy();
+      ).toEqual(page.answers[0].id);
+      expect(
+        result.routing.rules[0].expressionGroup.expressions[0].right
+      ).toBeNull();
     });
 
     // Passes intermittently
@@ -531,7 +533,21 @@ describe("routing", () => {
                   },
                 ],
                 routing: {
-                  rules: [{ expressionGroup: { expressions: [{}] } }],
+                  rules: [
+                    {
+                      expressionGroup: {
+                        expressions: [
+                          {
+                            right: {
+                              customValue: {
+                                number: 2,
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
                 },
               },
             ],

--- a/eq-author-api/src/businessLogic/createExpression.js
+++ b/eq-author-api/src/businessLogic/createExpression.js
@@ -1,11 +1,9 @@
 const uuid = require("uuid");
 const createLeftSide = require("./createLeftSide");
-const createRightSide = require("./createRightSide");
 
 module.exports = input => ({
   id: uuid.v4(),
   condition: "Equal",
   left: createLeftSide(),
-  right: createRightSide(),
   ...input,
 });

--- a/eq-author-api/src/businessLogic/createRightSide.js
+++ b/eq-author-api/src/businessLogic/createRightSide.js
@@ -1,6 +1,0 @@
-module.exports = input => ({
-  type: "SelectedOptions",
-  customValue: "",
-  optionIds: [],
-  ...input,
-});

--- a/eq-author-api/src/businessLogic/index.js
+++ b/eq-author-api/src/businessLogic/index.js
@@ -4,7 +4,6 @@ const createDestination = require("./createDestination");
 const createExpressionGroup = require("./createExpressionGroup");
 const createExpression = require("./createExpression");
 const createLeftSide = require("./createLeftSide");
-const createRightSide = require("./createRightSide");
 const getNextDestination = require("./getNextDestination");
 
 module.exports = {
@@ -14,6 +13,5 @@ module.exports = {
   createExpressionGroup,
   createExpression,
   createLeftSide,
-  createRightSide,
   getNextDestination,
 };

--- a/eq-author-api/tests/utils/questionnaireBuilder/buildRouting.js
+++ b/eq-author-api/tests/utils/questionnaireBuilder/buildRouting.js
@@ -1,0 +1,133 @@
+const { get, isNull } = require("lodash");
+
+const {
+  NEXT_PAGE,
+  END_OF_QUESTIONNAIRE,
+} = require("../../../constants/logicalDestinations");
+
+const {
+  createRouting,
+  updateRouting,
+  createRoutingRule,
+  updateRoutingRule,
+  createBinaryExpression,
+  updateBinaryExpression,
+  updateRightSide,
+} = require("./routing");
+
+const convertPathToDestination = (
+  { section, page, logical },
+  questionnaire
+) => {
+  if (logical === END_OF_QUESTIONNAIRE || logical === NEXT_PAGE) {
+    return { logical };
+  } else if (!isNull(page) && !isNull(section)) {
+    return {
+      pageId: get(questionnaire, `sections[${section}].pages[${page}].id`),
+    };
+  } else if (!isNull(section)) {
+    return {
+      pageId: get(questionnaire, `sections[${section}].id`),
+    };
+  } else {
+    throw new Error("Not a valid destination in the input config");
+  }
+};
+
+module.exports = async (questionnaire, config) => {
+  const { sections } = config;
+  if (!Array.isArray(sections)) {
+    return;
+  }
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    const { pages } = sections[sectionIndex];
+    if (!Array.isArray(pages)) {
+      return;
+    }
+    for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+      if (pages[pageIndex].routing) {
+        const { routing } = pages[pageIndex];
+        const questionnairePage = get(
+          questionnaire,
+          `sections[${sectionIndex}].pages[${pageIndex}]`
+        );
+        let createdRouting = await createRouting(
+          questionnaire,
+          questionnairePage
+        );
+        if (routing.else) {
+          createdRouting = await updateRouting(questionnaire, {
+            id: createdRouting.id,
+            else: convertPathToDestination(routing.else, questionnaire),
+          });
+        }
+        const rules = get(routing, "rules", []);
+        if (!Array.isArray(rules)) {
+          return;
+        }
+        for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
+          let createdRule = createdRouting.rules[ruleIndex];
+          const rule = rules[ruleIndex];
+          if (createdRouting.rules[ruleIndex] && rule.destination) {
+            createdRule = await updateRoutingRule(questionnaire, {
+              id: createdRouting.rules[ruleIndex].id,
+              destination: convertPathToDestination(
+                rule.destination,
+                questionnaire
+              ),
+            });
+          } else if (!createdRouting.rules[ruleIndex]) {
+            createdRule = await createRoutingRule(
+              questionnaire,
+              createdRouting
+            );
+            if (rule.destination) {
+              createdRule = await updateRoutingRule(questionnaire, {
+                id: createdRule.id,
+                destination: convertPathToDestination(
+                  rule.destination,
+                  questionnaire
+                ),
+              });
+            }
+          }
+          const {
+            expressionGroup: { expressions: createdExpressions },
+          } = createdRule;
+          const expressions = get(rule, "expressionGroup.expressions", []);
+          if (!Array.isArray(expressions)) {
+            return;
+          }
+          for (
+            let expressionIndex = 0;
+            expressionIndex < expressions.length;
+            expressionIndex++
+          ) {
+            const expression = expressions[expressionIndex];
+            let createdExpression = createdExpressions[expressionIndex];
+            if (!createdExpression) {
+              createdExpression = await createBinaryExpression(
+                questionnaire,
+                createdRule.expressionGroup
+              );
+            }
+
+            if (expression.condition) {
+              await updateBinaryExpression(questionnaire, {
+                id: createdExpression.id,
+                ...expression,
+              });
+            }
+
+            if (expression.right) {
+              await updateRightSide(questionnaire, {
+                expressionId: createdExpression.id,
+                ...expression.right,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/eq-author-api/tests/utils/questionnaireBuilder/index.js
+++ b/eq-author-api/tests/utils/questionnaireBuilder/index.js
@@ -1,6 +1,7 @@
-const { get, isNull } = require("lodash");
-
 const { SOCIAL } = require("../../../constants/questionnaireTypes");
+const { RADIO } = require("../../../constants/answerTypes");
+
+const { getQuestionnaire } = require("../../../utils/datastore");
 
 const { createQuestionnaireReturningPersisted } = require("./questionnaire");
 const { createMetadata, updateMetadata } = require("./metadata");
@@ -12,140 +13,13 @@ const {
   createMutuallyExclusiveOption,
   deleteOption,
 } = require("./option");
-const {
-  NEXT_PAGE,
-  END_OF_QUESTIONNAIRE,
-} = require("../../../constants/logicalDestinations");
+
 const {
   createQuestionConfirmation,
   updateQuestionConfirmation,
 } = require("./questionConfirmation");
 
-const { getQuestionnaire } = require("../../../utils/datastore");
-const { RADIO } = require("../../../constants/answerTypes");
-
-const {
-  createRouting,
-  updateRouting,
-  createRoutingRule,
-  updateRoutingRule,
-  createBinaryExpression,
-  updateBinaryExpression,
-} = require("./routing");
-
-const convertPathToDestination = (
-  { section, page, logical },
-  questionnaire
-) => {
-  if (logical === END_OF_QUESTIONNAIRE || logical === NEXT_PAGE) {
-    return { logical };
-  } else if (!isNull(page) && !isNull(section)) {
-    return {
-      pageId: get(questionnaire, `sections[${section}].pages[${page}].id`),
-    };
-  } else if (!isNull(section)) {
-    return {
-      pageId: get(questionnaire, `sections[${section}].id`),
-    };
-  } else {
-    throw new Error("Not a valid destination in the input config");
-  }
-};
-
-const buildRouting = async (questionnaire, config) => {
-  const { sections } = config;
-  if (!Array.isArray(sections)) {
-    return;
-  }
-  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
-    const { pages } = sections[sectionIndex];
-    if (!Array.isArray(pages)) {
-      return;
-    }
-    for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
-      if (pages[pageIndex].routing) {
-        const { routing } = pages[pageIndex];
-        const questionnairePage = get(
-          questionnaire,
-          `sections[${sectionIndex}].pages[${pageIndex}]`
-        );
-        let createdRouting = await createRouting(
-          questionnaire,
-          questionnairePage
-        );
-        if (routing.else) {
-          createdRouting = await updateRouting(questionnaire, {
-            id: createdRouting.id,
-            else: convertPathToDestination(routing.else, questionnaire),
-          });
-        }
-        const rules = get(routing, "rules", []);
-        if (!Array.isArray(rules)) {
-          return;
-        }
-        for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
-          let createdRule = createdRouting.rules[ruleIndex];
-          const rule = rules[ruleIndex];
-          if (createdRouting.rules[ruleIndex] && rule.destination) {
-            createdRule = await updateRoutingRule(questionnaire, {
-              id: createdRouting.rules[ruleIndex].id,
-              destination: convertPathToDestination(
-                rule.destination,
-                questionnaire
-              ),
-            });
-          } else if (!createdRouting.rules[ruleIndex]) {
-            createdRule = await createRoutingRule(
-              questionnaire,
-              createdRouting
-            );
-            if (rule.destination) {
-              createdRule = await updateRoutingRule(questionnaire, {
-                id: createdRule.id,
-                destination: convertPathToDestination(
-                  rule.destination,
-                  questionnaire
-                ),
-              });
-            }
-          }
-          const {
-            expressionGroup: { expressions: createdExpressions },
-          } = createdRule;
-          const expressions = get(rule, "expressionGroup.expressions", []);
-          if (!Array.isArray(expressions)) {
-            return;
-          }
-          for (
-            let expressionIndex = 0;
-            expressionIndex < expressions.length;
-            expressionIndex++
-          ) {
-            const expression = expressions[expressionIndex];
-            if (createdExpressions[expressionIndex] && expression.condition) {
-              await updateBinaryExpression(questionnaire, {
-                id: createdExpressions[expressionIndex].id,
-                ...expression,
-              });
-            } else if (!createdExpressions[expressionIndex]) {
-              const createdExpression = await createBinaryExpression(
-                questionnaire,
-                createdRule.expressionGroup
-              );
-
-              if (expression.condition) {
-                await updateBinaryExpression(questionnaire, {
-                  id: createdExpression.id,
-                  ...expression,
-                });
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-};
+const buildRouting = require("./buildRouting");
 
 //@todo - Split into smaller functions to avoid deeply nested chaining
 const buildQuestionnaire = async questionnaireConfig => {

--- a/eq-author-api/tests/utils/questionnaireBuilder/routing/createRouting.js
+++ b/eq-author-api/tests/utils/questionnaireBuilder/routing/createRouting.js
@@ -1,31 +1,49 @@
 const executeQuery = require("../../executeQuery");
 
 const createRoutingMutation = `
-      mutation createRouting2($input: CreateRouting2Input!) {
-        createRouting2(input: $input) {          
-          id
-          rules{
+mutation createRouting2($input: CreateRouting2Input!) {
+  createRouting2(input: $input) {
+    id
+    rules {
+      id
+      expressionGroup {
+        id
+        expressions {
+          ...on BinaryExpression2 {
             id
-            expressionGroup {
-              id
-              expressions {
-                ...on BinaryExpression2 {
+            left {
+              ... on BasicAnswer {
                 id
-              }  
+              }
+              ... on MultipleChoiceAnswer {
+                id
               }
             }
-          }
-          else {
-            logical
-            page {
-              id
+            right {
+              ... on SelectedOptions2 {
+                options {
+                  id
+                }
+              }
+              ... on CustomValue2 {
+                number
+              }
             }
-            section {
-              id
-            }
-          }   
+          }  
         }
-      }`;
+      }
+    }
+    else {
+      logical
+      page {
+        id
+      }
+      section {
+        id
+      }
+    }   
+  }
+}`;
 
 const createRouting = async (questionnaire, page) => {
   const input = {

--- a/eq-author/cypress/support/commands.js
+++ b/eq-author/cypress/support/commands.js
@@ -58,9 +58,13 @@ Cypress.Commands.add("dismissAllToast", () => {
 });
 
 Cypress.Commands.add("createQuestionnaire", title => {
-  cy.get(testId("logo")).click();
-  cy.get(testId("create-questionnaire")).click();
-  setQuestionnaireSettings({ title, type: "Business" });
+  cy.hash().then(hash => {
+    if (hash !== "#/") {
+      cy.get(testId("logo")).click();
+    }
+    cy.get(testId("create-questionnaire")).click();
+    setQuestionnaireSettings({ title, type: "Business" });
+  });
 });
 
 Cypress.Commands.add("deleteQuestionnaire", title => {

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/NumberAnswerSelector.js
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/NumberAnswerSelector.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { get } from "lodash/fp";
+import { get } from "lodash";
 
 import { colors, radius } from "constants/theme";
 import { Number, Select, Label } from "components/Forms";
@@ -83,7 +83,7 @@ class NumberAnswerSelector extends React.Component {
             min={-99999999}
             max={999999999}
             placeholder="Value"
-            value={get("right.number", expression)}
+            value={get(expression, "right.number", null)}
             name={`expression-right-${expression.id}`}
             onChange={this.handleRightChange}
             data-test="number-value-input"

--- a/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/NumberAnswerSelector.test.js.snap
+++ b/eq-author/src/App/questionPage/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/NumberAnswerSelector.test.js.snap
@@ -67,6 +67,7 @@ exports[`NumberAnswerSelector should render 1`] = `
       placeholder="Value"
       step={1}
       type="Number"
+      value={null}
     />
   </NumberAnswerSelector__Value>
 </NumberAnswerSelector__NumberAnswerRoutingSelector>
@@ -139,6 +140,7 @@ exports[`NumberAnswerSelector should render a currency 1`] = `
       placeholder="Value"
       step={1}
       type="Currency"
+      value={null}
     />
   </NumberAnswerSelector__Value>
 </NumberAnswerSelector__NumberAnswerRoutingSelector>
@@ -211,6 +213,7 @@ exports[`NumberAnswerSelector should render a percentage 1`] = `
       placeholder="Value"
       step={1}
       type="Percentage"
+      value={null}
     />
   </NumberAnswerSelector__Value>
 </NumberAnswerSelector__NumberAnswerRoutingSelector>


### PR DESCRIPTION
### What is the context of this PR?
Fix issues when creating

When running the `routing_spec` locally it would frequently fail as cypress now throws errors when it sees a `console.error`.

Issues:
1. API was incorrectly creating a right side for a new binary expression when it should be null. The right side it was creating wasn't valid for all scenarios either - it was fine for Radio but not basic answers.
2. Input was switching from uncontrolled to controlled causing React to log an error which caused Cypress to blow up. This was caused by the right side value defaulting to undefined not found. Have change it to null which resolves this.

### How to review 
1. Ensure that routing_spec fails for you locally ~~(seems to work in Travis 😫)~~ because they are only thrown in dev mode
2. On this branch it should no longer fail

