### PR TITLE
Bug - Unable to scroll questionnaire list

### DIFF
--- a/eq-author/src/components/Layout/index.js
+++ b/eq-author/src/components/Layout/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Titled } from "react-titled";
 import PropTypes from "prop-types";
 
+import ScrollPane from "components/ScrollPane";
 import BaseLayout from "components/BaseLayout";
 import MainCanvas from "components/MainCanvas";
 
@@ -11,7 +12,9 @@ const Layout = ({ title, children }) => (
   <Titled title={() => title}>
     <BaseLayout>
       <Header title={title} />
-      <MainCanvas maxWidth="70em">{children}</MainCanvas>
+      <ScrollPane>
+        <MainCanvas maxWidth="70em">{children}</MainCanvas>
+      </ScrollPane>
     </BaseLayout>
   </Titled>
 );


### PR DESCRIPTION
### What is the context of this PR?
Users are unable to scroll the questionnaire list on small screen. This is because the scroll pane was moved as a part of the header redesign as it was thought to be unnecessary.

### How to review 
1. Add a number of questionnaires
1. Shrink the height of your screen and see you are unable to scroll
1. See that with this PR this is resolved
