### PR TITLE
Improve handling of error that was observed in production.

### DIFF
--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -110,6 +110,12 @@ class Question {
       question.additionalInfoEnabled &&
       (question.additionalInfoLabel || question.additionalInfoContent)
     ) {
+      if (!this.answers.length) {
+        throw new Error(
+          `Cannot add additional information to question '${question.id}' because it has no answers.`
+        );
+      }
+
       last(this.answers).guidance = {
         show_guidance: question.additionalInfoLabel,
         hide_guidance: question.additionalInfoLabel,

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -207,6 +207,20 @@ describe("Question", () => {
         expect(last(question.answers).guidance.hide_guidance).toBeFalsy();
         expect(last(question.answers).guidance.content).toBeDefined();
       });
+
+      it("should throw an error when no answers on the page", () => {
+        expect(
+          () =>
+            new Question(
+              createQuestionJSON({
+                additionalInfoLabel: "Additional info",
+                additionalInfoContent: "<p>Additional info content</p>",
+                additionalInfoEnabled: true,
+                answers: [],
+              })
+            )
+        ).toThrow(/no answers/);
+      });
     });
 
     describe("when it is disabled", () => {


### PR DESCRIPTION
### What is the context of this PR?
There was an issue observed when debugging a live survey where additional information had been toggled on for a question but the question did not have any answers. This should no longer be an issue once #530 has been merged, but there's still a potential to run into this error when hitting the Publisher endpoint directly.

This PR handles the error case to provide some context instead of letting an unhandled runtime error to occur.

### How to review 
All tests and checks pass.
