### PR TITLE
Redirect to frontpage when already signed in

### DIFF
--- a/eq-author/src/App/SignInPage/index.js
+++ b/eq-author/src/App/SignInPage/index.js
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+import { Redirect } from "react-router-dom";
 import PropTypes from "prop-types";
+import CustomPropTypes from "custom-prop-types";
 import { providers, credentialHelper } from "components/Auth";
 
 import Panel from "components/Panel";
@@ -48,6 +50,9 @@ export class SignInPage extends React.Component {
         },
       },
     };
+    if (this.props.me) {
+      return <Redirect to="/" />;
+    }
     return (
       <Layout title="Sign in">
         <SignInPanel>
@@ -61,6 +66,7 @@ export class SignInPage extends React.Component {
 
 SignInPage.propTypes = {
   signIn: PropTypes.func.isRequired,
+  me: CustomPropTypes.me,
 };
 
 export default withMe(SignInPage);

--- a/eq-author/src/App/SignInPage/index.test.js
+++ b/eq-author/src/App/SignInPage/index.test.js
@@ -3,6 +3,7 @@ import SignInPage from "App/SignInPage";
 import { MeContext } from "App/MeContext";
 import { shallow } from "enzyme";
 import SignInForm from "./SignInForm";
+import { render } from "tests/utils/rtl";
 
 describe("SignInPage", () => {
   let signIn, signOut;
@@ -50,6 +51,21 @@ describe("SignInPage", () => {
       await signinCallback(user);
 
       expect(signinComponent.state("incompleteLoginAttempts")).toEqual(1);
+    });
+
+    it("should redirect to frontpage if user is already signed in", () => {
+      const me = {
+        id: "1",
+        email: "squanchy@mail.com",
+      };
+
+      const { history } = render(
+        <MeContext.Provider value={{ signOut, signIn, me }}>
+          <SignInPage />
+        </MeContext.Provider>,
+        { route: "/sign-in" }
+      );
+      expect(history.location.pathname).toBe("/");
     });
   });
 });

--- a/eq-author/src/custom-prop-types/index.js
+++ b/eq-author/src/custom-prop-types/index.js
@@ -84,6 +84,12 @@ const CustomPropTypes = {
     email: PropTypes.string.isRequired,
     picture: PropTypes.string,
   }),
+  me: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    email: PropTypes.string.isRequired,
+    picture: PropTypes.string,
+  }),
 };
 
 export default CustomPropTypes;


### PR DESCRIPTION
### What is the context of this PR?
This fixes the issue with an already signed in user being able to go to the `/sign-in` page. 

### How to review 
See that a logged in user will be redirected to the list of questionnaires if already signed in.
