### PR TITLE
Bug - flashing display name

### DIFF
--- a/eq-author/src/App/MetadataModal/MetadataTable/Row.js
+++ b/eq-author/src/App/MetadataModal/MetadataTable/Row.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import CustomPropTypes from "custom-prop-types";
-import metadataFragment from "graphql/fragments/metadata.graphql";
 import PropTypes from "prop-types";
 
 import withEntityEditor from "components/withEntityEditor";
@@ -120,4 +119,4 @@ StatelessRow.propTypes = {
   usedKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-export default withEntityEditor("metadata", metadataFragment)(StatelessRow);
+export default withEntityEditor("metadata")(StatelessRow);

--- a/eq-author/src/App/MetadataModal/withUpdateMetadata.js
+++ b/eq-author/src/App/MetadataModal/withUpdateMetadata.js
@@ -1,7 +1,21 @@
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
+import { filter } from "graphql-anywhere";
 
 import metadataFragment from "graphql/fragments/metadata.graphql";
+
+const fragment = gql`
+  {
+    id
+    key
+    alias
+    type
+    dateValue
+    regionValue
+    languageValue
+    textValue
+  }
+`;
 
 const updateMetadataMutation = gql`
   mutation UpdateMetadata($input: UpdateMetadataInput!) {
@@ -17,7 +31,9 @@ const updateMetadataMutation = gql`
 export const mapMutateToProps = ({ mutate }) => ({
   onUpdateMetadata: metadata =>
     mutate({
-      variables: { input: metadata },
+      variables: {
+        input: filter(fragment, metadata),
+      },
     }),
 });
 

--- a/eq-author/src/App/MetadataModal/withUpdateMetadata.test.js
+++ b/eq-author/src/App/MetadataModal/withUpdateMetadata.test.js
@@ -9,7 +9,10 @@ describe("withUpdateMetadata", () => {
     beforeEach(() => {
       mutate = jest.fn();
       props = mapMutateToProps({ mutate });
-      metadata = jest.fn();
+      metadata = {
+        id: "1",
+        __typename: "Metadata",
+      };
     });
 
     it("should have an onUpdateMetadata prop", () => {
@@ -20,7 +23,7 @@ describe("withUpdateMetadata", () => {
       it("should call mutate", () => {
         props.onUpdateMetadata(metadata);
         expect(mutate).toHaveBeenCalledWith({
-          variables: { input: metadata },
+          variables: { input: { id: metadata.id } },
         });
       });
     });

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -161,6 +161,4 @@ StatelessQuestionnaireMeta.fragments = {
   Questionnaire: questionnaireFragment,
 };
 
-export default withEntityEditor("questionnaire", questionnaireFragment)(
-  StatelessQuestionnaireMeta
-);
+export default withEntityEditor("questionnaire")(StatelessQuestionnaireMeta);

--- a/eq-author/src/App/questionConfirmation/Design/Editor.js
+++ b/eq-author/src/App/questionConfirmation/Design/Editor.js
@@ -81,8 +81,6 @@ export class UnwrappedEditor extends React.Component {
   }
 }
 
-const withConfirmationEditing = flow(
-  withEntityEditor("confirmation", confirmationFragment)
-);
+const withConfirmationEditing = flow(withEntityEditor("confirmation"));
 
 export default withConfirmationEditing(UnwrappedEditor);

--- a/eq-author/src/App/questionPage/Design/Validation/builder.js
+++ b/eq-author/src/App/questionPage/Design/Validation/builder.js
@@ -10,14 +10,7 @@ import withProps from "enhancers/withProps";
 import withPropRenamed from "enhancers/withPropRenamed";
 import withPropRemapped from "enhancers/withPropRemapped";
 
-export default (
-  displayName,
-  testId,
-  readKey,
-  writeKey,
-  fragment,
-  readToWriteMapper
-) =>
+export default (displayName, testId, readKey, writeKey, readToWriteMapper) =>
   flowRight(
     withProps({ displayName, testId, readKey }),
     withAnswerValidation(readKey),
@@ -28,6 +21,6 @@ export default (
       "onUpdate",
       readToWriteMapper(writeKey)
     ),
-    withEntityEditor(readKey, fragment),
+    withEntityEditor(readKey),
     withPropRenamed(readKey, "validation")
   )(Validation);

--- a/eq-author/src/App/questionPage/Design/Validation/index.js
+++ b/eq-author/src/App/questionPage/Design/Validation/index.js
@@ -5,19 +5,11 @@ import {
   numericReadToWriteMapper,
 } from "./readToWriteMapper";
 
-import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
-import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
-import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
-import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
-import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
-import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
-
 export const LatestDate = builder(
   "Latest date",
   "latest-date-validation",
   "latestDate",
   "latestDateInput",
-  LatestDateValidationRule,
   dateReadToWriteMapper
 );
 
@@ -26,7 +18,6 @@ export const EarliestDate = builder(
   "earliest-date-validation",
   "earliestDate",
   "earliestDateInput",
-  EarliestDateValidationRule,
   dateReadToWriteMapper
 );
 
@@ -35,7 +26,6 @@ export const MinDuration = builder(
   "min-duration-validation",
   "minDuration",
   "minDurationInput",
-  MinDurationValidationRule,
   durationReadToWriteMapper
 );
 
@@ -44,7 +34,6 @@ export const MaxDuration = builder(
   "max-duration-validation",
   "maxDuration",
   "maxDurationInput",
-  MaxDurationValidationRule,
   durationReadToWriteMapper
 );
 
@@ -53,7 +42,6 @@ export const MinValue = builder(
   "min-value-validation",
   "minValue",
   "minValueInput",
-  MinValueValidationRule,
   numericReadToWriteMapper
 );
 
@@ -62,6 +50,5 @@ export const MaxValue = builder(
   "max-value-validation",
   "maxValue",
   "maxValueInput",
-  MaxValueValidationRule,
   numericReadToWriteMapper
 );

--- a/eq-author/src/App/questionPage/Design/Validation/withUpdateAnswerValidation.js
+++ b/eq-author/src/App/questionPage/Design/Validation/withUpdateAnswerValidation.js
@@ -1,5 +1,7 @@
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
+import { filter } from "graphql-anywhere";
+
 import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
@@ -27,10 +29,62 @@ export const UPDATE_VALIDATION_RULE = gql`
   ${MaxDurationValidationRule}
 `;
 
+const INPUT_FRAGMENT = gql`
+  {
+    id
+    minValueInput {
+      inclusive
+      custom
+      entityType
+      previousAnswer
+    }
+    maxValueInput {
+      inclusive
+      custom
+      entityType
+      previousAnswer
+    }
+    earliestDateInput {
+      offset {
+        value
+        unit
+      }
+      relativePosition
+      entityType
+      custom
+      previousAnswer
+      metadata
+    }
+    latestDateInput {
+      offset {
+        value
+        unit
+      }
+      relativePosition
+      entityType
+      custom
+      previousAnswer
+      metadata
+    }
+    minDurationInput {
+      duration {
+        value
+        unit
+      }
+    }
+    maxDurationInput {
+      duration {
+        value
+        unit
+      }
+    }
+  }
+`;
+
 export const mapMutateToProps = ({ mutate }) => ({
   onUpdateAnswerValidation: input =>
     mutate({
-      variables: { input },
+      variables: { input: filter(INPUT_FRAGMENT, input) },
     }),
 });
 

--- a/eq-author/src/App/questionPage/Design/Validation/withUpdateAnswerValidation.test.js
+++ b/eq-author/src/App/questionPage/Design/Validation/withUpdateAnswerValidation.test.js
@@ -16,12 +16,20 @@ describe("withUpdateAnswerValidation", () => {
     const props = mapMutateToProps({ mutate });
     const answer = {
       id: "1",
-      minValueInput: { inclusive: true, custom: "201" },
+      minValueInput: { inclusive: true, custom: "201", __typename: "foo" },
     };
 
     props.onUpdateAnswerValidation(answer);
     expect(mutate).toHaveBeenCalledWith({
-      variables: { input: answer },
+      variables: {
+        input: {
+          id: answer.id,
+          minValueInput: {
+            inclusive: answer.minValueInput.inclusive,
+            custom: answer.minValueInput.custom,
+          },
+        },
+      },
     });
   });
 });

--- a/eq-author/src/App/questionPage/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/BasicAnswer/index.js
@@ -114,4 +114,4 @@ StatelessBasicAnswer.fragments = {
   `,
 };
 
-export default withEntityEditor("answer", answerFragment)(StatelessBasicAnswer);
+export default withEntityEditor("answer")(StatelessBasicAnswer);

--- a/eq-author/src/App/questionPage/Design/answers/Date/index.js
+++ b/eq-author/src/App/questionPage/Design/answers/Date/index.js
@@ -97,4 +97,4 @@ UnwrappedDate.fragments = {
   `,
 };
 
-export default withEntityEditor("answer", answerFragment)(UnwrappedDate);
+export default withEntityEditor("answer")(UnwrappedDate);

--- a/eq-author/src/App/questionPage/Design/answers/MultipleChoiceAnswer/Option.js
+++ b/eq-author/src/App/questionPage/Design/answers/MultipleChoiceAnswer/Option.js
@@ -159,4 +159,4 @@ StatelessOption.fragments = {
   Option: optionFragment,
 };
 
-export default withEntityEditor("option", optionFragment)(StatelessOption);
+export default withEntityEditor("option")(StatelessOption);

--- a/eq-author/src/App/questionPage/Design/index.js
+++ b/eq-author/src/App/questionPage/Design/index.js
@@ -22,7 +22,6 @@ import withEntityEditor from "components/withEntityEditor";
 import EditorLayout from "App/questionPage/Design/EditorLayout";
 import withPropRenamed from "enhancers/withPropRenamed";
 
-import pageFragment from "graphql/fragments/page.graphql";
 import { propType } from "graphql-anywhere";
 
 import { Label } from "components/Forms";
@@ -220,7 +219,7 @@ const withQuestionPageEditing = flowRight(
   withUpdateOption,
   withDeleteOption,
   withPropRenamed("onUpdatePage", "onUpdate"),
-  withEntityEditor("page", pageFragment)
+  withEntityEditor("page")
 );
 
 const WrappedQuestionPageRoute = withQuestionPageEditing(

--- a/eq-author/src/App/questionPage/Design/withUpdatePage.js
+++ b/eq-author/src/App/questionPage/Design/withUpdatePage.js
@@ -10,8 +10,8 @@ export const mapMutateToProps = ({ mutate }) => ({
       variables: { input: data },
       optimisticResponse: {
         updateQuestionPage: {
+          ...page,
           ...data,
-          displayName: "",
           __typename: "QuestionPage",
         },
       },

--- a/eq-author/src/App/questionPage/Design/withUpdatePage.test.js
+++ b/eq-author/src/App/questionPage/Design/withUpdatePage.test.js
@@ -9,7 +9,9 @@ describe("enhancers > withUpdatePage", () => {
     beforeEach(() => {
       mutate = jest.fn();
       props = mapMutateToProps({ mutate });
-      page = {};
+      page = {
+        displayName: "123",
+      };
     });
 
     it("should have an onUpdatePage prop", () => {
@@ -20,11 +22,11 @@ describe("enhancers > withUpdatePage", () => {
       props.onUpdatePage(page);
       expect(mutate).toHaveBeenCalledWith({
         variables: {
-          input: page,
+          input: {},
         },
         optimisticResponse: {
           updateQuestionPage: {
-            displayName: "",
+            displayName: "123",
             __typename: "QuestionPage",
           },
         },

--- a/eq-author/src/components/withEntityEditor/index.js
+++ b/eq-author/src/components/withEntityEditor/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { filter } from "graphql-anywhere";
 import { isEqual } from "lodash";
 import fp from "lodash/fp";
 import { startRequest, endRequest } from "redux/saving/actions";
@@ -11,7 +10,7 @@ const withSaveTracking = connect(
   { startRequest, endRequest }
 );
 
-const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
+const withEntityEditor = entityPropName => WrappedComponent => {
   class EntityEditor extends React.Component {
     static propTypes = {
       [entityPropName]: PropTypes.object.isRequired, // eslint-disable-line
@@ -51,10 +50,6 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
       return this.state[entityPropName];
     }
 
-    get filteredEntity() {
-      return filter(fragment, this.entity);
-    }
-
     handleChange = ({ name, value }, cb) => {
       if (fp.get(name, this.entity) === value) {
         return;
@@ -77,7 +72,7 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
       this.props.startRequest();
 
       this.props
-        .onUpdate(this.filteredEntity)
+        .onUpdate(this.entity)
         .then(() => {
           this.props.endRequest();
         })
@@ -94,7 +89,7 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
       e.preventDefault();
 
       this.dirtyField = null;
-      this.props.onSubmit(this.filteredEntity);
+      this.props.onSubmit(this.entity);
     };
 
     render() {

--- a/eq-author/src/components/withEntityEditor/index.test.js
+++ b/eq-author/src/components/withEntityEditor/index.test.js
@@ -1,20 +1,10 @@
 import React from "react";
 import withEntityEditor from ".";
 import { shallow } from "enzyme";
-import gql from "graphql-tag";
 import { SynchronousPromise } from "synchronous-promise";
-import { omit } from "lodash";
 import createMockStore from "tests/utils/createMockStore";
 
 const Component = props => <div {...props} />;
-
-const fragment = gql`
-  fragment Entity on Entity {
-    id
-    title
-    alias
-  }
-`;
 
 describe("withEntityEditor", () => {
   let wrapper,
@@ -23,7 +13,7 @@ describe("withEntityEditor", () => {
     handleSubmit,
     handleStartRequest,
     handleEndRequest;
-  const ComponentWithEntity = withEntityEditor("entity", fragment)(Component);
+  const ComponentWithEntity = withEntityEditor("entity")(Component);
   let store;
 
   const render = (props = {}) =>
@@ -71,7 +61,7 @@ describe("withEntityEditor", () => {
     wrapper.setProps({ entity });
     wrapper.simulate("update");
     expect(handleUpdate).toHaveBeenCalledWith({
-      ...omit(entity, "__typename"),
+      ...entity,
       title: "foo1",
     });
   });
@@ -128,7 +118,7 @@ describe("withEntityEditor", () => {
     wrapper.simulate("submit", { preventDefault });
 
     expect(preventDefault).toHaveBeenCalled();
-    expect(handleSubmit).toHaveBeenCalledWith(omit(entity, "__typename"));
+    expect(handleSubmit).toHaveBeenCalledWith(entity);
   });
 
   it("should update state when new entity passed via props", () => {
@@ -220,16 +210,7 @@ describe("withEntityEditor", () => {
   });
 
   it("should use the name to create deeply nested entities", () => {
-    const fragment = gql`
-      fragment Example on Example {
-        id
-        title
-        deep {
-          thing
-        }
-      }
-    `;
-    const ComponentWithEntity = withEntityEditor("entity", fragment)(Component);
+    const ComponentWithEntity = withEntityEditor("entity")(Component);
     const entity = {
       id: 1,
       title: "title",
@@ -255,6 +236,7 @@ describe("withEntityEditor", () => {
       deep: {
         thing: "updated",
       },
+      __typename: "Foo",
     });
   });
 
@@ -281,6 +263,7 @@ describe("withEntityEditor", () => {
       id: 1,
       title: "New title",
       alias: "updated",
+      __typename: "Example",
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes #275 

This was caused by the optimistic update setting the displayName to an empty string. To resolve this we need access to the unfiltered entity which was not provided by `withEntityEditor`. So `withEntityEditor` has been changed to no longer filter the entity and to allow the mutators (e.g. `withUpdatePage`) to filter down the entity as they choose.

### How to review 
1. On master, update a field in page. See that the display name in the side bar flashes
2. See that this doesn't happen in this branch.
