### PR TITLE
Enable graphql playground

### DIFF
--- a/eq-author-api/middleware/identification/index.js
+++ b/eq-author-api/middleware/identification/index.js
@@ -4,6 +4,11 @@ const jwt = require("jsonwebtoken");
 const { getUserByExternalId } = require("../../utils/datastore");
 
 module.exports = logger => async (req, res, next) => {
+  if (req.method === "GET") {
+    next();
+    return;
+  }
+
   const authHeader = req.header(process.env.AUTH_HEADER_KEY || "authorization");
   if (isNil(authHeader)) {
     logger.error("Request must contain a valid authorization header.");

--- a/eq-author-api/middleware/identification/index.test.js
+++ b/eq-author-api/middleware/identification/index.test.js
@@ -55,6 +55,14 @@ describe("auth middleware", () => {
     });
 
     describe("invalid token", () => {
+      it("should allow requests through when the methods is 'GET'", () => {
+        req.method = "GET";
+
+        middleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+      });
+
       it("should send a 401 response when no auth header", () => {
         req.header.mockImplementation(() => null);
 

--- a/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
+++ b/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
@@ -1,5 +1,10 @@
 module.exports = async (req, res, next) => {
-  if (!req.user.isVerified) {
+  if (req.method === "GET") {
+    next();
+    return;
+  }
+
+  if (!req.user || !req.user.isVerified) {
     res.status(401).send("User does not exist");
     return;
   }

--- a/eq-author-api/middleware/identification/rejectUnidentifiedUsers.test.js
+++ b/eq-author-api/middleware/identification/rejectUnidentifiedUsers.test.js
@@ -18,4 +18,9 @@ describe("rejectUnidentifiedUsers", () => {
     rejectUnidentifiedUsers(req, res, next);
     expect(next).toHaveBeenCalled();
   });
+  it("should allow GET calls through", () => {
+    req.method = "GET";
+    rejectUnidentifiedUsers(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
 });

--- a/eq-author-api/server.js
+++ b/eq-author-api/server.js
@@ -53,11 +53,24 @@ const createApp = () => {
           defaultSrc: ["'self'"],
           objectSrc: ["'none'"],
           baseUri: ["'none'"],
-          fontSrc: ["'self'", "'https://fonts.gstatic.com'"],
+          fontSrc: ["'self'", "https://fonts.gstatic.com"],
+          styleSrc: [
+            "'self'",
+            "http://cdn.jsdelivr.net/npm/@apollographql/",
+            "https://fonts.googleapis.com",
+            // These will change with graphql server versions
+            "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
+            "'sha256-iRiwFogHwyIOlQ0vgwGxLZXMnuPZa9eZnswp4v8s6fE='",
+            "'sha256-WYkrRZYpK8d/rqMjoMTIfcPzRxeojQUncPzhW9/2pg8='",
+            "'sha256-jQoC6QpIonlMBPFbUGlJFRJFFWbbijMl7Z8XqWrb46o='",
+          ],
           scriptSrc: [
             "'self'",
-            "'https://www.googleapis.com/identitytoolkit/v3'",
+            "https://www.googleapis.com/identitytoolkit/v3",
+            "http://cdn.jsdelivr.net/npm/@apollographql/",
+            "'sha256-qQ+vMtTOJ7ZAi9QUiV74BIEp2+xQJt7uiJ47QICu6xI='",
           ],
+          imgSrc: ["'self'", "http://cdn.jsdelivr.net/npm/@apollographql/"],
         },
       },
     }),
@@ -100,7 +113,7 @@ const createApp = () => {
       );
   }
 
-  app.get("/signIn", identificationMiddleware(logger), upsertUser);
+  app.post("/signIn", identificationMiddleware(logger), upsertUser);
 
   return app;
 };

--- a/eq-author/src/redux/auth/actions.js
+++ b/eq-author/src/redux/auth/actions.js
@@ -51,6 +51,7 @@ export const verifyAuthStatus = () => (dispatch, getState, { auth }) => {
     }
     window
       .fetch("/signIn", {
+        method: "POST",
         headers: { authorization: `Bearer ${authResult.ra}` },
       })
       .then(() =>

--- a/eq-author/src/redux/auth/actions.test.js
+++ b/eq-author/src/redux/auth/actions.test.js
@@ -99,6 +99,17 @@ describe("auth actions", () => {
       expect(auth.onAuthStateChanged).toHaveBeenCalledTimes(1);
     });
 
+    it("should update the server with the new user", () => {
+      store.dispatch(verifyAuthStatus());
+      changeHandler({});
+      expect(window.fetch).toHaveBeenCalledWith("/signIn", {
+        method: "POST",
+        headers: {
+          authorization: expect.stringMatching(/^Bearer .?/),
+        },
+      });
+    });
+
     it("should sign in user if determined to be authenticated", () => {
       store.dispatch(verifyAuthStatus());
       const toJSON = jest.fn().mockReturnValue(user);


### PR DESCRIPTION
### What is the context of this PR?
To work with subscriptions we need a decent client and either this requires using altair (a third party client) or we can enable graphql playground which comes with graphql server.

To enable this we need to allow GET requests through to graphql which required changing the auth middleware. 

This also required updating our CSP to allow it to import scripts and run them. Unfortunately it seems to use inline scripts and styles to run so we could either enable `unsafe-inline` or take the sha from the Chrome error. I chose the latter.

### How to review 
1. Hit `/graphql` on either http://localhost:3000/graphql or http://localhost:4000/graphql
1. Ensure that after adding an `authorization` header you can make calls and get autocomplete in the graphql playground interface.