### PR TITLE
Reduce what we return in a scan

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -1,4 +1,5 @@
 const dynamoose = require("dynamoose");
+const { pick } = require("lodash/fp");
 
 let throughput = "ON_DEMAND";
 let questionnanaireTableName = "author-questionnaires";
@@ -30,35 +31,6 @@ const baseQuestionnaireSchema = {
   createdBy: {
     type: String,
   },
-  version: {
-    type: Number,
-  },
-  description: {
-    type: String,
-  },
-  legalBasis: {
-    type: String,
-  },
-  navigation: {
-    type: Boolean,
-  },
-  surveyId: {
-    type: String,
-  },
-  theme: {
-    type: String,
-  },
-  summary: {
-    type: Boolean,
-  },
-  sections: {
-    type: Array,
-    required: true,
-  },
-  metadata: {
-    type: Array,
-    required: true,
-  },
   createdAt: {
     type: Date,
     required: true,
@@ -85,9 +57,41 @@ const questionnanaireSchema = new dynamoose.Schema(
   }
 );
 
+const LIST_FIELDS = [...Object.keys(baseQuestionnaireSchema), "updatedAt"];
+const justListFields = pick(LIST_FIELDS);
+
 const questionnaireVersionsSchema = new dynamoose.Schema(
   {
     ...baseQuestionnaireSchema,
+    version: {
+      type: Number,
+    },
+    description: {
+      type: String,
+    },
+    legalBasis: {
+      type: String,
+    },
+    navigation: {
+      type: Boolean,
+    },
+    surveyId: {
+      type: String,
+    },
+    theme: {
+      type: String,
+    },
+    summary: {
+      type: Boolean,
+    },
+    sections: {
+      type: Array,
+      required: true,
+    },
+    metadata: {
+      type: Array,
+      required: true,
+    },
     updatedAt: {
       type: Date,
       required: true,
@@ -113,4 +117,5 @@ module.exports = {
   QuestionnaireModel,
   QuestionnaireVersionsModel,
   dynamoose,
+  justListFields,
 };


### PR DESCRIPTION
### What is the context of this PR?
The scan was very slow as it was returning all the data in author. So
now instead, we store just the data needed for the listing page in the
list table which will still scan.

Then when we are reading we read all the data from the versions table
and ensure we are reading the latest version by the sort/range key on
the field updatedAt.

This takes a scan of ~160 questionnaires from >2 seconds to 170ms.

### How to review 
1. Ensure all tests pass
2. Ensure that it works locally
3. Ensure that the list table is faster after importing a large number of questionnaires.
