### PR TITLE
Fix issue where unable to delete questionnaires

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/withDeleteQuestionnaire.js
+++ b/eq-author/src/App/QuestionnairesPage/withDeleteQuestionnaire.js
@@ -15,6 +15,11 @@ export const mapMutateToProps = ({ ownProps, mutate }) => ({
           __typename: "Questionnaire",
         },
       },
+      context: {
+        headers: {
+          questionnaireId,
+        },
+      },
     });
 
     return mutation

--- a/eq-author/src/App/QuestionnairesPage/withDeleteQuestionnaire.test.js
+++ b/eq-author/src/App/QuestionnairesPage/withDeleteQuestionnaire.test.js
@@ -101,6 +101,11 @@ describe("withDeleteQuestionnaire", () => {
               variables: {
                 input: { id: questionnaireId },
               },
+              context: {
+                headers: {
+                  questionnaireId,
+                },
+              },
             })
           );
         });


### PR DESCRIPTION
### What is the context of this PR?
After restricting deletion to only users with write access we now
require having the questionnaire in the api request context to determine
if a user can delete a questionnaire.

This context is populated by middleware reading the questionnaireId from
the headers. For delete questionnaire this was not being sent as it is
on a list page and client middleware generating the header from the URL
for all other mutations does not work here so we need to send it
manually.


### How to review 
1. See that on master (and staging) that you cannot delete a questionnaire
1. See that after this PR you can delete questionnaires