### PR TITLE
Much better fix for layout issue

### DIFF
--- a/eq-author/src/components/Layout/index.js
+++ b/eq-author/src/components/Layout/index.js
@@ -11,9 +11,7 @@ const Layout = ({ title, children }) => (
   <Titled title={() => title}>
     <BaseLayout>
       <Header title={title} />
-      <div>
-        <MainCanvas maxWidth="70em">{children}</MainCanvas>
-      </div>
+      <MainCanvas maxWidth="70em">{children}</MainCanvas>
     </BaseLayout>
   </Titled>
 );

--- a/eq-author/src/components/MainCanvas/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/MainCanvas/__snapshots__/index.test.js.snap
@@ -6,6 +6,7 @@ exports[`MainCanvas should render 1`] = `
   margin: 0 auto 1em;
   padding: 0 1em;
   position: relative;
+  width: 100%;
 }
 
 <main

--- a/eq-author/src/components/MainCanvas/index.js
+++ b/eq-author/src/components/MainCanvas/index.js
@@ -5,6 +5,7 @@ const MainCanvas = styled.main`
   margin: 0 auto 1em;
   padding: 0 1em;
   position: relative;
+  width: 100%;
 `;
 
 MainCanvas.defaultProps = {


### PR DESCRIPTION
### What is the context of this PR?
This reduces the unnecessary `div` from `Layout` to resolve the issue with the empty states collapsing

### How to review 
1. See that the no editor questionnaires view is still the correct width
