### PR TITLE
Attempt to fix flakey calculated summary spec

### DIFF
--- a/eq-author/cypress/integration/authenticated/calculated_summary_spec.js
+++ b/eq-author/cypress/integration/authenticated/calculated_summary_spec.js
@@ -200,7 +200,12 @@ describe("calculated summary", () => {
 
     typeIntoDraftEditor(testId("txt-total-title", "testid"), "General total");
 
+    cy.get(testId("saving-indicator")).should("have.length", 0);
+
     cy.get(testId(`${NUMBER}-suggestion`)).click();
+
+    cy.get(testId("remove-answer-button")).should("have.length", 3);
+
     cy.get(testId("preview")).click();
 
     cy.get(testId("page-title")).should("contain", "Hello there");


### PR DESCRIPTION
### What is the context of this PR?
This was failing when going to preview and the total title was not set.
I managed to recreate this locally once and it was due to the answer
shortcut click response containing a blank title. It must have been out
of sync.

So this now waits for the total title to have finished saving by
checking the lack of saving indicator.

### Note
This spec seems to show an error whilst running as it randomly (not sure of the mechanism) loses the token mid way through a test. It is re-using the questionnaire as well and then faking login each time so I wonder if it is going against the grain with the way it is doing this. Seeding the questionnaire but using a separate one for each test seems most appropriate.

### How to review 
1. Ensure this passes for you locally.
2. Ensure this passes successfully in CI at least 10 times. (Count: 0)