### PR TITLE
Bug - Incorrectly calculating websocket protocol

### DIFF
--- a/eq-author/src/index.js
+++ b/eq-author/src/index.js
@@ -60,7 +60,7 @@ const history = createHistory();
 const httpLink = createHttpLink(config.REACT_APP_API_URL);
 let wsUri;
 if (config.REACT_APP_API_URL.startsWith("http")) {
-  wsUri = config.REACT_APP_API_URL.replace(/http[s]?:\/\//, "ws://");
+  wsUri = config.REACT_APP_API_URL.replace(/http([s])?:\/\//, "ws$1://");
 } else {
   const loc = window.location;
   const protocol = loc.protocol === "https:" ? "wss" : "ws";


### PR DESCRIPTION
### What is the context of this PR?
Fix issue where incorrectly calculating websocket protocol
When the API url contains a protocol we were always setting it to insecure websocket

### How to review 
1. Ensure the netlify preview linked to this PR loads
