### PR TITLE
Added transitions to Optional fields add/remove

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerTransition.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerTransition.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { CSSTransition } from "react-transition-group";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -10,7 +11,7 @@ const handleExit = node => {
   node.style.height = `${height}px`;
 };
 
-const AnswerTransition = styled(CSSTransition).attrs({
+const AnswerTransitionWrapper = styled(CSSTransition).attrs({
   classNames: "answer",
   onExit: () => handleExit,
 })`
@@ -43,6 +44,14 @@ const AnswerTransition = styled(CSSTransition).attrs({
       transform ${halfTimeout}ms ease-in;
   }
 `;
+
+const AnswerTransition = ({ children, ...otherProps }) => {
+  return (
+    <AnswerTransitionWrapper {...otherProps}>
+      <div>{children}</div>
+    </AnswerTransitionWrapper>
+  );
+};
 
 AnswerTransition.propTypes = {
   timeout: PropTypes.number,

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerTransition.test.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerTransition.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 
 import AnswerTransition from "./AnswerTransition";
 
@@ -15,7 +15,7 @@ describe("components/QuestionPageEditor/AnswerTransition", () => {
   });
 
   it("should set the final height of the element to the height of the element at the end of transition", () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AnswerTransition>
         <div>Content</div>
       </AnswerTransition>
@@ -26,7 +26,11 @@ describe("components/QuestionPageEditor/AnswerTransition", () => {
         height: null,
       },
     };
-    wrapper.props().onExit(node);
+
+    wrapper
+      .find("CSSTransition")
+      .props()
+      .onExit(node);
     expect(node.style.height).toEqual("10px");
   });
 });

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/__snapshots__/AnswerTransition.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/__snapshots__/AnswerTransition.test.js.snap
@@ -1,54 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/QuestionPageEditor/AnswerTransition should render 1`] = `
-.c0 {
-  position: relative;
-}
-
-.c0.answer-enter {
-  opacity: 0;
-  -webkit-transform: scale(0.9);
-  -ms-transform: scale(0.9);
-  transform: scale(0.9);
-  z-index: 200;
-}
-
-.c0.answer-enter-active {
-  opacity: 1;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transition: opacity 200ms ease-out,-webkit-transform 200ms cubic-bezier(0.175,0.885,0.32,1.275);
-  -webkit-transition: opacity 200ms ease-out,transform 200ms cubic-bezier(0.175,0.885,0.32,1.275);
-  transition: opacity 200ms ease-out,transform 200ms cubic-bezier(0.175,0.885,0.32,1.275);
-}
-
-.c0.answer-exit {
-  opacity: 1;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.c0.answer-exit-active {
-  opacity: 0;
-  height: 0 !important;
-  -webkit-transform: scale(0.9);
-  -ms-transform: scale(0.9);
-  transform: scale(0.9);
-  -webkit-transition: opacity 100ms ease-out,height 100ms ease-in 100ms,-webkit-transform 100ms ease-in;
-  -webkit-transition: opacity 100ms ease-out,height 100ms ease-in 100ms,transform 100ms ease-in;
-  transition: opacity 100ms ease-out,height 100ms ease-in 100ms,transform 100ms ease-in;
-}
-
-<CSSTransition
-  className="c0"
-  classNames="answer"
-  onExit={[Function]}
+<AnswerTransition__AnswerTransitionWrapper
   timeout={200}
 >
   <div>
-    Content
+    <div>
+      Content
+    </div>
   </div>
-</CSSTransition>
+</AnswerTransition__AnswerTransitionWrapper>
 `;


### PR DESCRIPTION
### What is the context of this PR?
Optional fields were not transitioning in/out

### How to review 
Toggling an "optional field" on a question page should result in that field transitioning in or out.

1. Create a questionnaire
2. Navigate to question page
3. Toggle an "optional field"
4. Pay attention to that field appearing or disappearing - master branch won't have the 200ms transition (opacity & size)

closes https://github.com/ONSdigital/eq-author-app/issues/273 