### PR TITLE
Fix reordering from constantly re-rendering

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/__snapshots__/index.test.js.snap
@@ -1,20 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Answers Editor should render 1`] = `
-<Reorder
-  Transition={[Function]}
-  list={
-    Array [
-      Object {
-        "id": "1",
-      },
-      Object {
-        "id": "2",
-      },
-    ]
-  }
-  onMove={[MockFunction]}
->
-  <Component />
-</Reorder>
+<AnswersEditor__Margin>
+  <Reorder
+    Transition={[Function]}
+    list={
+      Array [
+        Object {
+          "id": "1",
+        },
+        Object {
+          "id": "2",
+        },
+      ]
+    }
+    onMove={[MockFunction]}
+  >
+    <Component />
+  </Reorder>
+</AnswersEditor__Margin>
 `;

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/index.js
@@ -1,12 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { propType } from "graphql-anywhere";
+import styled from "styled-components";
 
 import Reorder from "components/Reorder";
 
 import withMoveAnswer from "./withMoveAnswer";
 import AnswerTransition from "./AnswerTransition";
 import AnswerEditor from "./AnswerEditor";
+
+const Margin = styled.div`
+  margin-top: 3em;
+`;
 
 export const AnswersEditor = ({
   answers,
@@ -19,20 +24,22 @@ export const AnswersEditor = ({
   moveAnswer,
 }) => {
   return (
-    <Reorder list={answers} onMove={moveAnswer} Transition={AnswerTransition}>
-      {(props, answer) => (
-        <AnswerEditor
-          {...props}
-          answer={answer}
-          onUpdate={onUpdate}
-          onAddOption={onAddOption}
-          onAddExclusive={onAddExclusive}
-          onUpdateOption={onUpdateOption}
-          onDeleteOption={onDeleteOption}
-          onDeleteAnswer={onDeleteAnswer}
-        />
-      )}
-    </Reorder>
+    <Margin>
+      <Reorder list={answers} onMove={moveAnswer} Transition={AnswerTransition}>
+        {(props, answer) => (
+          <AnswerEditor
+            {...props}
+            answer={answer}
+            onUpdate={onUpdate}
+            onAddOption={onAddOption}
+            onAddExclusive={onAddExclusive}
+            onUpdateOption={onUpdateOption}
+            onDeleteOption={onDeleteOption}
+            onDeleteAnswer={onDeleteAnswer}
+          />
+        )}
+      </Reorder>
+    </Margin>
   );
 };
 

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/index.test.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/index.test.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { shallow } from "enzyme";
 
+import Reorder from "components/Reorder";
+
 import { AnswersEditor } from "./";
 
 describe("Answers Editor", () => {
@@ -33,9 +35,9 @@ describe("Answers Editor", () => {
       onMoveUp: jest.fn(),
       onMoveDown: jest.fn(),
     };
-    const wrapper = shallow(<AnswersEditor {...props} />).renderProp(
-      "children"
-    )(extraProps, props.answers[0]);
+    const wrapper = shallow(<AnswersEditor {...props} />)
+      .find(Reorder)
+      .renderProp("children")(extraProps, props.answers[0]);
 
     expect(wrapper.props()).toMatchObject({
       answer: props.answers[0],

--- a/eq-author/src/components/Reorder/index.js
+++ b/eq-author/src/components/Reorder/index.js
@@ -21,10 +21,6 @@ const move = ({ transform, scale }) => keyframes`
   }
 `;
 
-const Margin = styled.div`
-  margin-top: 3em;
-`;
-
 export const Segment = styled.div`
   z-index: ${props => props.movement.zIndex};
   transform-origin: 50% 50%;
@@ -40,12 +36,7 @@ export const Segment = styled.div`
 const startingStyles = items => items.map(() => ({ transform: 0 }));
 
 const Reorder = ({ list, onMove, children, Transition }) => {
-  const OuterWrapper = Transition
-    ? ({ children }) => (
-        <TransitionGroup component={Margin}>{children}</TransitionGroup>
-      )
-    : React.Fragment;
-
+  const OuterWrapper = Transition ? TransitionGroup : React.Fragment;
   const InnerWrapper = Transition || React.Fragment;
 
   const [renderedItems, setRenderedItems] = useState(list);

--- a/eq-author/src/components/Reorder/index.test.js
+++ b/eq-author/src/components/Reorder/index.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
 import { act } from "react-dom/test-utils";
+import { TransitionGroup, CSSTransition } from "react-transition-group";
 import styled from "styled-components";
+
 import TestProvider from "tests/utils/TestProvider";
 
 import Reorder, { Segment } from "./";
@@ -11,9 +13,9 @@ describe("Reorder", () => {
 
   let props;
 
-  const MockTransition = styled.div`
-    position: relative;
-  `;
+  const MockTransition = styled(CSSTransition).attrs({
+    classNames: "mock",
+  });
 
   beforeEach(() => {
     props = {
@@ -194,22 +196,13 @@ describe("Reorder", () => {
 
   it("should render as reactFragment if no transition passed", () => {
     const wrapper = shallow(<Reorder {...props} />);
-    expect(wrapper.find("Fragment > Reorder__Segment")).toHaveLength(
-      props.list.length
-    );
+    expect(wrapper.find("Fragment")).toHaveLength(1);
+    expect(wrapper.find(TransitionGroup)).toHaveLength(0);
   });
 
-  it("should render with Transition is transition passed", () => {
-    const transitionProps = {
-      ...props,
-      Transition: MockTransition,
-    };
-    const wrapper = shallow(<Reorder {...transitionProps} />);
-
-    expect(wrapper.dive().find("Fragment > Reorder__Segment")).toHaveLength(0);
-
-    expect(
-      wrapper.dive().find("TransitionGroup > indextest__MockTransition")
-    ).toHaveLength(props.list.length);
+  it("should render with TransitionGroup when a transition passed", () => {
+    const wrapper = shallow(<Reorder Transition={MockTransition} {...props} />);
+    expect(wrapper.find("Fragment")).toHaveLength(0);
+    expect(wrapper.find(TransitionGroup)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
This was caused by the outer wrapper being created each time. It was
also applying a margin that was not correct as this component is used
for both answers and collapsibles.

This change pushes the margin to the answers components and reverts
the change so the outerwrapper is constant.

Closes #428 

### How to review 
1. Create multiple collapsibles or answers and see that reordering is janky
1. Switch to this branch and see it is resolved