### PR TITLE
Fix issue with script stopping on first questionnaire with same version

### DIFF
--- a/eq-author-api/scripts/bulkMigrateDataStore.js
+++ b/eq-author-api/scripts/bulkMigrateDataStore.js
@@ -13,7 +13,7 @@ const bulkMigrateDataStore = async () => {
   for (let q = 0; q < questionnaireList.length; q++) {
     let latestQuestionnaire = await getQuestionnaire(questionnaireList[q].id);
     if (latestQuestionnaire.version === currentVersion) {
-      return;
+      continue;
     }
 
     const bringQuestionnaireToLatest = async () => {


### PR DESCRIPTION
### What is the context of this PR?
Fix issue with `eq-author-api/scripts/bulkMigrateDataStore.js` breaking the for loop on the first occurrence of `latestQuestionnaire.version === currentVersion`. Script should now only break the current iteration and start on the next one.

