### PR TITLE
Fix refresh issue on duplicated option label validation

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -344,7 +344,7 @@ const Resolvers = {
         });
       });
 
-      return removedOption;
+      return answer;
     }),
     toggleValidationRule: withWritePermission((_, args, ctx) => {
       const validation = getValidationById(ctx, args.input.id);

--- a/eq-author-api/schema/tests/multipleChoiceAnswer.test.js
+++ b/eq-author-api/schema/tests/multipleChoiceAnswer.test.js
@@ -337,7 +337,7 @@ describe("multiple choice answer", () => {
     });
 
     describe("delete", () => {
-      it("should delete options", async () => {
+      it("should delete options and return answer object", async () => {
         ctx = await buildContext({
           sections: [
             {
@@ -357,7 +357,10 @@ describe("multiple choice answer", () => {
         const questionnaire = ctx.questionnaire;
 
         const option = getOption(questionnaire);
-        await deleteOption(ctx, option);
+
+        const deleteOptionsResult = await deleteOption(ctx, option);
+        expect(deleteOptionsResult.__typename).toEqual("MultipleChoiceAnswer");
+
         const queriedOption = await queryOption(ctx, option.id);
         expect(queriedOption).toBeNull();
       });

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -575,7 +575,7 @@ type Mutation {
   createOption(input: CreateOptionInput!): Option
   createMutuallyExclusiveOption(input: CreateMutuallyExclusiveOptionInput!): Option
   updateOption(input: UpdateOptionInput!): Option
-  deleteOption(input: DeleteOptionInput!): Option
+  deleteOption(input: DeleteOptionInput!): MultipleChoiceAnswer
   toggleValidationRule(input: ToggleValidationRuleInput!): ValidationRule!
   updateValidationRule(input: UpdateValidationRuleInput!): ValidationRule!
   createMetadata(input: CreateMetadataInput!): Metadata!

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -93,6 +93,9 @@
                 }
               ]
             }
+          },
+          "mutuallyExclusiveOption": {
+            "$ref": "entities.json#/definitions/option"
           }
         },
         "required": ["id", "options"]

--- a/eq-author-api/tests/utils/contextBuilder/option/deleteOption.js
+++ b/eq-author-api/tests/utils/contextBuilder/option/deleteOption.js
@@ -7,6 +7,7 @@ const deleteOptionMutation = `
   mutation DeleteOption($input: DeleteOptionInput!) {
     deleteOption(input: $input) {
       id
+      __typename
     }
   }
 `;

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
@@ -228,6 +228,10 @@ MultipleChoiceAnswer.fragments = {
         }
         mutuallyExclusiveOption {
           ...Option
+          validationErrorInfo {
+            ...ValidationErrorInfo
+          }
+          isNew @client
         }
       }
     }

--- a/eq-author/src/App/page/Design/answers/withDeleteOption.js
+++ b/eq-author/src/App/page/Design/answers/withDeleteOption.js
@@ -1,36 +1,14 @@
 import { graphql } from "react-apollo";
-import { remove, get } from "lodash";
 import deleteOptionMutation from "graphql/deleteOption.graphql";
-import fragment from "graphql/answerFragment.graphql";
-
-export const createUpdater = (optionId, answerId) => proxy => {
-  const id = `MultipleChoiceAnswer${answerId}`;
-  const answer = proxy.readFragment({ id, fragment });
-
-  if (get(answer, "mutuallyExclusiveOption.id") === optionId) {
-    answer.mutuallyExclusiveOption = null;
-  } else {
-    remove(answer.options, { id: optionId });
-  }
-
-  proxy.writeFragment({
-    id,
-    fragment,
-    data: answer,
-  });
-};
 
 export const mapMutateToProps = ({ mutate }) => ({
-  onDeleteOption(optionId, answerId) {
+  onDeleteOption(optionId) {
     const option = {
       id: optionId,
     };
 
-    const update = createUpdater(optionId, answerId);
-
     return mutate({
       variables: { input: option },
-      update,
     });
   },
 });

--- a/eq-author/src/App/page/Design/answers/withDeleteOption.test.js
+++ b/eq-author/src/App/page/Design/answers/withDeleteOption.test.js
@@ -1,8 +1,7 @@
-import { mapMutateToProps, createUpdater } from "./withDeleteOption";
-import fragment from "graphql/answerFragment.graphql";
+import { mapMutateToProps } from "./withDeleteOption";
 
 describe("containers/QuestionnaireDesignPage/withDeleteOption", () => {
-  let mutate, result, answer, answerWithMutuallyExclusive, option;
+  let mutate, result, answer, option;
 
   beforeEach(() => {
     option = {
@@ -16,13 +15,6 @@ describe("containers/QuestionnaireDesignPage/withDeleteOption", () => {
       options: [option],
     };
 
-    answerWithMutuallyExclusive = {
-      ...answer,
-      mutuallyExclusiveOption: {
-        id: option.id,
-      },
-    };
-
     result = {
       data: {
         deleteOption: answer,
@@ -30,43 +22,6 @@ describe("containers/QuestionnaireDesignPage/withDeleteOption", () => {
     };
 
     mutate = jest.fn(() => Promise.resolve(result));
-  });
-
-  describe("createUpdater", () => {
-    it("should update the cache pass and remove option", () => {
-      const id = `MultipleChoiceAnswer${answer.id}`;
-      const writeFragment = jest.fn();
-      const readFragment = jest.fn(() => answer);
-
-      const updater = createUpdater(option.id, answer.id);
-      updater({ readFragment, writeFragment });
-
-      expect(readFragment).toHaveBeenCalledWith({ id, fragment });
-      expect(writeFragment).toHaveBeenCalledWith({
-        id,
-        fragment,
-        data: answer,
-      });
-      expect(answer.options).not.toContain(option);
-    });
-  });
-
-  it("should update the cache pass and unset mutuallyExclusiveOption", () => {
-    const id = `MultipleChoiceAnswer${answerWithMutuallyExclusive.id}`;
-    const writeFragment = jest.fn();
-    const readFragment = jest.fn(() => answerWithMutuallyExclusive);
-
-    const updater = createUpdater(option.id, answerWithMutuallyExclusive.id);
-    updater({ readFragment, writeFragment });
-
-    answerWithMutuallyExclusive.mutuallyExclusiveOption = null;
-
-    expect(readFragment).toHaveBeenCalledWith({ id, fragment });
-    expect(writeFragment).toHaveBeenCalledWith({
-      id,
-      fragment,
-      data: answerWithMutuallyExclusive,
-    });
   });
 
   describe("mapMutateToProps", () => {

--- a/eq-author/src/apollo/resolvers/index.js
+++ b/eq-author/src/apollo/resolvers/index.js
@@ -119,5 +119,9 @@ export const resolvers = {
     updateOption: (root, input, { cache }) => {
       removeNewEntity(OPTIONS, root.updateOption.id, cache);
     },
+
+    createMutuallyExclusiveOption: (root, input, { cache }) => {
+      addNewEntity(OPTIONS, root.createMutuallyExclusiveOption.id, cache);
+    },
   },
 };

--- a/eq-author/src/apollo/resolvers/index.test.js
+++ b/eq-author/src/apollo/resolvers/index.test.js
@@ -131,7 +131,7 @@ describe("resolvers", () => {
       expect(cacheData.newEntityList).toMatchObject(newUpdatePages);
     });
 
-    it("should initialise optiond of new multiple answer", () => {
+    it("should initialise option of new multiple answer", () => {
       const answer = {
         createAnswer: { id: 3, options: [{ id: 4 }] },
       };
@@ -151,6 +151,28 @@ describe("resolvers", () => {
       const newPages = [`${ANSWERS}_1`, `${OPTIONS}_2`];
 
       resolvers.Mutation.createOption(option, {}, { cache });
+
+      expect(cacheData.newEntityList).toMatchObject(newPages);
+
+      const updateOption = {
+        updateOption: { id: 2 },
+      };
+
+      const newUpdatePages = [`${ANSWERS}_1`];
+
+      resolvers.Mutation.updateOption(updateOption, {}, { cache });
+
+      expect(cacheData.newEntityList).toMatchObject(newUpdatePages);
+    });
+
+    it("should initialise new mutually exclisive option and remove on update", () => {
+      const option = {
+        createMutuallyExclusiveOption: { id: 2 },
+      };
+
+      const newPages = [`${ANSWERS}_1`, `${OPTIONS}_2`];
+
+      resolvers.Mutation.createMutuallyExclusiveOption(option, {}, { cache });
 
       expect(cacheData.newEntityList).toMatchObject(newPages);
 

--- a/eq-author/src/graphql/createMutuallyExclusiveOption.graphql
+++ b/eq-author/src/graphql/createMutuallyExclusiveOption.graphql
@@ -1,9 +1,14 @@
 #import "./fragments/option.graphql"
+#import "./fragments/validationErrorInfo.graphql"
 
 mutation createMutuallyExclusiveOption(
   $input: CreateMutuallyExclusiveOptionInput!
 ) {
   createMutuallyExclusiveOption(input: $input) {
     ...Option
+    validationErrorInfo {
+      ...ValidationErrorInfo
+    }
+    isNew @client
   }
 }

--- a/eq-author/src/graphql/deleteOption.graphql
+++ b/eq-author/src/graphql/deleteOption.graphql
@@ -1,5 +1,14 @@
+#import "./fragments/option.graphql"
+#import "./fragments/validationErrorInfo.graphql"
+
 mutation DeleteOption($input: DeleteOptionInput!) {
   deleteOption(input: $input) {
     id
+    options {
+      ...Option
+      validationErrorInfo {
+        ...ValidationErrorInfo
+      }
+    }
   }
 }

--- a/eq-author/src/graphql/deleteOption.graphql
+++ b/eq-author/src/graphql/deleteOption.graphql
@@ -10,5 +10,11 @@ mutation DeleteOption($input: DeleteOptionInput!) {
         ...ValidationErrorInfo
       }
     }
+    mutuallyExclusiveOption {
+      ...Option
+      validationErrorInfo {
+        ...ValidationErrorInfo
+      }
+    }
   }
 }


### PR DESCRIPTION
…labels in option is made.

### What is the context of this PR?
Previous [PR](https://github.com/ONSdigital/eq-author-app/pull/440) neglected to update page to re-validate after option delete 

### How to review 
1. Create options with duplicate label fields
2. Duplicate label message displayed on both options
3. Delete one option
4. Duplicate label message removed from other field
5. Do the same with OR option
