### PR TITLE
Fixed piping formatting issue

### DIFF
--- a/eq-author-api/migrations/dropDatatypeFieldFromPipedValues.js
+++ b/eq-author-api/migrations/dropDatatypeFieldFromPipedValues.js
@@ -1,0 +1,41 @@
+const { flatMap, get, set } = require("lodash");
+
+module.exports = function dropDatatypeFieldFromPipedValues(questionnaire) {
+  const regex = /\s?data-type="[^"]*"/g;
+
+  const sections = flatMap(questionnaire.sections, section => section);
+  const pages = flatMap(questionnaire.sections, section =>
+    flatMap(section.pages, page => page)
+  );
+
+  const PIPEABLE_PAGE_FIELDS = [
+    "title",
+    "totalTitle",
+    "description",
+    "guidance",
+    "additionalInfoContent",
+    "confirmation.title",
+  ];
+  const PIPEABLE_SECTION_FIELDS = ["introductionTitle", "introductionContent"];
+
+  const removePipe = (ctx, prop) => {
+    const value = get(ctx, prop);
+    if (typeof value === "string") {
+      set(ctx, prop, value.replace(regex, ""));
+    }
+  };
+
+  pages.forEach(page => {
+    PIPEABLE_PAGE_FIELDS.forEach(prop => {
+      removePipe(page, prop);
+    });
+  });
+
+  sections.forEach(section => {
+    PIPEABLE_SECTION_FIELDS.forEach(prop => {
+      removePipe(section, prop);
+    });
+  });
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/dropDatatypeFieldFromPipedValues.test.js
+++ b/eq-author-api/migrations/dropDatatypeFieldFromPipedValues.test.js
@@ -1,0 +1,101 @@
+const dropDatatypeFieldFromPipedValues = require("./dropDatatypeFieldFromPipedValues.js");
+
+describe("dropDatatypeFieldFromPipedValues", () => {
+  let questionnaire;
+  beforeEach(() => {
+    questionnaire = {
+      sections: [
+        {
+          randomNum: 100,
+          introductionTitle:
+            '<p>Intro content <span data-piped="answers" data-id="a06d223f-667a-45d4-85ce-22a9d8ff07d8" data-type="Currency">[Revenue 2018]</span></p>',
+          introductionContent:
+            '<p>Section 2 intro <span data-piped="answers"data-id="a06d223f-667a-45d4-85ce-22a9d8ff07d8"data-type="Currency">[Revenue 2018]</span></p>',
+          pages: [
+            {
+              title:
+                '<p>How much of <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588"data-type="Currency">[Revenue 2018]</span> was sales?</p>',
+            },
+          ],
+        },
+        {
+          pages: [
+            {
+              randomBool: true,
+              title:
+                '<p>Revenue was <span data-piped="answers"data-id="2dfcd4f9-4d54-4a28-984a-4fbc8ec2ef38"data-type="Currency">[Your revenue]</span> and sold cars was <span data-piped="answers"data-id="88b3930f-5d15-432e-a7e9-04a33f6a5aaa"data-type="Number">[Sold cars]</span></p>',
+              description:
+                '<p>Question description <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588"data-type="Currency">[Revenue 2018]</span></p>',
+              guidance:
+                '<p>Include/exclude <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588"data-type="Currency">[Revenue 2018]</span></p>',
+              additionalInfoContent:
+                '<p>Additional info content <span data-piped="answers"data-id="6e4cb076-a6f9-4f27-90c5-db5f93ffada1"data-type="Currency">[Revenue 2018]</span></p>',
+              confirmation: {
+                title:
+                  '<p>Confirmation question <span data-piped="answers"data-id="9bb4c3ad-3882-45cc-a824-bb832a6e4b34"data-type="Currency">[Sales 2018]</span></p>',
+              },
+            },
+            {
+              totalTitle:
+                '<p>Total title <span data-piped="answers"data-id="6134"data-type="Currency">[Value at start of period]</span></p>',
+            },
+          ],
+        },
+      ],
+    };
+  });
+  it("should remove data-type from span in title", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[0].pages[0].title).toEqual(
+      '<p>How much of <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588">[Revenue 2018]</span> was sales?</p>'
+    );
+  });
+  it("should remove data-type from span in description", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[0].description).toEqual(
+      '<p>Question description <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588">[Revenue 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in guidance", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[0].guidance).toEqual(
+      '<p>Include/exclude <span data-piped="answers"data-id="b4a52321-b404-473f-a459-c50b57cf1588">[Revenue 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in two piped values", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[0].title).toEqual(
+      '<p>Revenue was <span data-piped="answers"data-id="2dfcd4f9-4d54-4a28-984a-4fbc8ec2ef38">[Your revenue]</span> and sold cars was <span data-piped="answers"data-id="88b3930f-5d15-432e-a7e9-04a33f6a5aaa">[Sold cars]</span></p>'
+    );
+  });
+  it("should remove data-type from span in introductionTitle", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[0].introductionTitle).toEqual(
+      '<p>Intro content <span data-piped="answers" data-id="a06d223f-667a-45d4-85ce-22a9d8ff07d8">[Revenue 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in introductionContent", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[0].introductionContent).toEqual(
+      '<p>Section 2 intro <span data-piped="answers"data-id="a06d223f-667a-45d4-85ce-22a9d8ff07d8">[Revenue 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in additionalInfoContent", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[0].additionalInfoContent).toEqual(
+      '<p>Additional info content <span data-piped="answers"data-id="6e4cb076-a6f9-4f27-90c5-db5f93ffada1">[Revenue 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in confirmation question", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[0].confirmation.title).toEqual(
+      '<p>Confirmation question <span data-piped="answers"data-id="9bb4c3ad-3882-45cc-a824-bb832a6e4b34">[Sales 2018]</span></p>'
+    );
+  });
+  it("should remove data-type from span in summary question", () => {
+    const result = dropDatatypeFieldFromPipedValues(questionnaire);
+    expect(result.sections[1].pages[1].totalTitle).toEqual(
+      '<p>Total title <span data-piped="answers"data-id="6134">[Value at start of period]</span></p>'
+    );
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -3,6 +3,7 @@ const addOptionalFieldProperties = require("./addOptionalFieldProperties");
 const addQuestionnaireType = require("./addQuestionnaireType");
 const updateMetadataValue = require("./updateMetadataValue");
 const addBusinessQuestionnaireIntroduction = require("./addBusinessQuestionnaireIntroduction");
+const dropDatatypeFieldFromPipedValues = require("./dropDatatypeFieldFromPipedValues");
 
 const migrations = [
   addVersion,
@@ -10,6 +11,7 @@ const migrations = [
   addQuestionnaireType,
   updateMetadataValue,
   addBusinessQuestionnaireIntroduction,
+  dropDatatypeFieldFromPipedValues,
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
@@ -276,19 +276,16 @@ describe("components/RichTextEditor", function() {
           id: "1",
           displayName: "answer 1",
           label: "answer 1",
-          type: "TextField",
         },
         {
           id: "2",
           displayName: "answer 2",
           label: "answer 2",
-          type: "TextField",
         },
         {
           id: "3",
           displayName: "answer 3",
           label: "answer 3",
-          type: "TextField",
         },
       ];
 
@@ -306,7 +303,7 @@ describe("components/RichTextEditor", function() {
       });
 
       it("should load labels for piped answers when mounted", () => {
-        const html = `<p><span data-piped="answers" data-id="1" data-type="TextField">[Piped Value]</span> <span data-piped="answers" data-id="2" data-type="TextField">[Piped Value]</span> <span data-piped="metadata" data-id="1">[Piped Value]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="1">[Piped Value]</span> <span data-piped="answers" data-id="2">[Piped Value]</span> <span data-piped="metadata" data-id="1">[Piped Value]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -322,7 +319,6 @@ describe("components/RichTextEditor", function() {
           .addEntity(
             createPipedEntity(createEntity, {
               id: answers[0].id,
-              type: answers[0].type,
               pipingType: "answers",
             }),
             0,
@@ -331,7 +327,6 @@ describe("components/RichTextEditor", function() {
           .addEntity(
             createPipedEntity(createEntity, {
               id: answers[1].id,
-              type: answers[1].type,
               pipingType: "answers",
             }),
             11,
@@ -340,7 +335,6 @@ describe("components/RichTextEditor", function() {
           .addEntity(
             createPipedEntity(createEntity, {
               id: metadata[0].id,
-              type: null,
               pipingType: "metadata",
             }),
             22,
@@ -354,15 +348,13 @@ describe("components/RichTextEditor", function() {
       it("should handle piped values for answers that no longer exist", () => {
         const nonExistentAnswer = {
           id: "4",
-          type: "TextField",
           pipingType: "answers",
         };
         const nonExistentMetadata = {
           id: "2",
-          type: null,
           pipingType: "metadata",
         };
-        const html = `<p><span data-piped="answers" data-id="4" data-type="TextField">[Piped Value]</span> <span data-piped="answers" data-id="2" data-type="TextField">[Piped Value]</span> <span data-piped="metadata" data-id="2">[Piped Value]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="4">[Piped Value]</span> <span data-piped="answers" data-id="2">[Piped Value]</span> <span data-piped="metadata" data-id="2">[Piped Value]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -379,7 +371,6 @@ describe("components/RichTextEditor", function() {
           .addEntity(
             createPipedEntity(createEntity, {
               id: answers[1].id,
-              type: answers[1].type,
               pipingType: "answers",
             }),
             17,
@@ -401,11 +392,10 @@ describe("components/RichTextEditor", function() {
       });
 
       it("should not update piped value text if answer or metadata doesn't have name to display", () => {
-        const html = `<p><span data-piped="answers" data-id="123" data-type="TextField">[Piped Value]</span> <span data-piped="metadata" data-id="456">[Piped Metadata]</span></p>`;
-        const answer = { id: "123", type: "TextField", pipingType: "answers" };
+        const html = `<p><span data-piped="answers" data-id="123">[Piped Value]</span> <span data-piped="metadata" data-id="456">[Piped Metadata]</span></p>`;
+        const answer = { id: "123", pipingType: "answers" };
         const metadataNoAlias = {
           id: "456",
-          type: null,
           pipingType: "metadata",
         };
         fetch = jest.fn(() => Promise.resolve([answer]));
@@ -434,7 +424,6 @@ describe("components/RichTextEditor", function() {
         const answer = {
           id: "123",
           displayName: "FooBar",
-          type: "TextField",
           pipingType: "answers",
         };
 
@@ -479,12 +468,11 @@ describe("components/RichTextEditor", function() {
           displayName: "FooBar",
           label: "from label",
           secondaryLabel: "to label",
-          type: "DateRange",
           pipingType: "answers",
         };
 
         const fetchDateRange = jest.fn(() => Promise.resolve([answer]));
-        const html = `<p><span data-piped="answers" data-id="123" data-type="DateRange">[FooBar]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="123">[FooBar]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -498,25 +486,25 @@ describe("components/RichTextEditor", function() {
         const expected = new Raw()
           .addBlock("[FooBar]")
           .addEntity(
-            createPipedEntity(createEntity, omit(answer, ["displayName", "label", "secondaryLabel"])),
+            createPipedEntity(
+              createEntity,
+              omit(answer, ["displayName", "label", "secondaryLabel"])
+            ),
             0,
             8
           )
           .toRawContentState();
 
         expect(toRaw(wrapper)).toEqual(expected);
-    
       });
 
       it("should ignore answers if no answer pipes given", () => {
-
         const metadata = {
           id: "123",
-          type: null,
           displayName: "FooBar",
           pipingType: "metadata",
         };
-  
+
         const fetch = jest.fn(() => Promise.resolve([]));
         const html = `<p><span data-piped="metadata" data-id="123">[Piped Answer]</span></p>`;
 
@@ -539,7 +527,6 @@ describe("components/RichTextEditor", function() {
           .toRawContentState();
 
         expect(toRaw(wrapper)).toEqual(expected);
-    
       });
     });
   });
@@ -549,7 +536,6 @@ describe("components/RichTextEditor", function() {
       const answer = {
         id: "123",
         label: "pipe",
-        type: "TextField",
         displayName: "FooBar",
         pipingType: "answers",
       };
@@ -559,7 +545,7 @@ describe("components/RichTextEditor", function() {
 
       const { value } = props.onUpdate.mock.calls[0][0];
       expect(value).toEqual(
-        '<p><span data-piped="answers" data-id="123" data-type="TextField">[FooBar]</span></p>'
+        '<p><span data-piped="answers" data-id="123">[FooBar]</span></p>'
       );
     });
   });

--- a/eq-author/src/components/RichTextEditor/entities/PipedValue.js
+++ b/eq-author/src/components/RichTextEditor/entities/PipedValue.js
@@ -22,15 +22,14 @@ const PipedValueDecorator = styled.span`
   white-space: pre;
 `;
 
-const PipedValueSerialized = ({ data: { id, type, text, pipingType } }) => (
-  <span data-piped={pipingType} data-id={id} data-type={type}>
+const PipedValueSerialized = ({ data: { id, text, pipingType } }) => (
+  <span data-piped={pipingType} data-id={id}>
     {text}
   </span>
 );
 
 PipedValueSerialized.propTypes = {
   data: PropTypes.shape({
-    type: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
   }).isRequired,
@@ -46,9 +45,8 @@ export const createPipedEntity = (create, entity) => {
 export const htmlToEntity = (nodeName, node, createEntity) => {
   if (node.hasAttribute && node.hasAttribute("data-piped")) {
     const id = node.getAttribute("data-id");
-    const type = node.getAttribute("data-type");
     const pipingType = node.getAttribute("data-piped");
-    return createPipedEntity(createEntity, { id, type, pipingType });
+    return createPipedEntity(createEntity, { id, pipingType });
   }
 };
 

--- a/eq-author/src/components/RichTextEditor/entities/PipedValue.test.js
+++ b/eq-author/src/components/RichTextEditor/entities/PipedValue.test.js
@@ -82,7 +82,6 @@ describe("PipedValue", () => {
   });
 
   describe("htmlToEntity", () => {
-    const type = "TextField";
     const id = "123";
     const text = "hello world";
     const pipingType = "SomeType";
@@ -94,7 +93,6 @@ describe("PipedValue", () => {
       elem.innerText = text;
       elem.setAttribute("data-piped", pipingType);
       elem.setAttribute("data-id", id);
-      elem.setAttribute("data-type", type);
 
       entity = {};
       createEntity = jest.fn(() => entity);
@@ -110,7 +108,6 @@ describe("PipedValue", () => {
 
       expect(createEntity).toHaveBeenCalledWith(ENTITY_TYPE, "IMMUTABLE", {
         pipingType,
-        type,
         id,
       });
     });

--- a/eq-author/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
@@ -19,7 +19,6 @@ exports[`PipedValue entityToHTML should convert entity to HTML 1`] = `
 <span
   data-id="123"
   data-piped="SomeType"
-  data-type="TextField"
 >
   hello world
 </span>

--- a/eq-publisher/src/eq_schema/Block.test.js
+++ b/eq-publisher/src/eq_schema/Block.test.js
@@ -90,26 +90,24 @@ describe("Block", () => {
 
   describe("piping", () => {
     const createPipeInText = ({
-      id = 123,
-      type = "TextField",
+      id = 1,
       text = "foo",
       pipeType = "answers",
-    } = {}) =>
-      `<span data-piped="${pipeType}" data-id="${id}" data-type="${type}">${text}</span>`;
+    } = {}) => `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
     const createPipeInHtml = ({
-      id = 123,
-      type = "TextField",
+      id = 1,
       text = "foo",
       pipeType = "answers",
     } = {}) =>
-      `<strong><span data-piped="${pipeType}" data-id="${id}" data-type="${type}">${text}</span></strong><ul><li>Some Value</li></ul>`;
+      `<strong><span data-piped="${pipeType}" data-id="${id}">${text}</span></strong><ul><li>Some Value</li></ul>`;
 
     const createContext = (
       metadata = [{ id: "123", type: "Text", key: "my_metadata" }]
     ) => ({
       questionnaireJson: {
         metadata,
+        sections: [{ pages: [{ answers: [{ id: `1`, type: "Text" }] }] }],
       },
     });
 
@@ -121,7 +119,7 @@ describe("Block", () => {
         createContext()
       );
 
-      expect(introBlock.title).toEqual("{{ answers['answer123'] }}");
+      expect(introBlock.title).toEqual("{{ answers['answer1'] }}");
     });
 
     it("should handle piped values in title while stripping html", () => {
@@ -132,7 +130,7 @@ describe("Block", () => {
         createContext()
       );
 
-      expect(introBlock.title).toEqual("{{ answers['answer123'] }}");
+      expect(introBlock.title).toEqual("{{ answers['answer1'] }}");
     });
 
     it("should handle piped values in description", () => {
@@ -144,7 +142,7 @@ describe("Block", () => {
       );
 
       expect(introBlock.description).toEqual(
-        "<strong>{{ answers['answer123'] }}</strong><ul><li>Some Value</li></ul>"
+        "<strong>{{ answers['answer1'] }}</strong><ul><li>Some Value</li></ul>"
       );
     });
 

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -447,19 +447,15 @@ describe("Question", () => {
   });
 
   describe("piping", () => {
-    const createPipe = ({
-      id = 123,
-      type = "TextField",
-      text = "foo",
-      pipeType = "answers",
-    } = {}) =>
-      `<span data-piped="${pipeType}" data-id="${id}" data-type="${type}">${text}</span>`;
+    const createPipe = ({ id = 1, text = "foo", pipeType = "answers" } = {}) =>
+      `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
     const createContext = (
       metadata = [{ id: "123", type: "Text", key: "my_metadata" }]
     ) => ({
       questionnaireJson: {
         metadata,
+        sections: [{ pages: [{ answers: [{ id: `1`, type: "Text" }] }] }],
       },
     });
 
@@ -471,13 +467,13 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.title).toEqual("{{ answers['answer123'] }}");
+      expect(question.title).toEqual("{{ answers['answer1'] }}");
     });
 
     it("should handle piped values in guidance", () => {
       const question = new Question(
         createQuestionJSON({
-          guidance: `<h2>${createPipe({ pipeType: "metadata" })}</h2>`,
+          guidance: `<h2>${createPipe({ id: 123, pipeType: "metadata" })}</h2>`,
           guidanceEnabled: true,
         }),
         createContext()
@@ -509,9 +505,7 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.description).toEqual(
-        "<h2>{{ answers['answer123'] }}</h2>"
-      );
+      expect(question.description).toEqual("<h2>{{ answers['answer1'] }}</h2>");
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
This is an alternative to <https://github.com/ONSdigital/eq-author-app/pull/312>.

Added a function for retrieving the data type from the answer when publisher processes the questionnaire rather than having the data type stored in \<span\> in the database. This should fix the problem with wrong formatting of answers in publisher. And, there is no longer a need to have the data type stored in both the answer and the \<span\> element. 

This is also done to be consistent as it is the same way that metadata data-type is piped.
```js
retrieve: ({ id }, ctx) => getMetadata(ctx, id.toString()),
```

From
```js
retrieve: element => element,
```
To
```js
retrieve: ({ id }, ctx) => getAnswer(ctx, id.toString()),
```

Tests have been corrected to no longer expect a data-type attribute in the \<span\> element. The tests in `convertPipes.test.js` will test to see if the correct formatting is still being applied.

#### Migration
Added a new migration to remove all data-type fields from questionnaires.

### How to review 
1. Create a new questionnaire and pipe in a value which require formatting, for example currency or number. You can also add a description and a guidance with piped values.
2. Publish survey and see that the correct formatting is applied to the piped value.
3. Check the dynamodb-admin and confirm that the new questionnaire does **not** have a data-type in the \<Span\> element.
