### PR TITLE
Added user auth middleware to import endpoint

### DIFF
--- a/eq-author-api/middleware/import.js
+++ b/eq-author-api/middleware/import.js
@@ -5,6 +5,7 @@ module.exports = async (req, res) => {
   const input = req.body;
   input.id = uuid.v4();
   input.createdAt = new Date();
+  input.createdBy = req.user.id;
   input.editors = [];
   const savedQuestionnaire = await createQuestionnaire(input);
   res.json({

--- a/eq-author-api/server.js
+++ b/eq-author-api/server.js
@@ -90,7 +90,14 @@ const createApp = () => {
 
   app.get("/export/:questionnaireId", exportQuestionnaire);
   if (process.env.ENABLE_IMPORT === "true") {
-    app.use(bodyParser.json()).post("/import", importQuestionnaire);
+    app
+      .use(bodyParser.json())
+      .post(
+        "/import",
+        identificationMiddleware(logger),
+        rejectUnidentifiedUsers,
+        importQuestionnaire
+      );
   }
 
   app.get("/signIn", identificationMiddleware(logger), upsertUser);

--- a/eq-author-api/server.test.js
+++ b/eq-author-api/server.test.js
@@ -52,12 +52,14 @@ describe("Server", () => {
       });
       const { questionnaire } = ctx;
       const questionnaireJSON = JSON.parse(JSON.stringify(questionnaire));
-
+      ctx.user.sub = ctx.user.externalId;
+      const token = jwt.sign(ctx.user, uuid.v4());
       process.env.ENABLE_IMPORT = "true";
       const server = createApp();
 
       const response = await request(server)
         .post("/import")
+        .set("authorization", `Bearer ${token}`)
         .send(questionnaireJSON);
 
       expect(response.headers["content-type"]).toMatch(/json/);


### PR DESCRIPTION
### What is the context of this PR?
There was a bug in the import middleware where the createdBy wasn't being correctly re-applied to the new user, this pr fixes that by adding the auth middleware to the import endpoint. 

### Note
You will now need to add a valid _Existing_ user auth header to any import request.

### How to review 
Import a questionnaire with your auth header, should see the owner has been re-assigned to yourself. 
