### PR TITLE
Bug - Wide sign in page

### DIFF
--- a/eq-author/src/App/SignInPage/SignInForm/index.js
+++ b/eq-author/src/App/SignInPage/SignInForm/index.js
@@ -34,6 +34,8 @@ const SignInForm = styled(FirebaseAuth)`
   .firebaseui-container {
     box-shadow: none;
   }
+
+  min-width: 100%;
 `;
 
 SignInForm.defaultProps = {

--- a/eq-author/src/App/SignInPage/index.js
+++ b/eq-author/src/App/SignInPage/index.js
@@ -18,12 +18,13 @@ const Text = styled.p`
 `;
 
 const SignInPanel = styled(Panel)`
-  margin-top: 3em;
+  margin: 3em auto 0;
   padding: 2em 3em;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  max-width: 25em;
 `;
 
 export class UnconnectedSignInPage extends React.Component {


### PR DESCRIPTION
### What is the context of this PR?
Reduce width of sign in page and remove wiggle

Closes #472 

### How to review 
1. See that the sign in page is full width on master
1. See that on master the elements move when you enter an incorrect password
1. See this PR reduces the width
1. See that the form elements do not move on this branch