### PR TITLE
Improve performance of questionnaire search

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { debounce } from "lodash";
@@ -59,6 +59,10 @@ const Header = ({ onCreateQuestionnaire, onSearchChange, searchTerm }) => {
   const handleModalOpen = () => setIsModalOpen(true);
   const handleModalClose = () => setIsModalOpen(false);
 
+  const onSearchChangeDebounced = useMemo(() => {
+    return debounce(({ value }) => onSearchChange(value), DEBOUNCE_TIMEOUT);
+  }, [onSearchChange]);
+
   return (
     <>
       <Wrapper>
@@ -69,9 +73,7 @@ const Header = ({ onCreateQuestionnaire, onSearchChange, searchTerm }) => {
           <SearchInput
             id="search"
             defaultValue={searchTerm}
-            onChange={({ value }) => {
-              debounce(onSearchChange, DEBOUNCE_TIMEOUT)(value);
-            }}
+            onChange={onSearchChangeDebounced}
           />
         </Search>
 

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import { propType } from "graphql-anywhere";
 import { isEmpty } from "lodash";
@@ -81,13 +81,16 @@ const QuestionnairesView = ({
     return <NoResults onCreateQuestionnaire={onCreateQuestionnaire} />;
   }
 
+  const onSearchChange = useCallback(
+    searchTerm => dispatch({ type: ACTIONS.SEARCH, payload: searchTerm }),
+    [dispatch]
+  );
+
   return (
     <>
       <Header
         onCreateQuestionnaire={onCreateQuestionnaire}
-        onSearchChange={searchTerm =>
-          dispatch({ type: ACTIONS.SEARCH, payload: searchTerm })
-        }
+        onSearchChange={onSearchChange}
         searchTerm={state.searchTerm}
       />
       {isEmpty(state.questionnaires) ? (


### PR DESCRIPTION
### What is the context of this PR?
I noticed that we are actually debouncing the function many times and so we aren't getting the benefit of using it. This PR ensures that it is only created and therefore we actually get the benefits of using it. It is also now reasonable to use when using 4x slow down in Chrome.

### How to review 
1. Set 4x CPU slow down in Chrome and see that the filtering is laggy and sometimes blocks typing
2. Switch to this PR and see that it is improved
