### PR TITLE
Added a check on every request to see if the access token is valid

### DIFF
--- a/eq-author/src/middleware/headers/authHeader.test.js
+++ b/eq-author/src/middleware/headers/authHeader.test.js
@@ -1,44 +1,58 @@
 import appendAuthHeader from "./authHeader";
+import jwt from "jsonwebtoken";
+import { SynchronousPromise } from "synchronous-promise";
 
 describe("appendAuthHeader", () => {
-  let otherHeaders;
+  let otherHeaders, originalFetch;
 
   beforeEach(() => {
     otherHeaders = {
       ContentType: "text/html",
     };
+    originalFetch = window.fetch;
+    window.fetch = jest.fn(() =>
+      SynchronousPromise.resolve({
+        //eslint-disable-next-line
+        json: jest.fn(() => ({ access_token: "I'm a access token, honest!" })),
+      })
+    );
 
     localStorage.removeItem("accessToken");
   });
 
-  describe("non-existent localStorage", () => {
-    let tempLocalStorage = {};
-    beforeEach(() => {
-      Object.assign(tempLocalStorage, localStorage);
-    });
-    afterEach(() => {
-      Object.defineProperty(window, "localStorage", {
-        value: tempLocalStorage,
-      });
-    });
-
-    it("should just return default headers if no localStorage exists", () => {
-      expect(appendAuthHeader(otherHeaders)).toMatchObject({
-        ContentType: "text/html",
-      });
-    });
+  afterEach(() => {
+    window.fetch = originalFetch;
   });
 
-  it("should append auth header if token exists", () => {
-    localStorage.setItem("accessToken", "abc.def.ghi");
+  it("should append auth header if token exists and has not expired", async () => {
+    const token = jwt.sign(
+      {
+        test: "I'm a jwt from the future",
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      "shhhhh"
+    );
+    localStorage.setItem("accessToken", token);
 
-    expect(appendAuthHeader(otherHeaders)).toMatchObject({
+    await expect(appendAuthHeader(otherHeaders)).resolves.toMatchObject({
       ContentType: "text/html",
-      authorization: "Bearer abc.def.ghi",
+      authorization: `Bearer ${token}`,
     });
   });
 
-  it("should not append auth header if no access token exists", () => {
-    expect(appendAuthHeader(otherHeaders)).not.toHaveProperty("authorization");
+  it("try to fetch a new token if current access token has expired", async () => {
+    const token = jwt.sign(
+      {
+        test: "I'm a jwt from the past",
+        exp: Math.floor(Date.now() / 1000) - 300,
+      },
+      "shhhhh"
+    );
+    localStorage.setItem("accessToken", token);
+
+    await expect(appendAuthHeader(otherHeaders)).resolves.toMatchObject({
+      ContentType: "text/html",
+      authorization: "Bearer I'm a access token, honest!",
+    });
   });
 });

--- a/eq-author/src/redux/auth/actions.js
+++ b/eq-author/src/redux/auth/actions.js
@@ -4,18 +4,10 @@ export const SIGN_IN_USER = "SIGN_IN_USER";
 export const SIGN_OUT_USER = "SIGN_OUT_USER";
 export const SIGN_IN_ERROR = "SIGN_IN_ERROR";
 
-export const signInUser = ({
-  displayName,
-  email,
-  photoURL,
-  stsTokenManager: { accessToken },
-  uid,
-}) => {
+export const signInUser = ({ displayName, email, photoURL, uid }) => {
   if (config.REACT_APP_FULLSTORY_ORG) {
     window.FS.identify(email, { displayName });
   }
-
-  localStorage.setItem("accessToken", accessToken);
 
   return {
     type: SIGN_IN_USER,


### PR DESCRIPTION
### What is the context of this PR?
Currently the app allows you to use an out-of-date jwt token in all the requests to the api. As we don't validate this currently that is not a problem however now we need to check the tokens are coming from firebase in this PR: https://github.com/ONSdigital/eq-author-app/pull/427

An invalid token could be rejected by the api if it is more than 7 hours old due to google rotating the signing keys.

This PR adds a check to ensure that the access token sent to the api is valid and if it is not it will use the refresh token to ask google for a new one.

### How to review 
Log in on master and check your access token, if its invalid great, if not wait an hour (not sure how else to do this?) then when it has expired check out this branch. You should find as soon as the app loads your old expired token has been replaced with a shiny new one. 

Also tests pass
