### PR TITLE
Styling fix for validation error on other option

### DIFF
--- a/eq-author-api/src/businessLogic/createAdditionalAnswer.js
+++ b/eq-author-api/src/businessLogic/createAdditionalAnswer.js
@@ -4,5 +4,6 @@ const { TEXTFIELD } = require("../../constants/answerTypes");
 module.exports = () =>
   createAnswer({
     description: "",
+    label: "",
     type: TEXTFIELD,
   });

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -22,6 +22,7 @@ export const StatelessBasicAnswer = ({
   children,
   labelPlaceholder,
   labelText,
+  errorLabel,
   descriptionText,
   descriptionPlaceholder,
   showDescription,
@@ -43,7 +44,7 @@ export const StatelessBasicAnswer = ({
         bold
         errorValidationMsg={getValidationError({
           field: "label",
-          label: "Answer label",
+          label: errorLabel,
         })}
       />
     </Field>
@@ -76,6 +77,7 @@ StatelessBasicAnswer.propTypes = {
   children: PropTypes.element,
   labelText: PropTypes.string,
   labelPlaceholder: PropTypes.string,
+  errorLabel: PropTypes.string,
   descriptionText: PropTypes.string,
   descriptionPlaceholder: PropTypes.string,
   showDescription: PropTypes.bool,
@@ -85,6 +87,7 @@ StatelessBasicAnswer.propTypes = {
 
 StatelessBasicAnswer.defaultProps = {
   labelText: "Label",
+  errorLabel: "Answer label",
   descriptionText: "Description (optional)",
   showDescription: false,
   autoFocus: true,

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
@@ -50,7 +50,7 @@ export const AddOtherLink = styled.button`
 
 const SpecialOptionWrapper = styled.div`
   padding-top: 0.25em;
-  margin-bottom: 1em;
+  margin-bottom: 2em;
 `;
 
 class MultipleChoiceAnswer extends Component {
@@ -156,6 +156,7 @@ class MultipleChoiceAnswer extends Component {
                         showDescription={false}
                         labelText="Other label"
                         labelPlaceholder="eg. Please specify"
+                        errorLabel="Other label"
                         bold={false}
                       />
                     </SpecialOptionWrapper>


### PR DESCRIPTION
### What is the context of this PR?
Added validation for mandatory label on "Other" option. This PR fixes a styling issue on Other label of Other checkbox

### How to review 
1. Create at checkbox/radio answer with at least 2 options
2. Empty labels in options should have validation error and disappear when filled in. Error does not appear until input is blurred.
3. Ensure duplicate labels for options generate validation error
4. Ensure Other validation message displays within Option border
