### PR TITLE
Allow setting NI theme

### DIFF
--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -346,6 +346,7 @@ enum AnswerType {
 enum Theme {
   default
   census
+  northernireland
 }
 
 type Metadata {

--- a/eq-publisher/src/eq_schema/Questionnaire.js
+++ b/eq-publisher/src/eq_schema/Questionnaire.js
@@ -28,6 +28,7 @@ const DEFAULT_METADATA = [
 
 const SOCIAL_THEME = "social";
 const DEFAULT_THEME = "default";
+const NI_THEME = "northernireland";
 
 const DEFAULT_METADATA_NAMES = DEFAULT_METADATA.map(({ name }) => name);
 
@@ -50,6 +51,9 @@ class Questionnaire {
 
     this.theme =
       questionnaireJson.type === SOCIAL ? SOCIAL_THEME : DEFAULT_THEME;
+
+    this.theme = questionnaireJson.theme === NI_THEME ? NI_THEME : this.theme;
+
     this.legal_basis = this.buildLegalBasis(questionnaireJson.introduction);
     this.navigation = {
       visible: questionnaireJson.navigation,

--- a/eq-publisher/src/eq_schema/Questionnaire.test.js
+++ b/eq-publisher/src/eq_schema/Questionnaire.test.js
@@ -301,4 +301,26 @@ describe("Questionnaire", () => {
       },
     ]);
   });
+
+  it("should allow setting northern ireland theme", () => {
+    const questionnaireJson = createQuestionnaireJSON({
+      theme: "northernireland",
+    });
+
+    expect(new Questionnaire(questionnaireJson)).toHaveProperty(
+      "theme",
+      "northernireland"
+    );
+  });
+
+  it("should allow setting default theme", () => {
+    const questionnaireJson = createQuestionnaireJSON({
+      theme: "default",
+    });
+
+    expect(new Questionnaire(questionnaireJson)).toHaveProperty(
+      "theme",
+      "default"
+    );
+  });
 });

--- a/eq-publisher/src/getQuestionnaire/queries.js
+++ b/eq-publisher/src/getQuestionnaire/queries.js
@@ -155,6 +155,7 @@ exports.getQuestionnaire = `
       title
       description
       type
+      theme
       introduction {
         id
         title


### PR DESCRIPTION
### What is the context of this PR?
Currently there is no way to set a theme other than business and social because the logic in publisher only looks at the questionnaire type to determine the theme.

One of the requirements for nisra is that the theme be set to NI theme.
This PR allows publishing questionnaires that have a theme of "northernireland"

### How to review 
Create a questionnaire.
Change theme to northernireland in the database.
Launch questionnaire.
Questionnaire should have the NI theme and logo
