### PR TITLE
Fix issue with 404 not loading

### DIFF
--- a/eq-author/src/App/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/__snapshots__/index.test.js.snap
@@ -24,9 +24,9 @@ exports[`containers/AppContainer Routes should render  1`] = `
   }
   isSignedIn={true}
 >
-  <ErrorBoundary>
-    <Toasts>
-      <withApollo(withRouter(ContextProvider))>
+  <withApollo(withRouter(ContextProvider))>
+    <ErrorBoundary>
+      <Toasts>
         <Switch>
           <Route
             component={[Function]}
@@ -57,9 +57,9 @@ exports[`containers/AppContainer Routes should render  1`] = `
             path="*"
           />
         </Switch>
-      </withApollo(withRouter(ContextProvider))>
-    </Toasts>
-  </ErrorBoundary>
+      </Toasts>
+    </ErrorBoundary>
+  </withApollo(withRouter(ContextProvider))>
 </Router>
 `;
 

--- a/eq-author/src/App/index.js
+++ b/eq-author/src/App/index.js
@@ -23,9 +23,9 @@ import { MeProvider } from "./MeContext";
 export const Routes = ({ ...otherProps }) => {
   return (
     <Router {...otherProps}>
-      <ErrorBoundary>
-        <Toasts>
-          <MeProvider>
+      <MeProvider>
+        <ErrorBoundary>
+          <Toasts>
             <Switch>
               <Route path={RoutePaths.SIGN_IN} component={SignInPage} exact />
               <PrivateRoute
@@ -48,9 +48,9 @@ export const Routes = ({ ...otherProps }) => {
               />
               <Route path="*" component={NotFoundPage} exact />
             </Switch>
-          </MeProvider>
-        </Toasts>
-      </ErrorBoundary>
+          </Toasts>
+        </ErrorBoundary>
+      </MeProvider>
     </Router>
   );
 };


### PR DESCRIPTION
### What is the context of this PR?
The error boundary errors renders the header when showing an error. This requires the user so the MeProvider needs to be above it.

### How to review 
1. Open a questionnaire
1. Change the URL to a questionnaire id is one that does not exist
1. See on master the 404 does not load (a white page is shown) and on this branch it shows correctly.
