### PR TITLE
Add opentracing instrumentation to GraphQL API

### DIFF
--- a/eq-author-api/README.md
+++ b/eq-author-api/README.md
@@ -84,3 +84,23 @@ It is possible to retrieve the full questionnaire data by making a `GET` request
 
 When the environment variable `ENABLE_IMPORT` is set to `true` then it exposes `/import` which will take the
 `POST` body and save it to the database. It performs no validation as it does this.
+
+## Instrumentation and tracing
+
+Instrumenting the GraphQL API is useful for troubleshooting errors and to help identify the root cause of slow running queries and mutations.
+
+The Author GraphQL API can be instrumented using [opentracing](https://opentracing.io) via the [apollo-opentracing](https://www.npmjs.com/package/apollo-opentracing) package.
+
+To enable instrumentation and to allow request tracing set the environment variable `ENABLE_OPENTRACING=true`. For convenience the [docker-compose-with-tracing.yml](docker-compose.yml) configuration that has been pre-configured to instrument the API, produce tracing metrics using Prometheus and collect the tracing output using [Jaeger](https://www.npmjs.com/package/jaeger-client).
+
+This configuration is only intended for local development and should not be used for production.
+
+To run the author API with instrumentation and request tracing enabled, simply run:
+
+```
+docker-compose up
+```
+
+Once running, the trace metrics and spans can be viewed by browsing to the Jaeger UI which is exposed on port `16686`.
+
+[http://localhost:16686](http://0.0.0.0:16686)

--- a/eq-author-api/app.js
+++ b/eq-author-api/app.js
@@ -2,9 +2,10 @@ require("dotenv").config();
 
 const logger = require("pino")();
 
-const server = require("./server");
+const { createApp } = require("./server");
 
 const { PORT = 4000 } = process.env;
+const server = createApp();
 
 server.listen(PORT, "0.0.0.0", () => {
   logger.child({ port: PORT }).info("Listening on port");

--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -5,8 +5,10 @@ services:
       context: .
     depends_on:
       - dynamo
+      - jaeger
     links:
       - dynamo
+      - jaeger
     volumes:
       - .:/app
     ports:
@@ -23,6 +25,11 @@ services:
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
       - PUBLISHER_URL=http://localhost:9000/publish/
       - ENABLE_IMPORT=true
+      - JAEGER_SERVICE_NAME=eq_author_api
+      - JAEGER_ENDPOINT=http://jaeger:14268/api/traces
+      - JAEGER_SAMPLER_MANAGER_HOST_PORT=http://jaeger:5778/sampling
+      - JAEGER_SAMPLER_TYPE=probabilistic
+      - JAEGER_SAMPLER_PARAM=1
     entrypoint:
       - yarn
       - start:dev
@@ -30,3 +37,15 @@ services:
     image: amazon/dynamodb-local
     ports:
       - 8050:8000
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.11
+    ports:
+      - 5775/udp
+      - 6831/udp
+      - 6832/udp
+      - 5778
+      - 14250
+      - 14268
+      - 16686:16686
+

--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node app.js",
-    "start:dev": "NODE_ENV=development nodemon --ignore 'data/ migrations/' --inspect=0.0.0.0:5858",
+    "start:dev": "ENABLE_OPENTRACING=true NODE_ENV=development nodemon --ignore 'data/ migrations/' --inspect=0.0.0.0:5858",
     "lint": "eslint .",
     "test": "./scripts/test.sh",
     "test:breakingChanges": "node scripts/checkForBreakingChanges.js",
@@ -13,6 +13,7 @@
     "create-migration": "node scripts/createMigration.js"
   },
   "dependencies": {
+    "apollo-opentracing": "^1.2.4",
     "apollo-server-express": "latest",
     "body-parser": "latest",
     "chalk": "latest",
@@ -30,6 +31,7 @@
     "graphql-tools": "latest",
     "graphql-type-json": "latest",
     "helmet": "latest",
+    "jaeger-client": "^3.15.0",
     "js-yaml": "latest",
     "json-stable-stringify": "latest",
     "json-web-key": "latest",
@@ -39,6 +41,7 @@
     "lodash": "latest",
     "node-jose": "latest",
     "pino-noir": "latest",
+    "prom-client": "^11.3.0",
     "uuid": "latest",
     "wait-on": "latest"
   },

--- a/eq-author-api/tracer.js
+++ b/eq-author-api/tracer.js
@@ -1,0 +1,35 @@
+const {
+  initTracerFromEnv,
+  PrometheusMetricsFactory,
+} = require("jaeger-client");
+const promClient = require("prom-client");
+
+let tracer;
+
+const createTracer = logger => {
+  if (!tracer) {
+    const config = {
+      serviceName: process.env.JAEGER_SERVICE_NAME,
+    };
+
+    const namespace = config.serviceName;
+    const metrics = new PrometheusMetricsFactory(promClient, namespace);
+
+    const options = {
+      tags: {
+        "eq_author_api.version": process.env.EQ_AUTHOR_API_VERSION,
+      },
+      metrics,
+      logger,
+    };
+
+    tracer = initTracerFromEnv(config, options);
+  }
+
+  return tracer;
+};
+
+module.exports = logger => ({
+  localTracer: createTracer(logger),
+  serverTracer: createTracer(logger),
+});

--- a/eq-author-api/tracer.test.js
+++ b/eq-author-api/tracer.test.js
@@ -1,0 +1,55 @@
+const createTracer = require("./tracer");
+
+describe("createTracer", () => {
+  let logger;
+
+  const SERVICE_NAME = "service_name";
+  const API_VERSION = "api_version";
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+    };
+    process.env.JAEGER_SERVICE_NAME = SERVICE_NAME;
+    process.env.EQ_AUTHOR_API_VERSION = API_VERSION;
+  });
+
+  afterAll(() => {
+    delete process.env.JAEGER_SERVICE_NAME;
+    delete process.env.EQ_AUTHOR_API_VERSION;
+  });
+
+  it("should be a function", () => {
+    expect(createTracer).toEqual(expect.any(Function));
+  });
+
+  it("should return a local tracer", () => {
+    expect(createTracer(logger).localTracer).toEqual(expect.any(Object));
+  });
+
+  it("should return a server tracer", () => {
+    expect(createTracer(logger).serverTracer).toEqual(expect.any(Object));
+  });
+
+  it("should reuse the same tracer instance", () => {
+    expect(createTracer(logger).localTracer).toBe(
+      createTracer(logger).serverTracer
+    );
+  });
+
+  it("should set the tracer service name", () => {
+    expect(createTracer(logger).localTracer).toHaveProperty(
+      "_serviceName",
+      SERVICE_NAME
+    );
+  });
+
+  it("should tag the trace with API version number", () => {
+    expect(createTracer(logger).localTracer).toHaveProperty(
+      "_tags",
+      expect.objectContaining({
+        "eq_author_api.version": API_VERSION,
+      })
+    );
+  });
+});

--- a/eq-author-api/yarn.lock
+++ b/eq-author-api/yarn.lock
@@ -562,6 +562,11 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-color@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-color/-/ansi-color-0.2.1.tgz#3e75c037475217544ed763a8db5709fa9ae5bf9a"
+  integrity sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o=
+
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -667,6 +672,13 @@ apollo-link@^1.2.3:
     ts-invariant "^0.3.2"
     tslib "^1.9.3"
     zen-observable-ts "^0.8.18"
+
+apollo-opentracing@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/apollo-opentracing/-/apollo-opentracing-1.2.4.tgz#4deb1d7ff06e541b484f1c6231bd69336c9d79b0"
+  integrity sha512-jDVRLgCZAIf/GRIKT/ZJBcA2p07TJRy5q/QkfOyF/KH+OtvaiWS6Fo54FzBdLFV4DADnPCxmOLjtOIt8txo8HQ==
+  dependencies:
+    graphql-extensions "^0.6.0"
 
 apollo-server-caching@0.4.0:
   version "0.4.0"
@@ -1049,6 +1061,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
   integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bn.js@^4.0.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -1165,6 +1182,15 @@ buffer@4.9.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+bufrw@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bufrw/-/bufrw-1.2.1.tgz#93f222229b4f5f5e2cd559236891407f9853663b"
+  integrity sha1-k/IiIptPX14s1VkjaJFAf5hTZjs=
+  dependencies:
+    ansi-color "^0.2.1"
+    error "^7.0.0"
+    xtend "^4.0.0"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1987,6 +2013,14 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error@7.0.2, error@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/error/-/error-7.0.2.tgz#a5f75fff4d9926126ddac0ea5dc38e689153cb02"
+  integrity sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=
+  dependencies:
+    string-template "~0.2.1"
+    xtend "~4.0.0"
 
 errorhandler@^1.4.3:
   version "1.5.0"
@@ -2958,7 +2992,7 @@ graphql-anywhere@latest:
     apollo-utilities "^1.1.2"
     tslib "^1.9.3"
 
-graphql-extensions@0.6.0:
+graphql-extensions@0.6.0, graphql-extensions@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.6.0.tgz#3ee3aa57fe213f90aec5cd31275f6d04767c6a23"
   integrity sha512-SshzmbD68fHXRv2q3St29olMOxHDLQ5e9TOh+Tz2BYxinrfhjFaPNcEefiK/vF295wW827Y58bdO11Xmhf8J+Q==
@@ -3757,6 +3791,17 @@ iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
+jaeger-client@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.15.0.tgz#01e38937aa161d3118bdd685dd1b1eabab6bcf5e"
+  integrity sha512-0SfuEE7E6XVLhu8th5JG/ACtnIWq4Tad0iSst3+De9HOMSz1RI0Tl1MLXzetudI670rqfCs4m37XCTMRgu8oxg==
+  dependencies:
+    node-int64 "^0.4.0"
+    opentracing "^0.13.0"
+    thriftrw "^3.5.0"
+    uuid "^3.2.1"
+    xorshift "^0.2.0"
+
 jest-changed-files@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.0.0.tgz#c02c09a8cc9ca93f513166bc773741bd39898ff7"
@@ -4524,6 +4569,11 @@ lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+long@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
+  integrity sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8=
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -5109,6 +5159,11 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+opentracing@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.13.0.tgz#6a341442f09d7d866bc11ed03de1e3828e3d6aab"
+  integrity sha1-ajQUQvCdfYZrwR7QPeHjgo49aqs=
+
 opn@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
@@ -5449,6 +5504,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+prom-client@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.3.0.tgz#fe93f360182f1ec1921722efc211a6c0e68e0253"
+  integrity sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==
+  dependencies:
+    tdigest "^0.1.1"
 
 prompts@^2.0.1:
   version "2.0.1"
@@ -6257,6 +6319,11 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
+string-template@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
+  integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -6416,6 +6483,13 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
+
 teeny-request@^3.11.3:
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
@@ -6446,6 +6520,15 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thriftrw@^3.5.0:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/thriftrw/-/thriftrw-3.11.3.tgz#2cef6b4d089b7ba6275198b86582881582907d45"
+  integrity sha512-mnte80Go5MCfYyOQ9nk6SljaEicCXlwLchupHR+/zlx0MKzXwAiyt38CHjLZVvKtoyEzirasXuNYtkEjgghqCw==
+  dependencies:
+    bufrw "^1.2.1"
+    error "7.0.2"
+    long "^2.4.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -6755,7 +6838,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.3.2, uuid@^3.1.0, uuid@^3.3.2, uuid@latest:
+uuid@3.3.2, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@latest:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -6980,7 +7063,12 @@ xmlhttprequest@1.8.0:
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
-xtend@^4.0.1, xtend@~4.0.1:
+xorshift@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
+  integrity sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=
+
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=


### PR DESCRIPTION
### What is the context of this PR?
Added the ability to instrument and trace the GraphQL requests through the API which is useful for identifying and troubleshooting slow performing queries and mutations so we can make more informed decisions about where to make performance improvements.

Added docker-compose and application configuration necessary to instrument the Graphql API using Apollo OpenTracing library.

I have gone with a simple configuration which sees prometheus metrics collected and displayed using the Jaeger tracer library. This is only intended as a configuration to aid local development and should not be considered suitable for production use.

Added separate command for running the API with tracing enabled and added some documentation to the Readme.

### How to review 
- Ensure you have run `docker-compose down` and killed any existing API containers before switching between the two docker-compose configuration files. I have found not doing this can lead to issues starting and stopping the services.
- Run `docker-compose up` inside the API directory.
- Run the front-end as you normally would.
- Perform some actions in the UI e.g. create survey, add question etc.
- Navigate to the Jaeger UI which should be running on http://localhost:16686
- Select the eq_author_api service and view the traces.
- Should see the requests and be able to order them by the longest time and drill into them etc.

We can add additional tags to the traces over time to add additional contextual information to make the traces a bit more useful.
