### PR TITLE
Import graphql output to dynamo

### DIFF
--- a/eq-author-api/migrations/addOptionalFieldProperties.js
+++ b/eq-author-api/migrations/addOptionalFieldProperties.js
@@ -4,21 +4,13 @@ const { isEmpty } = require("lodash");
 module.exports = function addOptionalFieldProperties(questionnaire) {
   questionnaire.sections.forEach(section => {
     section.pages.forEach(page => {
-      if (!isEmpty(page.description)) {
-        page.descriptionEnabled = true;
-      }
-      if (!isEmpty(page.guidance)) {
-        page.guidanceEnabled = true;
-      }
-      if (!isEmpty(page.definitionLabel) || !isEmpty(page.definitionContent)) {
-        page.definitionEnabled = true;
-      }
-      if (
+      page.descriptionEnabled = !isEmpty(page.description);
+      page.guidanceEnabled = !isEmpty(page.guidance);
+      page.definitionEnabled =
+        !isEmpty(page.definitionLabel) || !isEmpty(page.definitionContent);
+      page.additionalInfoEnabled =
         !isEmpty(page.additionalInfoLabel) ||
-        !isEmpty(page.additionalInfoContent)
-      ) {
-        page.additionalInfoEnabled = true;
-      }
+        !isEmpty(page.additionalInfoContent);
     });
   });
 

--- a/eq-author-api/migrations/addOptionalFieldProperties.test.js
+++ b/eq-author-api/migrations/addOptionalFieldProperties.test.js
@@ -18,62 +18,62 @@ describe("addOptionalFieldProperties", () => {
   it("should enable optional field when description has content", () => {
     page.description = "foo";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).descriptionEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).descriptionEnabled).toEqual(true);
   });
 
   it("should not enable optional field when description has no content", () => {
     page.description = "";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).descriptionEnabled).toBeFalsy();
+    expect(get(result, firstPagePath).descriptionEnabled).toEqual(false);
   });
 
   it("should enable optional field when guidance has content", () => {
     page.guidance = "foo";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).guidanceEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).guidanceEnabled).toEqual(true);
   });
 
   it("should not enable optional field when guidance has no content", () => {
     page.guidance = "";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).guidanceEnabled).toBeFalsy();
+    expect(get(result, firstPagePath).guidanceEnabled).toEqual(false);
   });
 
   it("should enable optional field when definition label has content", () => {
     page.definitionLabel = "foo";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).definitionEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).definitionEnabled).toEqual(true);
   });
 
   it("should enable optional field when definition content has content", () => {
     page.definitionContent = "bar";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).definitionEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).definitionEnabled).toEqual(true);
   });
 
   it("should not enable optional field when definition has no content", () => {
     page.definitionLabel = "";
     page.definitionContent = "";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).definitionEnabled).toBeFalsy();
+    expect(get(result, firstPagePath).definitionEnabled).toEqual(false);
   });
 
   it("should enable optional field when additionalInfo label has content", () => {
     page.additionalInfoLabel = "foo";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).additionalInfoEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).additionalInfoEnabled).toEqual(true);
   });
 
   it("should enable optional field when additionalInfo content has content", () => {
     page.additionalInfoContent = "bar";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).additionalInfoEnabled).toBeTruthy();
+    expect(get(result, firstPagePath).additionalInfoEnabled).toEqual(true);
   });
 
   it("should not enable optional field when additionalInfo has no content", () => {
     page.additionalInfoLabel = "";
     page.additionalInfoContent = "";
     const result = addOptionalFieldProperties(questionnaire);
-    expect(get(result, firstPagePath).additionalInfoEnabled).toBeFalsy();
+    expect(get(result, firstPagePath).additionalInfoEnabled).toEqual(false);
   });
 });

--- a/eq-author-api/scripts/import-json-to-dynamo.js
+++ b/eq-author-api/scripts/import-json-to-dynamo.js
@@ -12,8 +12,96 @@ const importQuestionnaire = async contents => {
   return createQuestionnaire({ ...contents, id: contents.id });
 };
 
+const transformDestination = ({ section, page, ...rest }) => ({
+  sectionId: section ? section.id : section,
+  pageId: page ? page.id : page,
+  ...rest,
+});
+
+const transformBinaryExpression = binaryExpression => {
+  const { left, right, ...rest } = binaryExpression;
+  if (left && left.__typename) {
+    if (
+      left.__typename === "BasicAnswer" ||
+      left.__typename === "MultipleChoiceAnswer"
+    ) {
+      left.type = "Answer";
+      left.answerId = left.id;
+    }
+  }
+
+  if (right && right.__typename) {
+    if (right.__typename === "CustomValue2") {
+      right.type = "Custom";
+      right.customValue = { number: right.number };
+    }
+    if (right.__typename === "SelectedOptions2") {
+      right.type = "SelectedOptions";
+      right.optionIds = right.options.map(o => o.id);
+    }
+  }
+
+  return {
+    ...rest,
+    left,
+    right,
+  };
+};
+
+const transformRule = rule => {
+  rule.destination = transformDestination(rule.destination);
+  rule.expressionGroup.expressions = rule.expressionGroup.expressions.map(
+    transformBinaryExpression
+  );
+  return rule;
+};
+
+const transformRouting = routing => {
+  if (!routing) {
+    return routing;
+  }
+  routing.else = transformDestination(routing.else);
+  routing.rules = routing.rules.map(transformRule);
+  return routing;
+};
+
+const transformValidation = ({ metadata, previousAnswer, ...rest }) => ({
+  previousAnswer: previousAnswer ? previousAnswer.id : previousAnswer,
+  metadata: metadata ? metadata.id : metadata,
+  ...rest,
+});
+
+const transformAnswer = answer => {
+  if (answer.childAnswers) {
+    answer.secondaryLabel = answer.childAnswers[1].label;
+  }
+  answer.validation = Object.keys(answer.validation || {}).reduce(
+    (validations, key) => ({
+      ...validations,
+      [key]: transformValidation(answer.validation[key]),
+    }),
+    {}
+  );
+  return answer;
+};
+
+const transformPage = page => ({
+  ...page,
+  routing: transformRouting(page.routing),
+  answers: page.answers.map(transformAnswer),
+});
+
+const transformSection = section => ({
+  ...section,
+  pages: section.pages.map(transformPage),
+});
+
 const loadQuestionnaireJSON = async path => {
   const contents = JSON.parse(fs.readFileSync(path, "utf-8"));
+  contents.type = "Business";
+  contents.createdBy = contents.createdBy.name || "Unknown";
+  contents.version = 0;
+  contents.sections = contents.sections.map(transformSection);
   await importQuestionnaire(contents);
 };
 


### PR DESCRIPTION
### What is the context of this PR?
This takes graphql data output from the [data export](https://github.com/ONSdigital/eq-author-data-export/pull/2) and transforms it so that it can be imported.

### How to review 
1. Run the data export https://github.com/ONSdigital/eq-author-data-export/pull/2
2. Copy the folder to `author-api/data`
3. Run the import script.
4. See the publisher output is the same as preprod.
