### PR TITLE
Remove references to an unused environment variable.

### DIFF
--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -65,7 +65,6 @@
       window.config.REACT_APP_LAUNCH_URL = "";
       window.config.REACT_APP_FULLSTORY_ORG = "";
       window.config.REACT_APP_SENTRY_DSN = "";
-      window.config.REACT_APP_AUTH_TYPE = "";
       window.config.REACT_APP_HOT_JAR_ID = "";
       window.config.REACT_APP_GTM_ID = "";
       window.config.REACT_APP_GTM_ENV_ID = "";

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -20,8 +20,6 @@ const config = {
     process.env.REACT_APP_FULLSTORY_ORG,
   REACT_APP_SENTRY_DSN:
     window.config.REACT_APP_SENTRY_DSN || process.env.REACT_APP_SENTRY_DSN,
-  REACT_APP_AUTH_TYPE:
-    window.config.REACT_APP_AUTH_TYPE || process.env.REACT_APP_AUTH_TYPE,
   REACT_APP_HOT_JAR_ID:
     window.config.REACT_APP_HOT_JAR_ID || process.env.REACT_APP_HOT_JAR_ID,
   REACT_APP_GTM_ID:

--- a/eq-author/src/redux/auth/reducer.js
+++ b/eq-author/src/redux/auth/reducer.js
@@ -1,4 +1,3 @@
-import config from "config";
 import { get, isNil } from "lodash";
 import { SIGN_IN_USER, SIGN_OUT_USER } from "./actions";
 
@@ -28,9 +27,6 @@ export default (state = initialState, { type, payload }) => {
 
 export const getUser = state => get(state, "auth.user");
 export const isSignedIn = () => {
-  return (
-    config.REACT_APP_AUTH_TYPE === "external" ||
-    (localStorage && !isNil(localStorage.getItem("accessToken")))
-  );
+  return localStorage && !isNil(localStorage.getItem("accessToken"));
 };
 export const verifiedAuthStatus = state => get(state, "auth.verifiedStatus");


### PR DESCRIPTION
### What is the context of this PR?
I noticed that there was an environment variable being referenced in Author.
I could not find anywhere where we are setting this environment variable in the `eq-deploy` repo and we don't appear to be setting it to anything other than "firebase" in `eq-author-terraform` (see [here](https://github.com/ONSdigital/eq-author-terraform/blob/e6f430c3cab36e7ac125262b45d231fe7a23b3cf/author.tf#L266)) so we can probably remove it.

### How to review 
Shout if I've missed something.
