### PR TITLE
Switch us to using mainline dynamoose now fork merged

### DIFF
--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -23,7 +23,7 @@
     "cors": "latest",
     "deep-map": "^1.5",
     "dotenv": "latest",
-    "dynamoose": "onsdigital/dynamoose#bug-static-original-item",
+    "dynamoose": "latest",
     "express": "latest",
     "express-pino-logger": "latest",
     "firebase-admin": "latest",

--- a/eq-author-api/yarn.lock
+++ b/eq-author-api/yarn.lock
@@ -2073,9 +2073,10 @@ dynamodb-admin@latest:
     lodash "^4.17.11"
     opn "^5.4.0"
 
-dynamoose@onsdigital/dynamoose#bug-static-original-item:
-  version "1.7.2"
-  resolved "https://codeload.github.com/onsdigital/dynamoose/tar.gz/35d4dcff25ce7a9e4b8449d9d784fd673d175f6e"
+dynamoose@latest:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/dynamoose/-/dynamoose-1.8.4.tgz#287c1fd7b8d07a06105ce576d42fa80462b4cf2b"
+  integrity sha512-4nAYymr/nzvnrrCGHtrQdTTWLrSAkehV+h6BITtDjH6bZuPTITmLqOXcsfTWSKYILxh1mPhHRMC9KEtLJC1B/g==
   dependencies:
     "@types/node" "11.11.0"
     aws-sdk "2.395.0"


### PR DESCRIPTION
### What is the context of this PR?
Our dynamoose PR was merged over the weekend. https://github.com/dynamoosejs/dynamoose/pull/623

So it is now released in 1.8.4 so we can happily delete our fork and use the proper release

### How to review 
1. Ensure tests pass
