### PR TITLE
Wrapped the headers builder in a piped promise util

### DIFF
--- a/eq-author/src/index.js
+++ b/eq-author/src/index.js
@@ -28,8 +28,8 @@ auth.onIdTokenChanged(user => {
     localStorage.setItem("accessToken", user.ra);
     localStorage.setItem("refreshToken", user.refreshToken);
   } else {
-    localStorage.removeItem("accessToken", user.ra);
-    localStorage.removeItem("refreshToken", user.refreshToken);
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
   }
 });
 

--- a/eq-author/src/middleware/headers/authHeader.js
+++ b/eq-author/src/middleware/headers/authHeader.js
@@ -44,5 +44,5 @@ export default headers => {
 
   returnedHeaders.authorization = `Bearer ${accessToken}`;
 
-  return Promise.resolve(returnedHeaders);
+  return returnedHeaders;
 };

--- a/eq-author/src/middleware/headers/authHeader.test.js
+++ b/eq-author/src/middleware/headers/authHeader.test.js
@@ -24,7 +24,7 @@ describe("appendAuthHeader", () => {
     window.fetch = originalFetch;
   });
 
-  it("should append auth header if token exists and has not expired", async () => {
+  it("should append auth header if token exists and has not expired", () => {
     const token = jwt.sign(
       {
         test: "I'm a jwt from the future",
@@ -34,7 +34,7 @@ describe("appendAuthHeader", () => {
     );
     localStorage.setItem("accessToken", token);
 
-    await expect(appendAuthHeader(otherHeaders)).resolves.toMatchObject({
+    expect(appendAuthHeader(otherHeaders)).toMatchObject({
       ContentType: "text/html",
       authorization: `Bearer ${token}`,
     });

--- a/eq-author/src/middleware/headers/index.js
+++ b/eq-author/src/middleware/headers/index.js
@@ -1,8 +1,8 @@
 import appendAuthHeader from "./authHeader";
 import appendVersionHeader from "./versionHeader";
-import { flow } from "lodash";
+import pipeP from "utils/pipeP";
 
-export default flow(
+export default pipeP(
   appendAuthHeader,
   appendVersionHeader
 );


### PR DESCRIPTION
### What is the context of this PR?
Bug appeared in staging due to a new env var that doesn't exist normally locally, this was causing the get headers function to return an object rather than a promise. This Pr fixes that by wrapping the header builder in a util we have which flows promises and returns a promise object.

### How to review 
on Master add the REACT_APP_EQ_AUTHOR_VERSION="hello" to local envs and reset the app. It'll fail. Check out this branch and you'll see it working again. 
