### PR TITLE
Questionnaires should be sorted by createdAt

### DIFF
--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -1,4 +1,4 @@
-const { last } = require("lodash");
+const { last, findIndex } = require("lodash");
 
 const { SOCIAL, BUSINESS } = require("../../constants/questionnaireTypes");
 
@@ -12,6 +12,7 @@ const {
   queryQuestionnaire,
   updateQuestionnaire,
   deleteQuestionnaire,
+  listQuestionnaires,
 } = require("../../tests/utils/questionnaireBuilder/questionnaire");
 
 describe("questionnaire", () => {
@@ -180,6 +181,24 @@ describe("questionnaire", () => {
       expect(last(queriedQuestionnaire.metadata).id).toEqual(
         last(questionnaire.metadata).id
       );
+    });
+  });
+
+  describe("list questionnaires", () => {
+    it("should order then newest to oldest", async () => {
+      const oldestQuestionnaire = await buildQuestionnaire({});
+      const newestQuestionnaire = await buildQuestionnaire({});
+
+      const questionnnaires = await listQuestionnaires();
+      const oldestIndex = findIndex(
+        questionnnaires,
+        q => q.id === oldestQuestionnaire.id
+      );
+      const newestIndex = findIndex(
+        questionnnaires,
+        q => q.id === newestQuestionnaire.id
+      );
+      expect(oldestIndex > newestIndex).toEqual(true);
     });
   });
 

--- a/eq-author-api/tests/utils/questionnaireBuilder/questionnaire/index.js
+++ b/eq-author-api/tests/utils/questionnaireBuilder/questionnaire/index.js
@@ -4,4 +4,5 @@ module.exports = {
   ...require("./duplicateQuestionnaire"),
   ...require("./updateQuestionnaire"),
   ...require("./queryQuestionnaire"),
+  ...require("./listQuestionnaires"),
 };

--- a/eq-author-api/tests/utils/questionnaireBuilder/questionnaire/listQuestionnaires.js
+++ b/eq-author-api/tests/utils/questionnaireBuilder/questionnaire/listQuestionnaires.js
@@ -1,0 +1,19 @@
+const executeQuery = require("../../executeQuery");
+
+const listQuestionnairesQuery = `
+  query ListQuestionnaires {
+    questionnaires {
+      id
+    }
+  }
+`;
+
+const listQuestionnaires = async () => {
+  const result = await executeQuery(listQuestionnairesQuery);
+  return result.data.questionnaires;
+};
+
+module.exports = {
+  listQuestionnaires,
+  listQuestionnairesQuery,
+};

--- a/eq-author-api/utils/datastoreDynamo.js
+++ b/eq-author-api/utils/datastoreDynamo.js
@@ -131,6 +131,7 @@ const listQuestionnaires = () => {
         if (err) {
           reject(err);
         }
+        questionnaires.sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
         resolve(questionnaires);
       });
   });


### PR DESCRIPTION
### What is the context of this PR?
This ensures that the questionnaires are sorted by createdAt from newest to oldest

### How to review 
1. Import the data and see that against master they are order in a seemingly random order
2. See that they are sorted by createdAt descending after this PR
