### PR TITLE
Validate section navigation

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -536,6 +536,8 @@ const Resolvers = {
     availablePipingAnswers: ({ id }, args, ctx) =>
       getPreviousAnswersForSection(ctx.questionnaire, id),
     availablePipingMetadata: (section, args, ctx) => ctx.questionnaire.metadata,
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo.sections[id] || { errors: [], totalCount: 0 },
   },
 
   LogicalDestination: {

--- a/eq-author-api/schema/tests/section.test.js
+++ b/eq-author-api/schema/tests/section.test.js
@@ -189,4 +189,28 @@ describe("section", () => {
       expect(deletedSection).toBeNull();
     });
   });
+
+  describe("author validation", () => {
+    it("should validate the section and return the errors", async () => {
+      ctx = await buildContext({
+        sections: [
+          {
+            title: "",
+          },
+        ],
+        navigation: true,
+      });
+
+      questionnaire = ctx.questionnaire;
+      const section = questionnaire.sections[0];
+
+      const queriedSection = await querySection(ctx, section.id);
+
+      expect(queriedSection.validationErrorInfo).toMatchObject({
+        totalCount: 1,
+        errors: expect.any(Array),
+      });
+      expect(queriedSection.validationErrorInfo.errors).toHaveLength(1);
+    });
+  });
 });

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -73,6 +73,7 @@ type Section {
   introductionContent: String
   availablePipingAnswers: [Answer!]!
   availablePipingMetadata: [Metadata!]!
+  validationErrorInfo: ValidationErrorInfo
 }
 
 interface Page {

--- a/eq-author-api/src/validation/customKeywords/index.js
+++ b/eq-author-api/src/validation/customKeywords/index.js
@@ -1,0 +1,4 @@
+module.exports = ajv => {
+  require("./uniquePropertyValueInArrayOfObjects")(ajv);
+  require("./requiredWhenQuestionnaireSetting")(ajv);
+};

--- a/eq-author-api/src/validation/customKeywords/requiredWhenQuestionnaireSetting.js
+++ b/eq-author-api/src/validation/customKeywords/requiredWhenQuestionnaireSetting.js
@@ -1,0 +1,33 @@
+module.exports = function(ajv) {
+  ajv.addKeyword("requiredWhenQuestionnaireSetting", {
+    validate: function validate(
+      settingName,
+      value,
+      fieldValue,
+      dataPath,
+      parentData,
+      fieldName,
+      questionnaire
+    ) {
+      const setting = questionnaire[settingName];
+      if (!setting) {
+        return true;
+      }
+
+      if (/\w+/.test(value)) {
+        return true;
+      }
+
+      validate.errors = [
+        {
+          keyword: "errorMessage",
+          dataPath,
+          message: "ERR_REQUIRED_WHEN_SETTING",
+          params: {},
+        },
+      ];
+
+      return false;
+    },
+  });
+};

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -6,7 +6,7 @@ const { ANSWERS } = require("../../constants/validationErrorTypes");
 
 const ajv = new Ajv({ allErrors: true, jsonPointers: true, $data: true });
 require("ajv-errors")(ajv);
-require("./customKeywords/uniquePropertyValueInArrayOfObjects")(ajv);
+require("./customKeywords")(ajv);
 
 const validate = ajv.addSchema(schemas.slice(1)).compile(schemas[0]);
 
@@ -26,6 +26,7 @@ module.exports = questionnaire => {
       answers: {},
       pages: {},
       options: {},
+      sections: {},
       totalCount: 0,
     };
   }
@@ -95,6 +96,7 @@ module.exports = questionnaire => {
         answers: {},
         pages: {},
         options: {},
+        sections: {},
         totalCount: errorMessages.length,
       }
     );

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -71,4 +71,42 @@ describe("schema validation", () => {
       type: "answers",
     });
   });
+
+  describe("Section validation", () => {
+    it("should return an error when navigation is enabled but there is no section title", () => {
+      questionnaire.navigation = true;
+      const section = questionnaire.sections[0];
+      section.title = "";
+
+      const validationErrors = validation(questionnaire);
+      const sectionErrors = validationErrors.sections[section.id].errors;
+      expect(sectionErrors).toHaveLength(1);
+      expect(sectionErrors[0]).toMatchObject({
+        errorCode: "ERR_REQUIRED_WHEN_SETTING",
+        field: "title",
+        id: section.id,
+        type: "sections",
+      });
+    });
+
+    it("should NOT return an error when navigation is disabled but there is no section title", () => {
+      questionnaire.navigation = false;
+      const section = questionnaire.sections[0];
+      section.title = "";
+
+      const validationErrors = validation(questionnaire);
+      const sectionErrors = validationErrors.sections[section.id];
+      expect(sectionErrors).toBeUndefined();
+    });
+
+    it("should NOT return an error when navigation is enabled and there is a title", () => {
+      questionnaire.navigation = true;
+      const section = questionnaire.sections[0];
+      section.title = "Section title";
+
+      const validationErrors = validation(questionnaire);
+      const sectionErrors = validationErrors.sections[section.id];
+      expect(sectionErrors).toBeUndefined();
+    });
+  });
 });

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -6,7 +6,8 @@
       "properties": {
         "id": { "type": "string" },
         "title": {
-          "type": "string"
+          "type": "string",
+          "requiredWhenQuestionnaireSetting": "navigation"
         },
         "pages": {
           "type": "array",
@@ -15,7 +16,7 @@
           }
         }
       },
-      "required": ["id", "title", "pages"]
+      "required": ["id", "pages"]
     },
     "page": {
       "type": "object",

--- a/eq-author-api/tests/utils/contextBuilder/section/querySection.js
+++ b/eq-author-api/tests/utils/contextBuilder/section/querySection.js
@@ -20,6 +20,12 @@ const getSectionQuery = `
       availablePipingMetadata {
         id
       }
+      validationErrorInfo {
+        totalCount
+        errors {
+          id
+        }
+      }
     }
   }
 `;

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import SectionEditor from "App/section/Design/SectionEditor";
+
+import { SectionEditor } from "App/section/Design/SectionEditor";
 import RichTextEditor from "components/RichTextEditor";
 
 describe("SectionEditor", () => {
@@ -14,6 +15,10 @@ describe("SectionEditor", () => {
       id: "2",
       navigation: true,
     },
+    validationErrorInfo: {
+      totalCount: 0,
+      errors: [],
+    },
   };
 
   const section2 = {
@@ -25,6 +30,10 @@ describe("SectionEditor", () => {
     questionnaire: {
       id: "2",
       navigation: true,
+    },
+    validationErrorInfo: {
+      totalCount: 0,
+      errors: [],
     },
   };
 
@@ -43,6 +52,7 @@ describe("SectionEditor", () => {
     onCloseDeleteConfirmDialog: jest.fn(),
     onMoveSectionDialog: jest.fn(),
     onCloseMoveSectionDialog: jest.fn(),
+    getValidationError: jest.fn(),
   };
 
   const render = ({ ...props }) =>
@@ -134,6 +144,28 @@ describe("SectionEditor", () => {
     expect(
       wrapper.find("[testSelector='txt-section-title']").prop("autoFocus")
     ).toBe(false);
+  });
+
+  it("should show an error when there is a validation error", () => {
+    const getValidationError = jest.fn().mockReturnValue("Validation error");
+    const wrapper = render({
+      section: {
+        ...section1,
+        title: "",
+      },
+      getValidationError,
+    });
+    expect(
+      wrapper
+        .find("[testSelector='txt-section-title']")
+        .prop("errorValidationMsg")
+    ).toBe("Validation error");
+
+    expect(getValidationError).toHaveBeenCalledWith({
+      field: "title",
+      message:
+        "Enter a section title. If section navigation is not required, disable in 'settings'.",
+    });
   });
 
   describe("DeleteConfirmDialog", () => {

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -12,6 +12,8 @@ import { Label } from "components/Forms";
 
 import { colors, radius } from "constants/theme";
 
+import withValidationError from "enhancers/withValidationError";
+
 import sectionFragment from "graphql/fragments/section.graphql";
 
 import getIdForObject from "utils/getIdForObject";
@@ -41,7 +43,7 @@ const IntroCanvas = styled.div`
 
 const hasNavigation = section => get(section, ["questionnaire", "navigation"]);
 
-class SectionEditor extends React.Component {
+export class SectionEditor extends React.Component {
   static propTypes = {
     section: propType(sectionFragment),
     onChange: PropTypes.func.isRequired,
@@ -53,6 +55,7 @@ class SectionEditor extends React.Component {
     showMoveSectionDialog: PropTypes.bool.isRequired,
     onCloseMoveSectionDialog: PropTypes.func.isRequired,
     match: CustomPropTypes.match,
+    getValidationError: PropTypes.func.isRequired,
   };
 
   state = {
@@ -139,6 +142,11 @@ class SectionEditor extends React.Component {
               size="large"
               testSelector="txt-section-title"
               autoFocus={autoFocusTitle}
+              errorValidationMsg={this.props.getValidationError({
+                field: "title",
+                message:
+                  "Enter a section title. If section navigation is not required, disable in 'settings'.",
+              })}
             />
           )}
           <Label>
@@ -184,4 +192,4 @@ SectionEditor.fragments = {
   Section: sectionFragment,
 };
 
-export default SectionEditor;
+export default withValidationError("section")(SectionEditor);

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -87,6 +87,11 @@ const moveSectionMock = {
                 totalSectionCount: 1,
               },
             },
+            validationErrorInfo: {
+              totalCount: 0,
+              errors: [],
+              __typename: "ValidationErrorInfo",
+            },
           },
           {
             __typename: "Section",
@@ -123,6 +128,11 @@ const moveSectionMock = {
                 __typename: "QuestionnaireInfo",
                 totalSectionCount: 1,
               },
+            },
+            validationErrorInfo: {
+              totalCount: 0,
+              errors: [],
+              __typename: "ValidationErrorInfo",
             },
           },
         ],
@@ -195,6 +205,11 @@ describe("SectionRoute", () => {
                   totalSectionCount: 1,
                 },
               },
+              validationErrorInfo: {
+                totalCount: 0,
+                errors: [],
+                __typename: "ValidationErrorInfo",
+              },
             },
           },
         },
@@ -234,6 +249,11 @@ describe("SectionRoute", () => {
                   __typename: "QuestionnaireInfo",
                   totalSectionCount: 1,
                 },
+              },
+              validationErrorInfo: {
+                totalCount: 0,
+                errors: [],
+                __typename: "ValidationErrorInfo",
               },
             },
           },
@@ -324,6 +344,11 @@ describe("SectionRoute", () => {
         questionnaireInfo: {
           totalSectionCount: 1,
         },
+      },
+      validationErrorInfo: {
+        totalCount: 0,
+        errors: [],
+        __typename: "ValidationErrorInfo",
       },
     };
 

--- a/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
+++ b/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
@@ -17,6 +17,11 @@ describe("SectionIntroPreview", () => {
         id: "1",
         navigation: true,
       },
+      validationErrorInfo: {
+        totalCount: 0,
+        errors: [],
+        __typename: "ValidationErrorInfo",
+      },
     };
   });
 

--- a/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
@@ -50,6 +50,11 @@ exports[`PreviewSectionRoute should show the section intro preview when it is fi
           "navigation": true,
         },
         "title": "",
+        "validationErrorInfo": Object {
+          "__typename": "ValidationErrorInfo",
+          "errors": Array [],
+          "totalCount": 0,
+        },
       }
     }
   />

--- a/eq-author/src/App/section/Preview/index.test.js
+++ b/eq-author/src/App/section/Preview/index.test.js
@@ -48,6 +48,11 @@ describe("PreviewSectionRoute", () => {
               id: "2",
               navigation: true,
             },
+            validationErrorInfo: {
+              totalCount: 0,
+              errors: [],
+              __typename: "ValidationErrorInfo",
+            },
           },
         }}
       />
@@ -72,6 +77,11 @@ describe("PreviewSectionRoute", () => {
             questionnaire: {
               id: "2",
               navigation: true,
+            },
+            validationErrorInfo: {
+              totalCount: 0,
+              errors: [],
+              __typename: "ValidationErrorInfo",
             },
           },
         }}

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -1,4 +1,5 @@
 export default {
   ERR_VALID_REQUIRED: ({ label }) => `${label} is required`,
   ERR_UNIQUE_REQUIRED: ({ label }) => `${label} must be unique`,
+  ERR_REQUIRED_WHEN_SETTING: ({ message }) => message,
 };

--- a/eq-author/src/constants/validationMessages.test.js
+++ b/eq-author/src/constants/validationMessages.test.js
@@ -1,12 +1,23 @@
-import VALIDATION_MESSAGES from "./validationMessages";
+import messageTemplates from "./validationMessages";
+const {
+  ERR_VALID_REQUIRED,
+  ERR_UNIQUE_REQUIRED,
+  ERR_REQUIRED_WHEN_SETTING,
+} = messageTemplates;
 
 describe("constants/validationMessages", () => {
   let label = "Field Label";
 
   it("should return validation message with correct label", () => {
-    Object.values(VALIDATION_MESSAGES).forEach(messageTemplate => {
+    [ERR_VALID_REQUIRED, ERR_UNIQUE_REQUIRED].forEach(messageTemplate => {
       const validationMessage = messageTemplate({ label });
       expect(validationMessage).toEqual(expect.stringMatching(label));
     });
+  });
+
+  it("should return the message provided", () => {
+    expect(ERR_REQUIRED_WHEN_SETTING({ message: "Some error" })).toEqual(
+      "Some error"
+    );
   });
 });

--- a/eq-author/src/enhancers/withValidationError.js
+++ b/eq-author/src/enhancers/withValidationError.js
@@ -17,7 +17,7 @@ const withValidationError = entityPropName => WrappedComponent => {
 
     static fragments = WrappedComponent.fragments;
 
-    getValidationError = ({ field, label }) => {
+    getValidationError = ({ field, ...options }) => {
       const {
         [entityPropName]: { validationErrorInfo },
       } = this.props;
@@ -33,7 +33,7 @@ const withValidationError = entityPropName => WrappedComponent => {
       const errorMessageTemplate = VALIDATION_MESSAGES[fieldMessage.errorCode];
 
       if (errorMessageTemplate) {
-        return errorMessageTemplate({ label });
+        return errorMessageTemplate(options);
       } else {
         return fieldMessage.errorCode;
       }

--- a/eq-author/src/graphql/fragments/section.graphql
+++ b/eq-author/src/graphql/fragments/section.graphql
@@ -8,4 +8,13 @@ fragment Section on Section {
     id
     navigation
   }
+  validationErrorInfo {
+    errors {
+      id
+      type
+      field
+      errorCode
+    }
+    totalCount
+  }
 }

--- a/eq-author/src/graphql/updateQuestionnaire.graphql
+++ b/eq-author/src/graphql/updateQuestionnaire.graphql
@@ -1,7 +1,14 @@
 #import "./fragments/questionnaire.graphql"
+#import "./fragments/validationErrorInfo.graphql"
 
 mutation UpdateQuestionnaire($input: UpdateQuestionnaireInput!) {
   updateQuestionnaire(input: $input) {
     ...Questionnaire
+    sections {
+      id
+      validationErrorInfo {
+        ...ValidationErrorInfo
+      }
+    }
   }
 }

--- a/eq-author/src/graphql/updateSection.graphql
+++ b/eq-author/src/graphql/updateSection.graphql
@@ -1,3 +1,5 @@
+#import "./fragments/validationErrorInfo.graphql"
+
 mutation UpdateSection($input: UpdateSectionInput!) {
   updateSection(input: $input) {
     id
@@ -6,5 +8,8 @@ mutation UpdateSection($input: UpdateSectionInput!) {
     displayName
     introductionTitle
     introductionContent
+    validationErrorInfo {
+      ...ValidationErrorInfo
+    }
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Add first section validation which validates that a section title is provided when navigation is enabled.

### How to review 
1. Ensure that when section navigation is enabled against the questionnaire then an error is shown for sections without titles
1. Ensure that the error is removed/added when the title is changed
