### PR TITLE
Fix bugs after header redesign

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -8,7 +8,42 @@ exports[`QuestionnaireDesignPage should redirect to the introduction if it has o
 `;
 
 exports[`QuestionnaireDesignPage should render 1`] = `
-<BaseLayout>
+<BaseLayout
+  questionnaire={
+    Object {
+      "displayName": "my displayName",
+      "id": "3",
+      "sections": Array [
+        Object {
+          "id": "2",
+          "pages": Array [
+            Object {
+              "answers": Array [
+                Object {
+                  "id": "1",
+                  "label": "",
+                  "options": Array [
+                    Object {
+                      "id": "1",
+                    },
+                  ],
+                },
+              ],
+              "description": "",
+              "guidance": "",
+              "id": "1",
+              "pageType": "QuestionPage",
+              "position": 0,
+              "title": "",
+            },
+          ],
+          "title": "",
+        },
+      ],
+      "title": "hello world",
+    }
+  }
+>
   <GetContext
     title={[Function]}
   >

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -197,7 +197,7 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
     }
 
     return (
-      <BaseLayout>
+      <BaseLayout questionnaire={questionnaire}>
         <Titled title={this.getTitle}>
           <Grid>
             <Column cols={3} gutters={false}>

--- a/eq-author/src/components/Layout/index.js
+++ b/eq-author/src/components/Layout/index.js
@@ -11,7 +11,9 @@ const Layout = ({ title, children }) => (
   <Titled title={() => title}>
     <BaseLayout>
       <Header title={title} />
-      <MainCanvas maxWidth="70em">{children}</MainCanvas>
+      <div>
+        <MainCanvas maxWidth="70em">{children}</MainCanvas>
+      </div>
     </BaseLayout>
   </Titled>
 );


### PR DESCRIPTION
### What is the context of this PR?
This fixes issues noticed by @SamGodwin2 after the header redesign.

1. Empty state on questionnaire view was not expanding to take available
space.

2. Fix issue with read only banner not being shown in read only mode

### How to review 
1. See that the issues on master as described above are no longer created in this branch