### PR TITLE
Fix issue with canvas width on smaller screens

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnairesPage/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`components/QuestionnairesPage should not render table whilst data is lo
       permanentScrollBar={true}
     >
       <MainCanvas
-        width="55em"
+        maxWidth="55em"
       >
         <Query
           query={
@@ -211,7 +211,7 @@ exports[`components/QuestionnairesPage should render table when there are questi
       permanentScrollBar={true}
     >
       <MainCanvas
-        width="55em"
+        maxWidth="55em"
       >
         <Query
           query={
@@ -428,7 +428,7 @@ exports[`components/QuestionnairesPage should render when there are no questionn
       permanentScrollBar={true}
     >
       <MainCanvas
-        width="55em"
+        maxWidth="55em"
       >
         <Query
           query={

--- a/eq-author/src/App/page/Design/EditorLayout/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/EditorLayout/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`Editor Layout should render 1`] = `
     >
       <EditorLayout__Margin>
         <MainCanvas
-          width="55em"
+          maxWidth="55em"
         >
           <Connect(UnconnectedSavingIndicator) />
           <withRouter(UnwrappedTabs)

--- a/eq-author/src/components/MainCanvas/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/MainCanvas/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`MainCanvas should render 1`] = `
 .c0 {
-  width: 55em;
+  max-width: 55em;
   margin: 0 auto 1em;
   padding: 0 1em;
   position: relative;
@@ -10,7 +10,6 @@ exports[`MainCanvas should render 1`] = `
 
 <div
   className="c0"
-  width="55em"
 >
   Children
 </div>

--- a/eq-author/src/components/MainCanvas/index.js
+++ b/eq-author/src/components/MainCanvas/index.js
@@ -1,14 +1,14 @@
 import styled from "styled-components";
 
 const MainCanvas = styled.div`
-  width: ${props => props.width};
+  max-width: ${props => props.maxWidth};
   margin: 0 auto 1em;
   padding: 0 1em;
   position: relative;
 `;
 
 MainCanvas.defaultProps = {
-  width: "55em",
+  maxWidth: "55em",
 };
 
 export default MainCanvas;


### PR DESCRIPTION
### What is the context of this PR?
Previous PR on table redesign broke the maincanvas width for smaller screen sizes. Changed the width to say max-width instead of width so it will scale.

### How to review 
Open a new questionnaire and scale the width of the window till you see the maincanvas disappear behind the right panel.
Then pull down the change and check that the issue is fixed.