### PR TITLE
Fix flashing side bar when adding question page

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -530,7 +530,7 @@ const Resolvers = {
       getPreviousAnswersForSection(ctx.questionnaire, id),
     availablePipingMetadata: (section, args, ctx) => ctx.questionnaire.metadata,
     validationErrorInfo: ({ id }, args, ctx) =>
-      ctx.validationErrorInfo.sections[id] || { errors: [], totalCount: 0 },
+      ctx.validationErrorInfo.sections[id] || { id, errors: [], totalCount: 0 },
   },
 
   LogicalDestination: {
@@ -570,8 +570,9 @@ const Resolvers = {
     secondaryLabelDefault: answer =>
       getName({ label: answer.secondaryLabel }, "BasicAnswer"),
 
-    validationErrorInfo: (answer, args, ctx) =>
-      ctx.validationErrorInfo[ANSWERS][answer.id] || {
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[ANSWERS][id] || {
+        id,
         errors: [],
         totalCount: 0,
       },
@@ -604,8 +605,9 @@ const Resolvers = {
     },
     displayName: option => getName(option, "Option"),
     additionalAnswer: option => option.additionalAnswer,
-    validationErrorInfo: (option, args, ctx) =>
-      ctx.validationErrorInfo[OPTIONS][option.id] || {
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[OPTIONS][id] || {
+        id,
         errors: [],
         totalCount: 0,
       },

--- a/eq-author-api/schema/resolvers/pages/questionPage.js
+++ b/eq-author-api/schema/resolvers/pages/questionPage.js
@@ -73,7 +73,7 @@ Resolvers.QuestionPage = {
     };
   },
   validationErrorInfo: ({ id }, args, ctx) =>
-    ctx.validationErrorInfo.pages[id] || { errors: [], totalCount: 0 },
+    ctx.validationErrorInfo.pages[id] || { id, errors: [], totalCount: 0 },
 };
 
 Resolvers.Mutation = {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -231,6 +231,7 @@ type ValidationError {
 }
 
 type ValidationErrorInfo {
+  id: ID!
   errors: [ValidationError!]!
   totalCount: Int!
 }

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -61,12 +61,14 @@ module.exports = questionnaire => {
     })
     .reduce(
       (structure, error) => {
-        const { entityId, type, dataPath } = error;
+        const { id, entityId, type, dataPath } = error;
         const errorInfo = structure[type][entityId] || {
+          id,
           totalCount: 0,
           errors: [],
         };
         structure[type][entityId] = {
+          ...errorInfo,
           totalCount: errorInfo.totalCount + 1,
           errors: [...errorInfo.errors, error],
         };

--- a/eq-author-api/tests/utils/contextBuilder/answer/queryAnswer.js
+++ b/eq-author-api/tests/utils/contextBuilder/answer/queryAnswer.js
@@ -28,6 +28,7 @@ const getAnswerQuery = `
           }
         }
         validationErrorInfo {
+          id
           errors {
             id
             type
@@ -49,6 +50,7 @@ const getAnswerQuery = `
             description
           }
           validationErrorInfo {
+            id
             errors {
               id
               type

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/PageNavItem.js
@@ -67,6 +67,7 @@ UnwrappedPageNavItem.fragments = {
           id
         }
         validationErrorInfo {
+          id
           totalCount
         }
       }

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -55,6 +55,7 @@ UnwrappedSectionNavItem.fragments = {
       title
       displayName
       validationErrorInfo {
+        id
         totalCount
       }
       ...PageNav

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -617,6 +617,17 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
                       "kind": "Field",
                       "name": Object {
                         "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
                         "value": "totalCount",
                       },
                       "selectionSet": undefined,
@@ -820,6 +831,17 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
                             "kind": "Field",
                             "name": Object {
                               "kind": "Name",
+                              "value": "id",
+                            },
+                            "selectionSet": undefined,
+                          },
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
                               "value": "totalCount",
                             },
                             "selectionSet": undefined,
@@ -975,7 +997,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1748,
+        "end": 1772,
         "start": 0,
       },
     }
@@ -1174,6 +1196,17 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
                                               "kind": "Field",
                                               "name": Object {
                                                 "kind": "Name",
+                                                "value": "id",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
                                                 "value": "totalCount",
                                               },
                                               "selectionSet": undefined,
@@ -1230,7 +1263,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 366,
+        "end": 383,
         "start": 0,
       },
     }

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -306,6 +306,7 @@ const VALIDATION_QUERY = gql`
           id
           ... on QuestionPage {
             validationErrorInfo {
+              id
               totalCount
             }
           }

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -16,6 +16,7 @@ describe("SectionEditor", () => {
       navigation: true,
     },
     validationErrorInfo: {
+      id: "3",
       totalCount: 0,
       errors: [],
     },
@@ -32,6 +33,7 @@ describe("SectionEditor", () => {
       navigation: true,
     },
     validationErrorInfo: {
+      id: "3",
       totalCount: 0,
       errors: [],
     },

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -89,6 +89,7 @@ const moveSectionMock = {
               },
             },
             validationErrorInfo: {
+              id: "1",
               totalCount: 0,
               errors: [],
               __typename: "ValidationErrorInfo",
@@ -131,6 +132,7 @@ const moveSectionMock = {
               },
             },
             validationErrorInfo: {
+              id: "1",
               totalCount: 0,
               errors: [],
               __typename: "ValidationErrorInfo",
@@ -215,6 +217,7 @@ describe("SectionRoute", () => {
                 },
               },
               validationErrorInfo: {
+                id: "1",
                 totalCount: 0,
                 errors: [],
                 __typename: "ValidationErrorInfo",
@@ -260,6 +263,7 @@ describe("SectionRoute", () => {
                 },
               },
               validationErrorInfo: {
+                id: "1",
                 totalCount: 0,
                 errors: [],
                 __typename: "ValidationErrorInfo",
@@ -355,6 +359,7 @@ describe("SectionRoute", () => {
         },
       },
       validationErrorInfo: {
+        id: "1",
         totalCount: 0,
         errors: [],
         __typename: "ValidationErrorInfo",

--- a/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
+++ b/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
@@ -18,6 +18,7 @@ describe("SectionIntroPreview", () => {
         navigation: true,
       },
       validationErrorInfo: {
+        id: "vei1",
         totalCount: 0,
         errors: [],
         __typename: "ValidationErrorInfo",

--- a/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/section/Preview/__snapshots__/index.test.js.snap
@@ -53,6 +53,7 @@ exports[`PreviewSectionRoute should show the section intro preview when it is fi
         "validationErrorInfo": Object {
           "__typename": "ValidationErrorInfo",
           "errors": Array [],
+          "id": "4",
           "totalCount": 0,
         },
       }

--- a/eq-author/src/App/section/Preview/index.test.js
+++ b/eq-author/src/App/section/Preview/index.test.js
@@ -49,6 +49,7 @@ describe("PreviewSectionRoute", () => {
               navigation: true,
             },
             validationErrorInfo: {
+              id: "4",
               totalCount: 0,
               errors: [],
               __typename: "ValidationErrorInfo",
@@ -79,6 +80,7 @@ describe("PreviewSectionRoute", () => {
               navigation: true,
             },
             validationErrorInfo: {
+              id: "4",
               totalCount: 0,
               errors: [],
               __typename: "ValidationErrorInfo",

--- a/eq-author/src/graphql/createSection.graphql
+++ b/eq-author/src/graphql/createSection.graphql
@@ -25,6 +25,9 @@ mutation CreateSection($input: CreateSectionInput!) {
         }
       }
     }
+    validationErrorInfo {
+      ...ValidationErrorInfo
+    }
     questionnaire {
       id
       questionnaireInfo {

--- a/eq-author/src/graphql/fragments/section.graphql
+++ b/eq-author/src/graphql/fragments/section.graphql
@@ -9,6 +9,7 @@ fragment Section on Section {
     navigation
   }
   validationErrorInfo {
+    id
     errors {
       id
       type

--- a/eq-author/src/graphql/fragments/validationErrorInfo.graphql
+++ b/eq-author/src/graphql/fragments/validationErrorInfo.graphql
@@ -1,4 +1,5 @@
 fragment ValidationErrorInfo on ValidationErrorInfo {
+  id
   errors {
     id
     type


### PR DESCRIPTION
### What is the context of this PR?
Depending on how you load your cache you can create a situation where
an error is thrown when you add a question page. This causes a
noticeable flash to the user.

This is because apollo does not seem to be able to merge structures on
an object unless that is an object with its own id and normalized in the
apollo cache.

This change now returns the validation error info with an id so it can
be normalized. This then means that the cache is merged correctly.

### How to review 
1. Add question pages on question pages and section pages
1. See that on master sometimes you will see the sidebar flash and an error in the console.
1. See that on this branch that this is resolved