### PR TITLE
Added error boundary to handle 404 errors

### DIFF
--- a/eq-author/cypress/integration/authenticated/errors_spec.js
+++ b/eq-author/cypress/integration/authenticated/errors_spec.js
@@ -1,0 +1,23 @@
+import { testId } from "../../utils";
+describe("errors", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.login();
+  });
+
+  it("displays page not found page if navigating to non-existant questionnaire", done => {
+    cy.on("uncaught:exception", () => {
+      // return false to prevent the error from
+      // failing this test
+      return false;
+    });
+
+    cy.visit("/#/q/not-existant-id");
+
+    cy.get(testId("not-found-page-title"))
+      .should("have.length", 1)
+      .then(() => {
+        done();
+      });
+  });
+});

--- a/eq-author/src/App/ErrorBoundary/index.js
+++ b/eq-author/src/App/ErrorBoundary/index.js
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from "prop-types";
+import NotFound from "App/NotFoundPage";
+import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+
+export default class ErrorBoundary extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired
+  };
+
+  state = { error: false };
+
+  componentDidCatch(error) {
+    this.setState({ error });
+  }
+
+  render() {
+    if (this.state.error.message === ERR_PAGE_NOT_FOUND) {
+      // You can render any custom fallback UI
+      return <NotFound />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/eq-author/src/App/ErrorBoundary/index.test.js
+++ b/eq-author/src/App/ErrorBoundary/index.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import ErrorBoundary from "./";
+import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+import NotFound from "App/NotFoundPage";
+
+const MockComponent = () => null;
+
+describe("ErrorBoundary", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <ErrorBoundary>
+        <MockComponent />
+      </ErrorBoundary>
+    );
+  });
+
+  it("should render the child component by default", () => {
+    expect(wrapper.find(MockComponent)).toHaveLength(1);
+  });
+
+  it("should display not found page when ERR_PAGE_NOT_FOUND error thrown", () => {
+    const error = new Error(ERR_PAGE_NOT_FOUND);
+    wrapper.find(MockComponent).simulateError(error);
+    expect(wrapper.instance().render()).toMatchObject(<NotFound />);
+  });
+});

--- a/eq-author/src/App/NotFoundPage/__snapshots__/NotFoundPage.test.js.snap
+++ b/eq-author/src/App/NotFoundPage/__snapshots__/NotFoundPage.test.js.snap
@@ -15,7 +15,9 @@ exports[`NotFoundPage should render 1`] = `
       >
         <NotFoundPage__CenteredPane>
           <NotFoundPage__Pencil />
-          <NotFoundPage__Title>
+          <NotFoundPage__Title
+            data-test="not-found-page-title"
+          >
             404 – Sorry, the page you were looking for was not found.
           </NotFoundPage__Title>
           <Link__StyledLink

--- a/eq-author/src/App/NotFoundPage/index.js
+++ b/eq-author/src/App/NotFoundPage/index.js
@@ -36,7 +36,7 @@ const NotFound = () => {
           <Column cols={6} offset={3}>
             <CenteredPane>
               <Pencil />
-              <Title>
+              <Title data-test="not-found-page-title">
                 404 – Sorry, the page you were looking for was not found.
               </Title>
               <Link href="/">Back to home</Link>

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -29,6 +29,8 @@ import { raiseToast } from "redux/toast/actions";
 import withCreateQuestionConfirmation from "./withCreateQuestionConfirmation";
 import NavigationSidebar from "./NavigationSidebar";
 
+import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+
 export class UnwrappedQuestionnaireDesignPage extends Component {
   static propTypes = {
     onAddQuestionPage: PropTypes.func.isRequired,
@@ -154,6 +156,10 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
       data: { questionnaire },
       location,
     } = this.props;
+
+    if (!loading && !questionnaire) {
+      throw new Error(ERR_PAGE_NOT_FOUND);
+    }
 
     return (
       <BaseLayout questionnaire={questionnaire}>

--- a/eq-author/src/App/QuestionnaireDesignPage/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { shallow } from "enzyme";
 
 import { SECTION, PAGE, QUESTION_CONFIRMATION } from "constants/entities";
+import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
 
 import NavigationSidebar from "./NavigationSidebar";
 
@@ -207,10 +208,26 @@ describe("QuestionnaireDesignPage", () => {
     });
 
     it("should disable adding question confirmation whilst loading", () => {
-      wrapper.setProps({ data: {} });
+      wrapper.setProps({
+        loading: true,
+        data: {} 
+      });
       expect(wrapper.find(NavigationSidebar).props()).toMatchObject({
         canAddQuestionConfirmation: false,
       });
+    });
+
+    it("should trigger PAGE_NOT_FOUND error if no question data available after loading finished", () => {
+      
+      const throwWrapper = () => {
+        wrapper.setProps({
+          loading: false,
+          data: {}
+        });  
+      }
+
+      expect(throwWrapper).toThrow( new Error(ERR_PAGE_NOT_FOUND));
+
     });
   });
 });

--- a/eq-author/src/App/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/__snapshots__/index.test.js.snap
@@ -23,38 +23,40 @@ exports[`containers/AppContainer Routes should render  1`] = `
     }
   }
 >
-  <Switch>
-    <Route
-      component={[Function]}
-      exact={true}
-      path="/sign-in"
-    />
-    <PrivateRoute
-      component={[Function]}
-      exact={true}
-      isSignedIn={true}
-      path="/"
-    />
-    <RedirectRoute
-      from="/questionnaire/:questionnaireId/design/:sectionId/:pageId"
-      to="/q/:questionnaireId/page/:pageId/design"
-    />
-    <RedirectRoute
-      from="/questionnaire/:questionnaireId/design/:sectionId"
-      to="/q/:questionnaireId/section/:sectionId/design"
-    />
-    <PrivateRoute
-      component={[Function]}
-      exact={false}
-      isSignedIn={true}
-      path="/q/:questionnaireId/:entityName?/:entityId?/:tab?"
-    />
-    <Route
-      component={[Function]}
-      exact={true}
-      path="*"
-    />
-  </Switch>
+  <ErrorBoundary>
+    <Switch>
+      <Route
+        component={[Function]}
+        exact={true}
+        path="/sign-in"
+      />
+      <PrivateRoute
+        component={[Function]}
+        exact={true}
+        isSignedIn={true}
+        path="/"
+      />
+      <RedirectRoute
+        from="/questionnaire/:questionnaireId/design/:sectionId/:pageId"
+        to="/q/:questionnaireId/page/:pageId/design"
+      />
+      <RedirectRoute
+        from="/questionnaire/:questionnaireId/design/:sectionId"
+        to="/q/:questionnaireId/section/:sectionId/design"
+      />
+      <PrivateRoute
+        component={[Function]}
+        exact={false}
+        isSignedIn={true}
+        path="/q/:questionnaireId/:entityName?/:entityId?/:tab?"
+      />
+      <Route
+        component={[Function]}
+        exact={true}
+        path="*"
+      />
+    </Switch>
+  </ErrorBoundary>
 </Router>
 `;
 

--- a/eq-author/src/App/index.js
+++ b/eq-author/src/App/index.js
@@ -18,33 +18,36 @@ import QuestionnairesPage from "./QuestionnairesPage";
 import SignInPage from "./SignInPage";
 import QuestionnaireDesignPage from "./QuestionnaireDesignPage";
 import NotFoundPage from "./NotFoundPage";
+import ErrorBoundary from "./ErrorBoundary";
 
 export const Routes = ({ isSignedIn, ...otherProps }) => (
   <Router {...otherProps}>
-    <Switch>
-      <Route path={RoutePaths.SIGN_IN} component={SignInPage} exact />
-      <PrivateRoute
-        path={RoutePaths.HOME}
-        component={QuestionnairesPage}
-        isSignedIn={isSignedIn}
-        exact
-      />
-      <RedirectRoute
-        from="/questionnaire/:questionnaireId/design/:sectionId/:pageId"
-        to={"/q/:questionnaireId/page/:pageId/design"}
-      />
-      <RedirectRoute
-        from="/questionnaire/:questionnaireId/design/:sectionId"
-        to={"/q/:questionnaireId/section/:sectionId/design"}
-      />
-      <PrivateRoute
-        path={RoutePaths.QUESTIONNAIRE}
-        exact={false}
-        component={QuestionnaireDesignPage}
-        isSignedIn={isSignedIn}
-      />
-      <Route path="*" component={NotFoundPage} exact />
-    </Switch>
+    <ErrorBoundary>
+      <Switch>
+        <Route path={RoutePaths.SIGN_IN} component={SignInPage} exact />
+        <PrivateRoute
+          path={RoutePaths.HOME}
+          component={QuestionnairesPage}
+          isSignedIn={isSignedIn}
+          exact
+        />
+        <RedirectRoute
+          from="/questionnaire/:questionnaireId/design/:sectionId/:pageId"
+          to={"/q/:questionnaireId/page/:pageId/design"}
+        />
+        <RedirectRoute
+          from="/questionnaire/:questionnaireId/design/:sectionId"
+          to={"/q/:questionnaireId/section/:sectionId/design"}
+        />
+        <PrivateRoute
+          path={RoutePaths.QUESTIONNAIRE}
+          exact={false}
+          component={QuestionnaireDesignPage}
+          isSignedIn={isSignedIn}
+        />
+        <Route path="*" component={NotFoundPage} exact />
+      </Switch>
+    </ErrorBoundary>
   </Router>
 );
 

--- a/eq-author/src/constants/error-codes.js
+++ b/eq-author/src/constants/error-codes.js
@@ -1,0 +1,1 @@
+export const ERR_PAGE_NOT_FOUND = "PAGE_NOT_FOUND";


### PR DESCRIPTION
### What is the context of this PR?
Display Page Not Found page when navigating to non existant questionnaire in URL. URL is not to be changed.

### How to review 
1. Navigate to non existant questionnaire e.g. /#/q/non-existant
2. Page not found will display. nb: in Dev, the triggered JS error will display after a few seconds. The error is dismissable and only displayed in dev - this is a by design in React. see https://github.com/facebook/create-react-app/issues/3627
3. Ensure unit test passes
4. Ensure new Error_spec integration test passes. 
