### PR TITLE
Fix user search when user has no name

### DIFF
--- a/eq-author/src/components/Header/SharingModal/UserSearch.js
+++ b/eq-author/src/components/Header/SharingModal/UserSearch.js
@@ -110,7 +110,7 @@ const UserSearch = ({ users, onUserSelect }) => {
                       }
                       const value = inputValue.toLowerCase();
                       return (
-                        user.name.toLowerCase().includes(value) ||
+                        (user.name || "").toLowerCase().includes(value) ||
                         user.email.toLowerCase().includes(value)
                       );
                     })
@@ -146,7 +146,7 @@ UserSearch.propTypes = {
   users: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
+      name: PropTypes.string,
       email: PropTypes.string.isRequired,
     })
   ).isRequired,

--- a/eq-author/src/components/Header/index.test.js
+++ b/eq-author/src/components/Header/index.test.js
@@ -265,7 +265,7 @@ describe("Header", () => {
                     users: [
                       {
                         id: "10",
-                        name: "Clark Kent",
+                        name: null,
                         email: "clark@totallynotsuperman.com",
                       },
                       PETER_PARKER,


### PR DESCRIPTION
### What is the context of this PR?
Due to firebase issue it is possible for users to not have a name. This
was causing the user search to crash.

This is resolved by ensuring the name is an empty string when null.

### How to review 
1. Create a new user 
1. On master attempt to search for that new user and see the user search crash
1. Switch to this branch and see that you can now search
