### PR TITLE
Make questionnaire public or private

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -30,6 +30,10 @@ const baseQuestionnaireSchema = {
     hashKey: true,
     required: true,
   },
+  isPublic: {
+    type: Boolean,
+    required: true,
+  },
   title: {
     type: String,
   },

--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -6,6 +6,19 @@ module.exports = async (req, res, next) => {
     next();
     return;
   }
-  req.questionnaire = await getQuestionnaire(questionnaireId);
+
+  const questionnaire = await getQuestionnaire(questionnaireId);
+
+  if (questionnaire && questionnaire.isPublic === false) {
+    const userId = req.user.id;
+    const authorizedUsers = [questionnaire.createdBy, ...questionnaire.editors];
+
+    if (!authorizedUsers.includes(userId)) {
+      res.status(403).send("Unauthorized questionnaire access");
+      return;
+    }
+  }
+
+  req.questionnaire = questionnaire;
   next();
 };

--- a/eq-author-api/middleware/loadQuestionnaire.test.js
+++ b/eq-author-api/middleware/loadQuestionnaire.test.js
@@ -36,4 +36,25 @@ describe("loadQuestionnaire", () => {
     });
     expect(req.questionnaire).toEqual(undefined);
   });
+  it("should not load private questionnaire if user is not an editor", async () => {
+    const ctx = await buildContext({ isPublic: false });
+    const { questionnaire } = ctx;
+
+    const req = {
+      header: jest.fn().mockReturnValue(questionnaire.id),
+      user: { id: "unauthorizedId" },
+    };
+
+    const send = jest.fn();
+    const res = {
+      status: jest.fn(() => ({
+        send,
+      })),
+    };
+
+    await loadQuestionnaire(req, res);
+    expect(send).toHaveBeenCalledWith("Unauthorized questionnaire access");
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(req.questionnaire).toEqual(undefined);
+  });
 });

--- a/eq-author-api/migrations/addIsPublicFlag.js
+++ b/eq-author-api/migrations/addIsPublicFlag.js
@@ -1,0 +1,8 @@
+//This is an auto-generated file.  Do NOT modify the method signature.
+
+module.exports = function addIsPublicFlag(questionnaire) {
+  if (!questionnaire.hasOwnProperty("isPublic")) {
+    questionnaire.isPublic = true;
+  }
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addIsPublicFlag.test.js
+++ b/eq-author-api/migrations/addIsPublicFlag.test.js
@@ -1,0 +1,41 @@
+const { cloneDeep } = require("lodash");
+const addIsPublicFlag = require("./addIsPublicFlag.js");
+
+describe("addIsPublicFlag", () => {
+  let questionnaire = {};
+  beforeEach(() => {
+    questionnaire = {
+      id: "aca64645-98ef-43ae-8b77-d749b4e89a05",
+      title: "laa",
+      description: null,
+      type: "Social",
+      theme: "default",
+      introduction: null,
+      navigation: false,
+      surveyId: null,
+      summary: false,
+      metadata: [],
+      sections: [],
+    };
+  });
+  // This test must remain for your migration to always work
+  it("should be deterministic", () => {
+    expect(addIsPublicFlag(cloneDeep(questionnaire))).toEqual(
+      addIsPublicFlag(cloneDeep(questionnaire))
+    );
+  });
+
+  it("should add isPublic if it is missing", () => {
+    expect(addIsPublicFlag(questionnaire)).toEqual({
+      ...questionnaire,
+      isPublic: true,
+    });
+  });
+  it("should not set isPublic to true if it already is false", () => {
+    const newQuestionnaire = { ...questionnaire, isPublic: false };
+    expect(addIsPublicFlag(newQuestionnaire)).toEqual({
+      ...newQuestionnaire,
+      isPublic: false,
+    });
+  });
+});

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -1,4 +1,4 @@
-const { last, findIndex } = require("lodash");
+const { last, findIndex, find } = require("lodash");
 
 const { SOCIAL, BUSINESS } = require("../../constants/questionnaireTypes");
 
@@ -193,20 +193,49 @@ describe("questionnaire", () => {
   });
 
   describe("list questionnaires", () => {
-    it("should order then newest to oldest", async () => {
-      const { questionnaire: oldestQuestionnaire } = await buildContext({});
-      const { questionnaire: newestQuestionnaire } = await buildContext({});
-
-      const questionnnaires = await listQuestionnaires();
+    it("should order the newest to oldest", async () => {
+      const user = {
+        id: "123",
+      };
+      const { questionnaire: oldestQuestionnaire } = await buildContext(
+        {},
+        user
+      );
+      const { questionnaire: newestQuestionnaire } = await buildContext(
+        {},
+        user
+      );
+      const questionnaires = await listQuestionnaires(user);
       const oldestIndex = findIndex(
-        questionnnaires,
+        questionnaires,
         q => q.id === oldestQuestionnaire.id
       );
       const newestIndex = findIndex(
-        questionnnaires,
+        questionnaires,
         q => q.id === newestQuestionnaire.id
       );
       expect(oldestIndex > newestIndex).toEqual(true);
+    });
+    it("should not list unaccessible private questionnaires", async () => {
+      const user = {
+        id: "123",
+      };
+
+      const { questionnaire: publicQuestionnaire } = await buildContext(
+        {},
+        user
+      );
+      const { questionnaire: privateQuestionnaire } = await buildContext({
+        isPublic: false,
+      });
+      const questionnaires = await listQuestionnaires(user);
+
+      expect(
+        find(questionnaires, q => q.id === publicQuestionnaire.id)
+      ).toBeTruthy();
+      expect(
+        find(questionnaires, q => q.id === privateQuestionnaire.id)
+      ).toBeFalsy();
     });
   });
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -54,6 +54,7 @@ type Questionnaire {
   isNew: Boolean!
   editors: [User!]!
   permission: Permission!
+  isPublic: Boolean!
 }
 
 type DeletedQuestionnaire {
@@ -672,6 +673,7 @@ input CreateQuestionnaireInput {
   summary: Boolean
   type: QuestionnaireType!
   shortTitle: String
+  isPublic: Boolean
 }
 
 input UpdateQuestionnaireInput {
@@ -684,8 +686,10 @@ input UpdateQuestionnaireInput {
   surveyId: String
   summary: Boolean
   shortTitle: String
-  editors: [ID!]
+  editors: [ID!] 
+  isPublic: Boolean
 }
+
 
 input DeleteQuestionnaireInput {
   id: ID!

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/listQuestionnaires.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/listQuestionnaires.js
@@ -8,8 +8,8 @@ const listQuestionnairesQuery = `
   }
 `;
 
-const listQuestionnaires = async () => {
-  const result = await executeQuery(listQuestionnairesQuery);
+const listQuestionnaires = async user => {
+  const result = await executeQuery(listQuestionnairesQuery, {}, { user });
   return result.data.questionnaires;
 };
 

--- a/eq-author/cypress.json
+++ b/eq-author/cypress.json
@@ -1,6 +1,0 @@
-{
-  "viewportHeight": 660,
-  "viewportWidth": 1280,
-  "projectId": "hma77k",
-  "videoUploadOnPasses": false
-}

--- a/eq-author/src/App/AccessDeniedPage/icon-denied.svg
+++ b/eq-author/src/App/AccessDeniedPage/icon-denied.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="409px" height="409px" viewBox="0 0 409 409" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M204.497075,0 C317.444273,0 409,91.5557272 409,204.502925 C409,317.444273 317.444273,409 204.497075,409 C91.5557272,409 0,317.444273 0,204.502925 C0,91.5557272 91.5557272,0 204.497075,0 Z M72,174 L337,174 L337,236 L72,236 L72,174 Z" id="Shape" fill="#979797"></path>
+    </g>
+</svg>

--- a/eq-author/src/App/AccessDeniedPage/index.js
+++ b/eq-author/src/App/AccessDeniedPage/index.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+import Link from "components/Link";
+import icon from "./icon-denied.svg";
+import styled from "styled-components";
+
+import Layout from "components/Layout";
+
+const CenteredPane = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 6em;
+`;
+
+const Icon = styled.div`
+  background: url(${icon}) no-repeat center center;
+  background-size: contain;
+  width: 100px;
+  height: 100px;
+  margin-bottom: 1em;
+`;
+
+const Title = styled.h1`
+  font-size: 1em;
+  font-weight: 600;
+  margin: 0;
+`;
+
+const AccessDenied = () => (
+  <Layout title={"Access denied"}>
+    <CenteredPane>
+      <Icon />
+      <Title data-test="access-denied-page-title">403 — Access Denied</Title>
+      <p>Sorry, you do not have access to this questionnaire.</p>
+      <Link href="/">Back to home</Link>
+    </CenteredPane>
+  </Layout>
+);
+
+export default AccessDenied;

--- a/eq-author/src/App/AccessDeniedPage/index.test.js
+++ b/eq-author/src/App/AccessDeniedPage/index.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import AccessDenied from "./";
+
+describe("Access denied page", () => {
+  it("should render with access denied message", () => {
+    const { getByText } = render(<AccessDenied />);
+    expect(getByText("403 — Access Denied")).toBeTruthy();
+  });
+});

--- a/eq-author/src/App/ErrorBoundary/index.js
+++ b/eq-author/src/App/ErrorBoundary/index.js
@@ -1,7 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import NotFound from "App/NotFoundPage";
-import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+import AccessDenied from "App/AccessDeniedPage";
+import {
+  ERR_PAGE_NOT_FOUND,
+  ERR_UNAUTHORIZED_QUESTIONNAIRE,
+} from "constants/error-codes";
 
 export default class ErrorBoundary extends React.Component {
   static propTypes = {
@@ -16,8 +20,10 @@ export default class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.error.message === ERR_PAGE_NOT_FOUND) {
-      // You can render any custom fallback UI
       return <NotFound />;
+    }
+    if (this.state.error.message === ERR_UNAUTHORIZED_QUESTIONNAIRE) {
+      return <AccessDenied />;
     }
 
     return this.props.children;

--- a/eq-author/src/App/ErrorBoundary/index.test.js
+++ b/eq-author/src/App/ErrorBoundary/index.test.js
@@ -2,8 +2,12 @@ import React from "react";
 import { shallow } from "enzyme";
 
 import ErrorBoundary from "./";
-import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+import {
+  ERR_PAGE_NOT_FOUND,
+  ERR_UNAUTHORIZED_QUESTIONNAIRE,
+} from "constants/error-codes";
 import NotFound from "App/NotFoundPage";
+import AccessDenied from "App/AccessDeniedPage";
 
 const MockComponent = () => null;
 
@@ -26,5 +30,11 @@ describe("ErrorBoundary", () => {
     const error = new Error(ERR_PAGE_NOT_FOUND);
     wrapper.find(MockComponent).simulateError(error);
     expect(wrapper.instance().render()).toMatchObject(<NotFound />);
+  });
+
+  it("should display access denied page when ERR_UNAUTHORIZED_QUESTIONNAIRE error thrown", () => {
+    const error = new Error(ERR_UNAUTHORIZED_QUESTIONNAIRE);
+    wrapper.find(MockComponent).simulateError(error);
+    expect(wrapper.instance().render()).toMatchObject(<AccessDenied />);
   });
 });

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -1,5 +1,199 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`QuestionnaireDesignPage Adding question confirmation should render questionnaire design page if access granted 1`] = `
+<BaseLayout
+  questionnaire={
+    Object {
+      "displayName": "my displayName",
+      "id": "3",
+      "sections": Array [
+        Object {
+          "id": "2",
+          "pages": Array [
+            Object {
+              "answers": Array [
+                Object {
+                  "id": "1",
+                  "label": "",
+                  "options": Array [
+                    Object {
+                      "id": "1",
+                    },
+                  ],
+                },
+              ],
+              "description": "",
+              "guidance": "",
+              "id": "1",
+              "pageType": "QuestionPage",
+              "position": 0,
+              "title": "",
+            },
+          ],
+          "title": "",
+        },
+      ],
+      "title": "hello world",
+    }
+  }
+>
+  <GetContext
+    title={[Function]}
+  >
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <Column
+        cols={3}
+        gutters={false}
+      >
+        <withRouter(UnwrappedNavigationSidebar)
+          canAddCalculatedSummaryPage={true}
+          canAddQuestionConfirmation={true}
+          canAddQuestionPage={true}
+          data-test="side-nav"
+          loading={false}
+          onAddCalculatedSummaryPage={[Function]}
+          onAddQuestionConfirmation={[Function]}
+          onAddQuestionPage={[Function]}
+          onAddSection={[MockFunction]}
+          questionnaire={
+            Object {
+              "displayName": "my displayName",
+              "id": "3",
+              "sections": Array [
+                Object {
+                  "id": "2",
+                  "pages": Array [
+                    Object {
+                      "answers": Array [
+                        Object {
+                          "id": "1",
+                          "label": "",
+                          "options": Array [
+                            Object {
+                              "id": "1",
+                            },
+                          ],
+                        },
+                      ],
+                      "description": "",
+                      "guidance": "",
+                      "id": "1",
+                      "pageType": "QuestionPage",
+                      "position": 0,
+                      "title": "",
+                    },
+                  ],
+                  "title": "",
+                },
+              ],
+              "title": "hello world",
+            }
+          }
+        />
+      </Column>
+      <Column
+        cols={9}
+        gutters={false}
+      >
+        <ContextProvider
+          value={
+            Object {
+              "questionnaire": Object {
+                "displayName": "my displayName",
+                "id": "3",
+                "sections": Array [
+                  Object {
+                    "id": "2",
+                    "pages": Array [
+                      Object {
+                        "answers": Array [
+                          Object {
+                            "id": "1",
+                            "label": "",
+                            "options": Array [
+                              Object {
+                                "id": "1",
+                              },
+                            ],
+                          },
+                        ],
+                        "description": "",
+                        "guidance": "",
+                        "id": "1",
+                        "pageType": "QuestionPage",
+                        "position": 0,
+                        "title": "",
+                      },
+                    ],
+                    "title": "",
+                  },
+                ],
+                "title": "hello world",
+              },
+            }
+          }
+        >
+          <Switch>
+            <Route
+              component={[Function]}
+              key="page-design"
+              path="/q/:questionnaireId/page/:pageId/design/:modifier?"
+            />
+            <Route
+              component={[Function]}
+              key="page-preview"
+              path="/q/:questionnaireId/page/:pageId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="page-routing"
+              path="/q/:questionnaireId/page/:pageId/routing"
+            />
+            <Route
+              component={[Function]}
+              key="section-design"
+              path="/q/:questionnaireId/section/:sectionId/design"
+            />
+            <Route
+              component={[Function]}
+              key="section-preview"
+              path="/q/:questionnaireId/section/:sectionId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="confirmation-design"
+              path="/q/:questionnaireId/question-confirmation/:confirmationId/design"
+            />
+            <Route
+              component={[Function]}
+              key="confirmation-preview"
+              path="/q/:questionnaireId/question-confirmation/:confirmationId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="introduction-design"
+              path="/q/:questionnaireId/introduction/:introductionId/design/:modifier?"
+            />
+            <Route
+              component={[Function]}
+              key="introduction-preview"
+              path="/q/:questionnaireId/introduction/:introductionId/preview"
+            />
+            <Route
+              path="*"
+              render={[Function]}
+            />
+          </Switch>
+        </ContextProvider>
+      </Column>
+    </Grid>
+  </GetContext>
+</BaseLayout>
+`;
+
 exports[`QuestionnaireDesignPage should redirect to the introduction if it has one 1`] = `
 <Redirect
   push={false}

--- a/eq-author/src/App/QuestionnaireDesignPage/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.test.js
@@ -7,11 +7,17 @@ import {
   QUESTION_CONFIRMATION,
   INTRODUCTION,
 } from "constants/entities";
-import { ERR_PAGE_NOT_FOUND } from "constants/error-codes";
+import {
+  ERR_PAGE_NOT_FOUND,
+  ERR_UNAUTHORIZED_QUESTIONNAIRE,
+} from "constants/error-codes";
 
 import NavigationSidebar from "./NavigationSidebar";
 
-import { UnwrappedQuestionnaireDesignPage as QuestionnaireDesignPage } from ".";
+import {
+  UnwrappedQuestionnaireDesignPage as QuestionnaireDesignPage,
+  throwIfUnauthorized,
+} from "./";
 
 describe("QuestionnaireDesignPage", () => {
   let mockHandlers;
@@ -337,6 +343,33 @@ describe("QuestionnaireDesignPage", () => {
       };
 
       expect(throwWrapper).toThrow(new Error(ERR_PAGE_NOT_FOUND));
+    });
+
+    it("should throw ERR_UNAUTHORIZED_QUESTIONNAIRE if access denied", () => {
+      const innerProps = {
+        error: {
+          networkError: {
+            bodyText: ERR_UNAUTHORIZED_QUESTIONNAIRE,
+          },
+        },
+      };
+
+      expect(() => throwIfUnauthorized(innerProps)).toThrow(
+        new Error(ERR_UNAUTHORIZED_QUESTIONNAIRE)
+      );
+    });
+    it("should render questionnaire design page if access granted", () => {
+      const innerProps = {};
+      expect(
+        shallow(
+          throwIfUnauthorized(innerProps, {
+            ...mockHandlers,
+            match: match,
+            data: { questionnaire },
+            loading: false,
+          })
+        )
+      ).toMatchSnapshot();
     });
   });
 });

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -40,6 +40,7 @@ const moveSectionMock = {
         displayName: "Display name",
         shortTitle: "Short tile",
         permission: WRITE,
+        isPublic: true,
         createdBy: {
           id: "1",
           name: "Some user",

--- a/eq-author/src/apollo/createApolloErrorLink.test.js
+++ b/eq-author/src/apollo/createApolloErrorLink.test.js
@@ -18,10 +18,6 @@ describe("createErrorLink", () => {
     dispatch,
   });
 
-  beforeAll(() => {
-    dispatch = jest.fn();
-  });
-
   beforeEach(() => {
     /* eslint-disable-next-line camelcase */
     const tokenData = { user_id: "Test User", email: "test.user@email.com" };
@@ -36,11 +32,13 @@ describe("createErrorLink", () => {
         fail: "Uh oh",
       },
     ];
+    dispatch = jest.fn();
   });
 
-  it("should dispatch a logout event when the server responds with a 401 error", () => {
+  it("should dispatch a logout event when the server responds with 401 status code", () => {
     errorHandler(createMockStore, {
-      networkError: { bodyText: "User does not exist" },
+      networkError: { statusCode: 401 },
+      graphQLErrors,
     });
     expect(dispatch).toHaveBeenCalledWith(expect.any(Function));
   });
@@ -80,5 +78,11 @@ describe("createErrorLink", () => {
     expect(setSentryUser).toHaveBeenCalledWith(
       localStorage.getItem("accessToken")
     );
+  });
+  it("should return when networkError gives unauthorized questionnaire access", () => {
+    errorHandler(createMockStore, {
+      networkError: { statusCode: 403 },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/eq-author/src/components/EditorLayout/Header/SharingModal/index.test.js
+++ b/eq-author/src/components/EditorLayout/Header/SharingModal/index.test.js
@@ -1,0 +1,329 @@
+import React from "react";
+import { omit } from "lodash";
+import { render, fireEvent } from "tests/utils/rtl";
+import flushPromises from "tests/utils/flushPromises";
+import { raiseToast } from "redux/toast/actions";
+
+import SharingModal, { ALL_USERS_QUERY } from "./";
+import { ADD_REMOVE_EDITOR_MUTATION } from "./withAddRemoveEditor";
+import { WRITE } from "constants/questionnaire-permissions";
+
+jest.mock("redux/toast/actions");
+
+describe("Sharing Modal", () => {
+  let props;
+  const BETH_SMITH = {
+    id: "11",
+    name: "Beth Smith",
+    email: "beth@smith.com",
+  };
+  beforeEach(() => {
+    props = {
+      isOpen: true,
+      loading: false,
+      data: {
+        users: [
+          BETH_SMITH,
+          { id: "2", name: "Babs", email: "b@abs.com", picture: "babs.jpg" },
+        ],
+      },
+      onClose: jest.fn(),
+      addEditor: jest.fn(),
+      removeEditor: jest.fn(() => Promise.resolve()),
+      togglePublic: jest.fn(),
+      questionnaire: {
+        id: "456",
+        displayName: "Questionnaire of Awesomeness",
+        createdBy: {
+          id: "1",
+          name: "Jerry Smith",
+          email: "jerry@smith.com",
+          picture: "jerry.jpg",
+        },
+        editors: [
+          { id: "2", name: "Babs", email: "b@abs.com", picture: "babs.jpg" },
+          { id: "3", name: "Jay", email: "j@ay.com", picture: "jay.jpg" },
+        ],
+      },
+      previewUrl: `/launch/456`,
+      currentUser: { id: "1" },
+      history: { push: jest.fn() },
+    };
+  });
+  afterEach(async () => {
+    await flushPromises();
+  });
+
+  it("should list the owner and editors", async () => {
+    const { getByText } = render(<SharingModal {...props} />);
+
+    expect(getByText("Jerry Smith")).toBeTruthy();
+    expect(getByText("Babs")).toBeTruthy();
+    expect(getByText("Jay")).toBeTruthy();
+  });
+
+  it("should provide a button to copy the launch url", async () => {
+    const originalExecCommand = document.execCommand;
+    let selectedText = "no text selected";
+    document.execCommand = command => {
+      if (command === "copy") {
+        // jsdom has not implemented textselection so we we have do the next best thing
+        selectedText = document.querySelector("[data-test='share-link']")
+          .innerText;
+      }
+    };
+    const { getByText } = render(<SharingModal {...props} />);
+
+    const linkButton = getByText("Get shareable link");
+
+    fireEvent.click(linkButton);
+
+    expect(selectedText).toMatch(
+      new RegExp(`/launch/${props.questionnaire.id}$`)
+    );
+
+    expect(raiseToast).toHaveBeenCalledWith(
+      expect.any(String),
+      "Link copied to clipboard"
+    );
+    document.execCommand = originalExecCommand;
+  });
+
+  describe("removing editors", () => {
+    let mocks;
+    let mutationWasCalled = false;
+    beforeEach(() => {
+      mocks = [
+        {
+          request: {
+            query: ADD_REMOVE_EDITOR_MUTATION,
+            variables: {
+              input: {
+                id: "456",
+                editors: props.questionnaire.editors
+                  .filter(e => e.name !== "Babs")
+                  .map(e => e.id),
+              },
+            },
+          },
+          result() {
+            mutationWasCalled = true;
+            return {
+              data: {
+                updateQuestionnaire: {
+                  id: props.questionnaire.id,
+                  editors: props.questionnaire.editors
+                    .filter(e => e.name !== "Babs")
+                    .map(e => ({ ...e, __typename: "User" })),
+                  permission: WRITE,
+                  __typename: "Questionnaire",
+                },
+              },
+            };
+          },
+        },
+      ];
+    });
+
+    it("should be possible to remove editors", async () => {
+      const { getByText, queryByText, getAllByLabelText, rerender } = render(
+        <SharingModal {...props} />,
+        { mocks }
+      );
+
+      const row = getByText("Babs").parentElement;
+      const removeButton = getAllByLabelText("Remove editor").find(
+        btn => btn.parentElement === row
+      );
+
+      fireEvent.click(removeButton);
+      await flushPromises();
+
+      const updatedQuestionnaire = {
+        ...props.questionnaire,
+        editors: props.questionnaire.editors.filter(
+          editor => editor.name !== "Babs"
+        ),
+      };
+      props.questionnaire = updatedQuestionnaire;
+      rerender(<SharingModal {...props} />);
+
+      expect(mutationWasCalled).toEqual(true);
+      expect(queryByText("Babs")).toBeFalsy();
+    });
+    it("should display a confirmation before removing yourself as editor", async () => {
+      const jsdomWindowConfirm = window.confirm;
+      window.confirm = jest.fn(() => true);
+
+      props.currentUser.id = "2";
+
+      const { getByText, getAllByLabelText, history } = render(
+        <SharingModal {...props} />,
+        { mocks }
+      );
+      history.location = {};
+      const row = getByText("Babs").parentElement;
+      const removeButton = getAllByLabelText("Remove editor").find(
+        btn => btn.parentElement === row
+      );
+      fireEvent.click(removeButton);
+      await flushPromises();
+
+      expect(window.confirm).toHaveBeenCalled();
+      expect(history.location.pathname).toEqual("/");
+      window.confirm = jsdomWindowConfirm;
+    });
+  });
+  describe("adding editors", () => {
+    let mocks;
+    let PETER_PARKER;
+    beforeEach(() => {
+      PETER_PARKER = {
+        id: "11",
+        name: "Peter Parker",
+        email: "p@spidermanfanclub.com",
+        picture: "tarantula.jpg",
+      };
+      mocks = [
+        {
+          request: {
+            query: ALL_USERS_QUERY,
+          },
+          result: {
+            data: {
+              users: [
+                PETER_PARKER,
+                props.questionnaire.createdBy,
+                ...props.questionnaire.editors,
+              ].map(u => ({
+                ...omit(u, "picture"),
+                __typename: "User",
+              })),
+            },
+          },
+        },
+        {
+          request: {
+            query: ADD_REMOVE_EDITOR_MUTATION,
+            variables: {
+              input: {
+                id: props.questionnaire.id,
+                editors: [...props.questionnaire.editors, PETER_PARKER].map(
+                  e => e.id
+                ),
+              },
+            },
+          },
+          result: {
+            data: {
+              updateQuestionnaire: {
+                id: props.questionnaire.id,
+                editors: [...props.questionnaire.editors, PETER_PARKER].map(
+                  e => ({
+                    ...e,
+                    __typename: "User",
+                  })
+                ),
+                permission: WRITE,
+                __typename: "Questionnaire",
+              },
+            },
+          },
+        },
+      ];
+    });
+
+    it("should be possible to search for a user by name and add them as an editor", async () => {
+      const { getByText, getAllByLabelText, queryByText, rerender } = render(
+        <SharingModal {...props} />,
+        { mocks }
+      );
+
+      // load the users
+      await flushPromises();
+
+      expect(queryByText("Beth Smith")).toBeFalsy();
+
+      // downshift labels everything including the div
+      const input = getAllByLabelText("Add editors")[0];
+      fireEvent.change(input, { target: { value: "beTh" } });
+
+      const userResult = getByText(`Beth`);
+      fireEvent.click(userResult);
+
+      await flushPromises();
+
+      const updatedQuestionnaire = {
+        ...props.questionnaire,
+        editors: [...props.questionnaire.editors, BETH_SMITH],
+      };
+      props.questionnaire = updatedQuestionnaire;
+      rerender(<SharingModal {...props} />);
+
+      expect(queryByText("Beth Smith")).toBeTruthy();
+    });
+
+    it("should be possible to search for users by email", async () => {
+      const { getAllByLabelText, queryByText } = render(
+        <SharingModal {...props} />
+      );
+
+      // load the users
+      await flushPromises();
+
+      expect(queryByText("Beth Smith")).toBeFalsy();
+
+      const input = getAllByLabelText("Add editors")[0];
+      fireEvent.change(input, { target: { value: "beth@sm" } });
+
+      expect(queryByText("Beth Smith")).toBeTruthy();
+    });
+
+    it("removing your search should return no one", async () => {
+      const { getAllByLabelText, queryByText } = render(
+        <SharingModal {...props} />
+      );
+
+      // load the users
+      await flushPromises();
+
+      expect(queryByText("Beth Smith")).toBeFalsy();
+
+      const input = getAllByLabelText("Add editors")[0];
+      fireEvent.change(input, { target: { value: "smit" } });
+      fireEvent.change(input, { target: { value: "" } });
+
+      expect(queryByText("Beth Smith")).toBeFalsy();
+    });
+
+    it("should not be possible to add existing editors", async () => {
+      const { getAllByLabelText, queryAllByText } = render(
+        <SharingModal {...props} />
+      );
+
+      // load the users
+      await flushPromises();
+
+      const input = getAllByLabelText("Add editors")[0];
+      fireEvent.change(input, { target: { value: "babs" } });
+
+      expect(queryAllByText("Babs")[0]).toBeTruthy();
+      expect(queryAllByText("Babs")[1]).toBeFalsy();
+    });
+
+    it("should not be possible to add the owner", async () => {
+      const { queryAllByText, getAllByLabelText } = render(
+        <SharingModal {...props} />
+      );
+
+      // load the users
+      await flushPromises();
+
+      const input = getAllByLabelText("Add editors")[0];
+      fireEvent.change(input, { target: { value: "jerry" } });
+
+      expect(queryAllByText("Jerry Smith")[0]).toBeTruthy();
+      expect(queryAllByText("Jerry Smith")[1]).toBeFalsy();
+    });
+  });
+});

--- a/eq-author/src/components/EditorLayout/Header/SharingModal/withTogglePublic.js
+++ b/eq-author/src/components/EditorLayout/Header/SharingModal/withTogglePublic.js
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+import { graphql } from "react-apollo";
+
+const TOGGLE_PUBLIC_MUTATION = gql`
+  mutation TogglePublic($input: UpdateQuestionnaireInput!) {
+    updateQuestionnaire(input: $input) {
+      id
+      isPublic
+    }
+  }
+`;
+
+export const mapMutateToProps = ({ mutate, ownProps: { questionnaire } }) => ({
+  togglePublic: () =>
+    mutate({
+      variables: {
+        input: { id: questionnaire.id, isPublic: !questionnaire.isPublic },
+      },
+    }),
+});
+
+export default graphql(TOGGLE_PUBLIC_MUTATION, {
+  props: mapMutateToProps,
+});

--- a/eq-author/src/components/Layout/Header.js
+++ b/eq-author/src/components/Layout/Header.js
@@ -2,6 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import gql from "graphql-tag";
+import { Query } from "react-apollo";
 
 import { colors } from "constants/theme";
 
@@ -11,6 +13,24 @@ import UserProfile from "components/UserProfile";
 import Truncated from "components/Truncated";
 import Logo from "components/Logo";
 import { Grid, Column } from "components/Grid";
+
+export const CURRENT_USER_QUERY = gql`
+  query GetHeaderInformation {
+    me {
+      id
+      displayName
+      picture
+    }
+  }
+`;
+
+export const withCurrentUser = Component => props => (
+  <Query query={CURRENT_USER_QUERY}>
+    {innerProps => {
+      return <Component {...innerProps} {...props} />;
+    }}
+  </Query>
+);
 
 const StyledHeader = styled(Grid)`
   background-color: ${colors.black};
@@ -40,10 +60,11 @@ const Title = styled(TruncatedTitle)`
   line-height: 1.3;
 `;
 
-const StyledUserProfile = styled(UserProfile)`
+const StyledUserProfile = withCurrentUser(styled(UserProfile)`
   width: auto;
   margin-right: 0.5em;
-`;
+`);
+
 const UserProfileWrapper = styled("div")`
   height: 100%;
   display: flex;

--- a/eq-author/src/components/Layout/index.test.js
+++ b/eq-author/src/components/Layout/index.test.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { render, flushPromises } from "tests/utils/rtl";
 
-import { CURRENT_USER_QUERY } from "components/UserProfile";
+import { CURRENT_USER_QUERY } from "components/EditorLayout/Header";
 
 import Layout from "./";
 

--- a/eq-author/src/components/UserProfile/index.js
+++ b/eq-author/src/components/UserProfile/index.js
@@ -4,8 +4,6 @@ import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
 import { flowRight } from "lodash";
 import { connect } from "react-redux";
-import gql from "graphql-tag";
-import { Query } from "react-apollo";
 
 import { signOutUser } from "redux/auth/actions";
 
@@ -60,9 +58,7 @@ const UserProfile = ({
   if (loading || !data || error) {
     return null;
   }
-
   const user = data.me;
-
   return (
     <Tooltip content="Sign Out">
       <LogoutButton
@@ -97,28 +93,9 @@ UserProfile.propTypes = {
   error: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
-export const CURRENT_USER_QUERY = gql`
-  query GetHeaderInformation {
-    me {
-      id
-      displayName
-      picture
-    }
-  }
-`;
-
-export const withCurrentUser = Component => props => (
-  <Query query={CURRENT_USER_QUERY}>
-    {innerProps => {
-      return <Component {...innerProps} {...props} />;
-    }}
-  </Query>
-);
-
 export default flowRight(
   connect(
     null,
     { signOutUser }
-  ),
-  withCurrentUser
+  )
 )(UserProfile);

--- a/eq-author/src/components/UserProfile/index.test.js
+++ b/eq-author/src/components/UserProfile/index.test.js
@@ -1,11 +1,10 @@
 import React from "react";
 
 import { render, fireEvent } from "tests/utils/rtl";
-import flushPromises from "tests/utils/flushPromises";
 
 import { signOutUser } from "redux/auth/actions";
 
-import UserProfile, { CURRENT_USER_QUERY } from ".";
+import UserProfile from ".";
 
 jest.mock("redux/auth/actions");
 
@@ -21,33 +20,24 @@ describe("UserProfile", () => {
     };
   });
 
-  it("should show the logged in user's display name", async () => {
-    const { getByText, queryByText } = render(<UserProfile />, {
-      mocks: [
-        {
-          request: { query: CURRENT_USER_QUERY },
-          result: { data: { me: me } },
-        },
-      ],
-    });
-    expect(queryByText(me.displayName)).toBeFalsy();
-    await flushPromises();
+  it("should show the logged in user's display name", () => {
+    const { getByText } = render(
+      <UserProfile
+        data={{ me }}
+        loading={false}
+        client={{ resetStore: jest.fn() }}
+      />
+    );
     expect(getByText(me.displayName)).toBeTruthy();
   });
 
-  it("should trigger signOut and clear the apollo cache on sign out", async () => {
+  it("should trigger signOut and clear the apollo cache on sign out", () => {
     const fakeApolloClient = {
       resetStore: jest.fn(),
     };
-    const { getByText } = render(<UserProfile client={fakeApolloClient} />, {
-      mocks: [
-        {
-          request: { query: CURRENT_USER_QUERY },
-          result: { data: { me: me } },
-        },
-      ],
-    });
-    await flushPromises();
+    const { getByText } = render(
+      <UserProfile data={{ me }} loading={false} client={fakeApolloClient} />
+    );
 
     fireEvent.click(getByText(me.displayName));
 

--- a/eq-author/src/constants/error-codes.js
+++ b/eq-author/src/constants/error-codes.js
@@ -1,1 +1,3 @@
 export const ERR_PAGE_NOT_FOUND = "PAGE_NOT_FOUND";
+export const ERR_UNAUTHORIZED_QUESTIONNAIRE =
+  "Unauthorized questionnaire access";

--- a/eq-author/src/graphql/fragments/questionnaire.graphql
+++ b/eq-author/src/graphql/fragments/questionnaire.graphql
@@ -21,5 +21,6 @@ fragment Questionnaire on Questionnaire {
     name
     email
   }
+  isPublic
   permission
 }


### PR DESCRIPTION
### What is the context of this PR?
<https://trello.com/c/Z2mYhATn/1150-make-questionnaires-public-private-6>
Add the concept of public and private questionnaires. Users can only see a private questionnaire if they are an owner or an editor. Questionnaire is public by default, and can be set to private in the sharing modal.

### How to review 
Check that everything works as expected and the tests make sense.

* Try opening a private questionnaire you dont have editor access on, you should be shown an unauthorized access page.
* Try deleting yourself as editor, you should be shown an alert.
