### PR TITLE
Bug - Questionnaire not loading when it contains calculated summary

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { withRouter } from "react-router-dom";
 import CustomPropTypes from "custom-prop-types";
 import gql from "graphql-tag";
-import { flowRight } from "lodash";
+import { flowRight, get } from "lodash";
 
 import { buildPagePath } from "utils/UrlUtils";
 import { withValidations } from "components/ValidationsContext";
@@ -35,7 +35,7 @@ export const UnwrappedPageNavItem = ({
   validations,
   ...otherProps
 }) => {
-  let errorCount = page.validationErrorInfo.totalCount;
+  let errorCount = get(page, "validationErrorInfo.totalCount", 0);
   if (validations) {
     const pageErrors = validations.pages.find(
       validations => validations.id === page.id

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.test.js
@@ -73,4 +73,12 @@ describe("PageNavItem", () => {
       errorCount: 0,
     });
   });
+
+  it("should render no validations when the page has no validation info", () => {
+    props.page.validationErrorInfo = null;
+    const wrapper = shallow(<UnwrappedPageNavItem {...props} />);
+    expect(wrapper.find(NavLink).props()).toMatchObject({
+      errorCount: 0,
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
Fix issue where not loading when questionnaire contains a calculated summary

### How to review 
1. Create a questionnaire with a calculated summary
1. See it does not load 
1. See with this branch the questionnaire does load
