### PR TITLE
Netlify fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,18 @@
 [build]
   base    = "eq-author"
   publish = "eq-author/build"
-  command = "yarn build"
+  command = 'sed -i -e "s/AUTHOR_API_URL_PLACEHOLDER/$AUTHOR_API_URL/g" ../netlify.toml && yarn build'
+
+# A basic redirect rule
+[[redirects]]
+  from = "/signIn"
+  to = "AUTHOR_API_URL_PLACEHOLDER/signIn"
+  status = 200
+[[redirects]]
+  from = "/launch"
+  to = "AUTHOR_API_URL_PLACEHOLDER/launch"
+  status = 200
+[[redirects]]
+  from = "/graphql"
+  to = "AUTHOR_API_URL_PLACEHOLDER/graphql"
+  status = 200


### PR DESCRIPTION
The addition of the proxies required in the map user type to table pr broke the netlify deploy as it was not handling the required proxy correctly. This pr adds the proxies needed for netlify to get back up and running.


Test by checking Netlify deploy works.