### PR TITLE
Removed routing rules referencing deleted page

### DIFF
--- a/eq-author-api/schema/resolvers/pages/index.js
+++ b/eq-author-api/schema/resolvers/pages/index.js
@@ -1,6 +1,9 @@
 const { find, findIndex, remove, omit, set, first } = require("lodash");
 
 const { getSectionByPageId, remapAllNestedIds } = require("../utils");
+
+const onPageDeleted = require("../../../src/businessLogic/onPageDeleted");
+
 const { createMutation } = require("../createMutation");
 
 const addPrefix = require("../../../utils/addPrefix");
@@ -33,6 +36,7 @@ Resolvers.Mutation = {
   deletePage: createMutation((_, { input }, ctx) => {
     const section = getSectionByPageId(ctx, input.id);
     remove(section.pages, { id: input.id });
+    onPageDeleted(ctx, input.id);
     return section;
   }),
 

--- a/eq-author-api/src/businessLogic/onPageDeleted.js
+++ b/eq-author-api/src/businessLogic/onPageDeleted.js
@@ -1,0 +1,23 @@
+const { getPages } = require("../../schema/resolvers/utils");
+
+const onPageDeleted = (ctx, removedPageId) => {
+  const allPages = getPages(ctx);
+
+  allPages.forEach(page => {
+    if (!page.routing) {
+      return;
+    }
+
+    const validRules = page.routing.rules.filter(
+      rule => rule.destination && rule.destination.pageId !== removedPageId
+    );
+
+    if (validRules.length) {
+      page.routing.rules = validRules;
+    } else {
+      page.routing = null;
+    }
+  });
+};
+
+module.exports = onPageDeleted;

--- a/eq-author-api/tests/utils/contextBuilder/routing/updateRoutingRule.js
+++ b/eq-author-api/tests/utils/contextBuilder/routing/updateRoutingRule.js
@@ -4,6 +4,13 @@ const updateRoutingRuleMutation = `
       mutation updateRoutingRule2($input: UpdateRoutingRule2Input!) {
         updateRoutingRule2(input: $input) {
           id
+          destination {
+            id
+            page {
+              id
+            }
+            logical
+          }
           expressionGroup {
             id
             expressions {


### PR DESCRIPTION
### What is the context of this PR?
Deleting a page that has been used as a destination in routing crashes the app when returning to edit the routing is appears on.

### How to review 
1. Create at least 3 pages.
2. Add 2 rules to page 1, one referencing page2, one referencing page3
3. Delete page2
4. View page1 routing: Only routing to page3 should exist
5. Delete page3
6. View page1 routing: No routing should be displayed