### PR TITLE
Removed the ablity for cypress to record video

### DIFF
--- a/eq-author/scripts/run_tests.sh
+++ b/eq-author/scripts/run_tests.sh
@@ -47,5 +47,5 @@ cypress_config="watchForFileChanges=false,integrationFolder=$integration_folder"
 if [ -z "${CYPRESS_RECORD_KEY-}" ]; then
   CYPRESS_PUBLISHER_URL=http://localhost:19000 CYPRESS_API_URL=http://localhost:14000 yarn cypress run --browser chrome --config "$cypress_config"
 else
-  CYPRESS_PUBLISHER_URL=http://localhost:19000 CYPRESS_API_URL=http://localhost:14000  yarn cypress run --browser electron --record --config "$cypress_config"
+  CYPRESS_PUBLISHER_URL=http://localhost:19000 CYPRESS_API_URL=http://localhost:14000  yarn cypress run --browser electron --config "$cypress_config"
 fi


### PR DESCRIPTION
### What is the context of this PR?
We seem to have reached our maximum available recordings on cypress for the month, this means that all our travis tests are failing. This PR disables the recording of video meaning that the cypress tests should be able to run again. 

This is a short term fix to unblock our travis tests.
 

### How to review 
Travis should not fail.
