### PR TITLE
Re-added check for window.cypress to allow smoke tests to pass

### DIFF
--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -12,7 +12,8 @@
       var isChrome =
         !!window.chrome &&
         (!!window.chrome.webstore || !!window.chrome.runtime);
-      if (!isChrome) {
+      var isCypress = !!window.Cypress;
+      if (!isChrome && !isCypress) {
         window.location.replace("/unsupported-browser.html");
       }
     </script>


### PR DESCRIPTION
### What is the context of this PR?
Cypress smoke tests broke after removing it from our app due to the removal of the cypress check in the unsupported browser check. This Pr re-adds the check.

### How to review 
Run smoke tests against this pr, they should pass.