### PR TITLE
Add unit label validation

### DIFF
--- a/eq-author-api/constants/answerTypes.js
+++ b/eq-author-api/constants/answerTypes.js
@@ -9,6 +9,8 @@ const DATE_RANGE = "DateRange";
 const PERCENTAGE = "Percentage";
 const UNIT = "Unit";
 
+const BASIC_ANSWERS = [TEXTFIELD, TEXTAREA, CURRENCY, NUMBER, UNIT];
+
 module.exports = {
   CHECKBOX,
   RADIO,
@@ -20,4 +22,5 @@ module.exports = {
   DATE,
   DATE_RANGE,
   UNIT,
+  BASIC_ANSWERS,
 };

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1,3 +1,5 @@
+const { BASIC_ANSWERS } = require("../../constants/answerTypes");
+
 const validation = require(".");
 
 describe("schema validation", () => {
@@ -69,6 +71,48 @@ describe("schema validation", () => {
       field: "label",
       id: "additionalAnswer_1",
       type: "answers",
+    });
+  });
+
+  describe("Answer validation", () => {
+    describe("basic answer", () => {
+      it("should ensure that the label is populated", () => {
+        BASIC_ANSWERS.forEach(type => {
+          const answer = {
+            id: "a1",
+            type,
+            label: "",
+          };
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                pages: [
+                  {
+                    id: "p1",
+                    answers: [answer],
+                  },
+                ],
+              },
+            ],
+          };
+
+          const errors = validation(questionnaire);
+          expect(errors.answers[answer.id].errors).toHaveLength(1);
+          expect(errors.answers[answer.id].errors[0]).toMatchObject({
+            errorCode: "ERR_VALID_REQUIRED",
+            field: "label",
+            id: answer.id,
+            type: "answers",
+          });
+
+          answer.label = "some label";
+
+          const errors2 = validation(questionnaire);
+          expect(errors2.answers[answer.id]).toBeUndefined();
+        });
+      });
     });
   });
 

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -53,7 +53,8 @@
               "TextArea",
               "Number",
               "Percentage",
-              "Currency"
+              "Currency",
+              "Unit"
             ]
           }
         }


### PR DESCRIPTION
### What is the context of this PR?
Add validation for label on units

### How to review 
1. Ensure that unit answers must have a label and if they don't an error is shown. The error should also be shown in the left hand as an additional error on the page.