### PR TITLE
Waited for add metadata modal to close on flakey piping_spec test

### DIFF
--- a/eq-author/cypress/builders/metadata.js
+++ b/eq-author/cypress/builders/metadata.js
@@ -24,6 +24,8 @@ export const addMetadata = (metadataKey, type, existingCount = 0) => {
   cy.get("button")
     .contains("Done")
     .click();
+
+  cy.focused().should("have.attr", "data-test", "metadata-btn");
 };
 
 export const deleteFirstMetadata = () => {
@@ -38,4 +40,6 @@ export const deleteFirstMetadata = () => {
   cy.get("button")
     .contains("Done")
     .click();
+
+  cy.focused().should("have.attr", "data-test", "metadata-btn");
 };


### PR DESCRIPTION
### What is the context of this PR?
Piping_spec integration test was intermittently failing after adding metadata. This was due to a timing issue. Cypress clicked the section title but then metadata button became focussed as the modal closed.

### How to review 
1. On master - piping_spec fails about 1 in 4 times
2. On branch - piping_spec doesn't fail
