### PR TITLE
Fixed bug on creation of a routing rule on a radio answer

### DIFF
--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -13,6 +13,7 @@ const {
 const {
   createExpression,
   createLeftSide,
+  createRightSide,
 } = require("../../../../src/businessLogic");
 
 const { withWritePermission } = require("../../withWritePermission");
@@ -155,6 +156,7 @@ Resolvers.Mutation = {
     const expression = createExpression({
       left,
       condition: condition || "Equal",
+      right: createRightSide(firstAnswer),
     });
 
     expressionGroup.expressions.push(expression);

--- a/eq-author-api/schema/resolvers/routing2/routing2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/routing2/index.js
@@ -10,6 +10,7 @@ const {
   createExpressionGroup,
   createExpression,
   createLeftSide,
+  createRightSide,
 } = require("../../../../src/businessLogic");
 
 const answerTypeToConditions = require("../../../../src/businessLogic/answerTypeToConditions");
@@ -81,6 +82,7 @@ Resolvers.Mutation = {
               createExpression({
                 left: createLeftSide(leftHandSide),
                 condition,
+                right: createRightSide(firstAnswer),
               }),
             ],
           }),

--- a/eq-author-api/schema/resolvers/routing2/routingRule2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/routingRule2/index.js
@@ -13,12 +13,14 @@ const { withWritePermission } = require("../../withWritePermission");
 const isMutuallyExclusive = require("../../../../utils/isMutuallyExclusive");
 
 const conditions = require("../../../../constants/routingConditions");
+
 const {
   createDestination,
   createRoutingRule,
   createExpressionGroup,
   createExpression,
   createLeftSide,
+  createRightSide,
 } = require("../../../../src/businessLogic");
 const availableRoutingDestinations = require("../../../../src/businessLogic/availableRoutingDestinations");
 const validateRoutingDestinations = require("../../../../src/businessLogic/validateRoutingDestination");
@@ -89,6 +91,7 @@ Resolvers.Mutation = {
           createExpression({
             left: createLeftSide(leftHandSide),
             condition,
+            right: createRightSide(firstAnswer),
           }),
         ],
       }),

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -59,7 +59,7 @@ describe("routing", () => {
       ).toEqual(page.answers[0].id);
       expect(
         result.routing.rules[0].expressionGroup.expressions[0].right
-      ).toBeNull();
+      ).toEqual({ options: [] });
     });
 
     // Passes intermittently

--- a/eq-author-api/src/businessLogic/createRightSide.js
+++ b/eq-author-api/src/businessLogic/createRightSide.js
@@ -1,0 +1,8 @@
+const { RADIO } = require("../../constants/answerTypes");
+
+module.exports = firstAnswer => {
+  if (firstAnswer.type === RADIO) {
+    return { type: "SelectedOptions", optionIds: [] };
+  }
+  return;
+};

--- a/eq-author-api/src/businessLogic/index.js
+++ b/eq-author-api/src/businessLogic/index.js
@@ -5,6 +5,7 @@ const createExpressionGroup = require("./createExpressionGroup");
 const createExpression = require("./createExpression");
 const createLeftSide = require("./createLeftSide");
 const getNextDestination = require("./getNextDestination");
+const createRightSide = require("./createRightSide");
 
 module.exports = {
   createRouting,
@@ -14,4 +15,5 @@ module.exports = {
   createExpression,
   createLeftSide,
   getNextDestination,
+  createRightSide,
 };


### PR DESCRIPTION
### What is the context of this PR?
When creating a routing rule or expression on a radio answer the rule would start in an invalid state as right side wasn't being initialized correctly. Fixed in this PR and right side is created correctly on radio answers.

### How to review 
On master create a radio answer then create a rule and attempt to publish without changing anything. Should fail. Repeat on this branch and it should be successful. 
