### PR TITLE
Fix button colour on touch devices

### DIFF
--- a/eq-author/src/App/page/PropertiesPanel/QuestionProperties/index.js
+++ b/eq-author/src/App/page/PropertiesPanel/QuestionProperties/index.js
@@ -27,6 +27,7 @@ const FieldInfo = styled(IconText)`
 
 export const HelpButton = styled.button`
   --color-text: ${colors.primary};
+  background: ${colors.white};
   margin: 0.5em 0;
   position: relative;
   left: -0.5em;

--- a/eq-author/src/components/buttons/SidebarButton/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/SidebarButton/__snapshots__/index.test.js.snap
@@ -15,6 +15,7 @@ exports[`SidebarButton should render 1`] = `
   transition: all 100ms ease-out;
   position: relative;
   cursor: pointer;
+  background: #FFFFFF;
 }
 
 .c0:hover {

--- a/eq-author/src/components/buttons/SidebarButton/index.js
+++ b/eq-author/src/components/buttons/SidebarButton/index.js
@@ -15,6 +15,7 @@ const SidebarButton = styled.button`
   transition: all 100ms ease-out;
   position: relative;
   cursor: pointer;
+  background: ${colors.white};
 
   &:hover {
     border: 1px solid ${colors.borders};


### PR DESCRIPTION
### What is the context of this PR?
Fix the button background on touch devices. I've had a look around the app but these are the only ones I found.

Closes #446 

### How to review 
1. Switch chrome to responsive view via the mobile button in dev tools.
1. See that the buttons in the right hand panel are grey.
1. See in this branch they are now the correct colour.
