### PR TITLE
Bug - Flakey cypress test caused by nested modals

### DIFF
--- a/eq-author/src/components/modals/Modal/Modal.test.js
+++ b/eq-author/src/components/modals/Modal/Modal.test.js
@@ -1,15 +1,11 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
+
 import Modal, { CloseButton } from "./";
 
-const createWrapper = (props = {}, render = shallow, children = undefined) => {
-  return render(<Modal {...props}>{children}</Modal>);
-};
-
 describe("components/Modal", () => {
+  jest.useFakeTimers();
   let props;
-  let wrapper;
-  let children;
 
   beforeEach(() => {
     props = {
@@ -19,56 +15,88 @@ describe("components/Modal", () => {
       onClose: jest.fn(),
       icon: "move",
       isOpen: true,
+      children: <p>Modal content</p>,
     };
-
-    children = <p>Modal content</p>;
-
-    wrapper = createWrapper(props, shallow, children);
   });
 
   it("should render its children", () => {
+    const wrapper = shallow(<Modal {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
 
-  describe("closing the Modals", () => {
+  describe("opening the modal", () => {
+    it("should not render the react-modal until it is open", () => {
+      const wrapper = shallow(<Modal {...props} isOpen={false} />);
+      expect(wrapper.find("Modal__StyledModal").exists()).toBe(false);
+    });
+
+    it("should render the react modal when opened", () => {
+      const wrapper = mount(<Modal {...props} isOpen={false} />);
+      wrapper.setProps({ isOpen: true });
+      wrapper.update();
+      expect(wrapper.find("Modal__StyledModal").exists()).toBe(true);
+    });
+  });
+
+  describe("closing the modal", () => {
     it("should handle close on request to close the Modals", () => {
+      const wrapper = shallow(<Modal {...props} />);
       wrapper.find("Modal__StyledModal").simulate("requestClose");
       expect(props.onClose).toHaveBeenCalled();
     });
 
     it("should close if overlay is clicked", () => {
-      wrapper = createWrapper(props, mount, children);
+      const wrapper = mount(<Modal {...props} />);
       wrapper.find(".Overlay").simulate("click");
       expect(props.onClose).toHaveBeenCalled();
     });
 
     it("should close if ESC key is pressed", () => {
-      wrapper = createWrapper(props, mount, children);
+      const wrapper = mount(<Modal {...props} />);
       wrapper.find(".Modal").simulate("keyDown", { keyCode: 27 });
       expect(props.onClose).toHaveBeenCalled();
     });
 
     it("should not close if any other key is pressed", () => {
-      wrapper = createWrapper(props, mount, children);
+      const wrapper = mount(<Modal {...props} />);
       wrapper.find(".Modal").simulate("keyDown", { keyCode: 28 });
       expect(props.onClose).not.toHaveBeenCalled();
     });
 
     it("should close when the close button is clicked", () => {
-      wrapper = createWrapper(props, shallow, children);
+      const wrapper = shallow(<Modal {...props} />);
       wrapper.find(CloseButton).simulate("click");
       expect(props.onClose).toHaveBeenCalled();
     });
 
     it("should close if browser URL changes", () => {
+      shallow(<Modal {...props} />);
       document.dispatchEvent(new HashChangeEvent("hashchange"));
       expect(props.onClose).toHaveBeenCalled();
     });
 
     it("should stop listening for URL changes when unmounted", () => {
+      const wrapper = shallow(<Modal {...props} />);
       wrapper.unmount();
       document.dispatchEvent(new HashChangeEvent("hashchange"));
       expect(props.onClose).toHaveBeenCalledTimes(0);
+    });
+
+    it("should not hide the react modal until after the animation timeout", () => {
+      const wrapper = mount(<Modal {...props} />);
+      wrapper.setProps({ isOpen: false });
+      expect(wrapper.text()).toContain("Modal content");
+      jest.runAllTimers();
+      expect(wrapper.text()).toBe(null);
+    });
+
+    it("should not error if it is unmounted whilst animating out", () => {
+      const wrapper = mount(<Modal {...props} />);
+      wrapper.setProps({ isOpen: false });
+      wrapper.unmount();
+      expect(() => {
+        jest.runAllTimers();
+      }).not.toThrow();
     });
   });
 });

--- a/eq-author/src/components/modals/Modal/index.js
+++ b/eq-author/src/components/modals/Modal/index.js
@@ -5,6 +5,8 @@ import PropTypes from "prop-types";
 import { colors } from "constants/theme";
 import DeleteButton from "components/buttons/DeleteButton";
 
+const ANIMATION_DURATION = 100;
+
 export const CloseButton = styled(DeleteButton).attrs({
   "aria-label": "Close",
   size: "medium",
@@ -51,7 +53,7 @@ const StyledModal = styled(ReactModalAdapter).attrs({
 
     transform: scale(0.8);
     transform-origin: center center;
-    transition: all 100ms ease-in 50ms;
+    transition: all ${ANIMATION_DURATION}ms ease-in 50ms;
     opacity: 0;
 
     &--after-open {
@@ -71,7 +73,7 @@ const StyledModal = styled(ReactModalAdapter).attrs({
     left: 0;
     right: 0;
     bottom: 0;
-    transition: opacity 100ms ease-out;
+    transition: opacity ${ANIMATION_DURATION}ms ease-out;
     display: flex;
     justify-content: center;
     z-index: 9999999;
@@ -100,25 +102,43 @@ class Modal extends React.Component {
     hasCloseButton: true,
   };
 
+  state = {
+    open: this.props.isOpen,
+  };
+
   componentDidMount() {
     document.addEventListener("hashchange", this.props.onClose);
   }
 
   componentWillUnmount() {
     document.removeEventListener("hashchange", this.props.onClose);
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+
+  componentWillUpdate(nextProps) {
+    const isClosing = this.props.isOpen && !nextProps.isOpen;
+    const isOpening = !this.props.isOpen && nextProps.isOpen;
+    if (isClosing) {
+      this.timeoutId = setTimeout(() => {
+        this.setState({ open: false });
+      }, ANIMATION_DURATION);
+    }
+    if (isOpening) {
+      this.setState({ open: true });
+    }
   }
 
   render() {
-    const {
-      children,
-      isOpen,
-      onClose,
-      hasCloseButton,
-      ...otherProps
-    } = this.props;
+    const { children, onClose, hasCloseButton, ...otherProps } = this.props;
+    if (!this.state.open) {
+      return null;
+    }
     return (
       <StyledModal
-        isOpen={isOpen}
+        isOpen={this.state.open}
         onRequestClose={onClose}
         shouldCloseOnOverlayClick
         closeTimeoutMS={300}


### PR DESCRIPTION
### What is the context of this PR?
Nested modals causing focus to not go back to the original modals button.

So this fixes an issue which was causing a flakey cypress test.

With a lot of help from @pricea1 

### Recreation steps
1. Open a validation with the ability to pick previous answers
1. Select previous answer from the pill tabs
1. Switch away from previous answer on the pill tabs (notice the focus is on the validation button)
1. Close the validation modal

Expected: The validation button gets focus
Actual: The window has focus

### Explanation
react-modal (the library we use under the hood for all our modals) has a nice feature that when you close the modal the focus goes back to the button that opened it. 

However, it runs this logic even when you unmount the modal and before it is ever shown. This in itself would not be bad but it uses a static array to store the buttons to return focus to. This means that unmounting the an existing modal (even if it is never shown) the focus returns to the button that last opened a react-modal. react-modal incorrectly equates unmounting and closing which is incorrect.

In the example of the validations - we have the validation modal and a possible modal (previous answer or metadata picker) and as these render react-modals when you switch the pill tabs the modals are unmounted and the focus management kicks in.

### The fix
This changes the way we render react-modal so that we never render a react-modal until it is opened so that it is focus management does not kick in until it closes. This however had a slight knock on effect of losing the animation out timeout so we actually keep it in the DOM long enough for the animation out to run.

### How to review 
1. Ensure you can recreate the issue on master
1. Ensure the issue is resolved in this PR
