### PR TITLE
475 error when adding new question page

### DIFF
--- a/eq-author/cypress/integration/authenticated/builder_spec.js
+++ b/eq-author/cypress/integration/authenticated/builder_spec.js
@@ -96,6 +96,10 @@ describe("builder", () => {
       });
 
     cy.get(testId("page-item")).should("have.length", 2);
+
+    // Add page via Add Question Page on question design
+    cy.get(testId("btn-add-page")).click();
+    cy.get(testId("page-item")).should("have.length", 3);
   });
 
   it("Can edit question guidance", () => {

--- a/eq-author/src/App/questionPage/Design/index.js
+++ b/eq-author/src/App/questionPage/Design/index.js
@@ -95,12 +95,9 @@ export class UnwrappedQuestionPageRoute extends React.Component {
   };
 
   handleAddPage = () => {
-    const {
-      match: { params },
-      page,
-    } = this.props;
+    const { page } = this.props;
 
-    this.props.onAddPage(params.sectionId, page.position + 1);
+    this.props.onAddPage(page.section.id, page.position + 1);
   };
 
   handleAddAnswer = answerType => {
@@ -111,9 +108,8 @@ export class UnwrappedQuestionPageRoute extends React.Component {
 
   handleDuplicatePage = e => {
     e.preventDefault();
-    const { match, onDuplicatePage, page } = this.props;
+    const { onDuplicatePage, page } = this.props;
     onDuplicatePage({
-      sectionId: match.params.sectionId,
       pageId: page.id,
       position: page.position + 1,
     });

--- a/eq-author/src/App/questionPage/Design/index.test.js
+++ b/eq-author/src/App/questionPage/Design/index.test.js
@@ -11,6 +11,7 @@ import createRouterContext from "react-router-test-context";
 import PropTypes from "prop-types";
 
 import movePageQuery from "graphql/getQuestionnaire.graphql";
+import { byTestAttr } from "tests/utils/selectors";
 
 describe("QuestionPageRoute", () => {
   let store,
@@ -438,10 +439,31 @@ describe("QuestionPageRoute", () => {
         .simulate("click");
 
       expect(mockHandlers.onDuplicatePage).toHaveBeenCalledWith({
-        sectionId: match.params.sectionId,
         pageId: page.id,
         position: parseInt(page.position, 10) + 1,
       });
+    });
+
+    it("should add new answer page to correct section", () => {
+      const wrapper = render(
+        {
+          loading: false,
+          match,
+          page,
+          ...mockHandlers,
+        },
+        mount
+      );
+
+      wrapper
+        .find(byTestAttr("btn-add-page"))
+        .first()
+        .simulate("click");
+
+      expect(mockHandlers.onAddPage).toHaveBeenCalledWith(
+        page.section.id,
+        parseInt(page.position, 10) + 1
+      );
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
'Add Question Page' button at bottom of design page produced error. New tests added to cover Add Question Page button click.

### How to review 
1. On Master, Create new questionnaire and click 'Add Question Page' button beneath form design. Error occurs
2. On PR branch, repeat above step
3. Tests pass
