### PR TITLE
Add default metadata for business surveys

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -41,6 +41,7 @@ const addPrefix = require("../../utils/addPrefix");
 const { DATE, DATE_RANGE } = require("../../constants/answerTypes");
 const { DATE: METADATA_DATE } = require("../../constants/metadataTypes");
 const { ROUTING_ANSWER_TYPES } = require("../../constants/routingAnswerTypes");
+const { BUSINESS } = require("../../constants/questionnaireTypes");
 const {
   createQuestionnaire,
   saveQuestionnaire,
@@ -48,6 +49,10 @@ const {
   getQuestionnaire,
   listQuestionnaires,
 } = require("../../utils/datastore");
+
+const {
+  defaultBusinessSurveyMetadata,
+} = require("../../utils/defaultMetadata");
 
 const { VALIDATION_TYPES } = require("../../constants/validationTypes");
 
@@ -161,7 +166,7 @@ const createNewQuestionnaire = input => ({
   navigation: false,
   surveyId: "",
   createdAt: new Date(),
-  metadata: [],
+  metadata: input.type === BUSINESS ? defaultBusinessSurveyMetadata : [],
   sections: [createSection()],
   summary: false,
   version: currentVersion,

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -1,6 +1,6 @@
 const { last } = require("lodash");
 
-const { SOCIAL } = require("../../constants/questionnaireTypes");
+const { SOCIAL, BUSINESS } = require("../../constants/questionnaireTypes");
 
 const {
   buildQuestionnaire,
@@ -54,6 +54,26 @@ describe("questionnaire", () => {
       );
 
       expect(questionnaire.sections[0].pages[0]).not.toBeNull();
+    });
+
+    it("should create a questionnaire with no metadata when creating a social survey", async () => {
+      const result = await executeQuery(
+        createQuestionnaireMutation,
+        { input: config },
+        {}
+      );
+      const questionnaire = result.data.createQuestionnaire;
+      expect(questionnaire.metadata).toEqual([]);
+    });
+
+    it("should create a questionnaire with default business metadata when creating a business survey", async () => {
+      const result = await executeQuery(
+        createQuestionnaireMutation,
+        { input: { ...config, type: BUSINESS } },
+        {}
+      );
+      const questionnaire = result.data.createQuestionnaire;
+      expect(questionnaire.metadata).toHaveLength(6);
     });
   });
 

--- a/eq-author-api/utils/defaultMetadata.js
+++ b/eq-author-api/utils/defaultMetadata.js
@@ -1,3 +1,7 @@
+const uuid = require("uuid");
+const { includes } = require("lodash");
+const { filter, flow, map } = require("lodash/fp");
+
 const defaultTypeValueNames = {
   Date: "dateValue",
   Text: "textValue",
@@ -93,8 +97,29 @@ const defaultValues = [
   },
 ];
 
+const defaultBusinessSurveyMetadata = flow(
+  filter(({ key }) =>
+    includes(
+      [
+        "ru_name",
+        "trad_as",
+        "ref_p_start_date",
+        "ref_p_end_date",
+        "period_id",
+        "employmentDate",
+      ],
+      key
+    )
+  ),
+  map(metadata => ({
+    id: uuid.v4(),
+    ...metadata,
+  }))
+)(defaultValues);
+
 Object.assign(module.exports, {
   defaultTypeValueNames,
   defaultTypeValues,
   defaultValues,
+  defaultBusinessSurveyMetadata,
 });

--- a/eq-author/cypress/builders/questionnaire.js
+++ b/eq-author/cypress/builders/questionnaire.js
@@ -8,7 +8,7 @@ const updateDetails = ({ title }) => {
       .clear()
       .type(title);
     cy.get("label[for='navigation']").click();
-    cy.get(testId("select-questionnaire-type")).select("Business");
+    cy.get(testId("select-questionnaire-type")).select("Social");
 
     cy.get("form").submit();
   });

--- a/eq-author/cypress/fixtures/publisher.json
+++ b/eq-author/cypress/fixtures/publisher.json
@@ -91,7 +91,7 @@
       ]
     }
   ],
-  "theme": "default",
+  "theme": "social",
   "legal_basis": "StatisticsOfTradeAct",
   "navigation": {
     "visible": true

--- a/eq-author/cypress/utils/index.js
+++ b/eq-author/cypress/utils/index.js
@@ -46,7 +46,7 @@ export function setQuestionnaireSettings({ title, type, shortTitle }) {
 
 export const addQuestionnaire = title => {
   cy.get(testId("create-questionnaire")).click();
-  setQuestionnaireSettings({ title, type: "Business" });
+  setQuestionnaireSettings({ title, type: "Social" });
 };
 
 export const addSection = (initialNumberOfSections = 1) => {


### PR DESCRIPTION
### What is the context of this PR?
- Adds default metadata to business surveys

### How to review 
- Ensure tests pass
- Ensure default metadata specified in https://trello.com/c/9KPOTWcN/928-default-metadata-2 is set when creating a business survey
- Ensure there isn't any metadata set when creating a social survey