### PR TITLE
Give admins write access to all questionnaires.

### DIFF
--- a/eq-author-api/middleware/identification/getUserFromHeader.js
+++ b/eq-author-api/middleware/identification/getUserFromHeader.js
@@ -52,6 +52,7 @@ module.exports = logger => async authHeader => {
     externalId: payload.sub,
     email: payload.email,
     isVerified: false,
+    admin: payload.admin || false,
   };
 
   const dbUser = await getUserByExternalId(payload.sub);

--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -1,4 +1,5 @@
 const { getQuestionnaire } = require("../utils/datastore");
+const { get } = require("lodash");
 
 module.exports = async (req, res, next) => {
   const questionnaireId = req.header("questionnaireId");
@@ -8,6 +9,13 @@ module.exports = async (req, res, next) => {
   }
 
   const questionnaire = await getQuestionnaire(questionnaireId);
+
+  const isAdmin = get(req, "user.admin", false);
+  if (isAdmin) {
+    req.questionnaire = questionnaire;
+    next();
+    return;
+  }
 
   if (questionnaire && questionnaire.isPublic === false) {
     const userId = req.user.id;

--- a/eq-author-api/middleware/loadQuestionnaire.test.js
+++ b/eq-author-api/middleware/loadQuestionnaire.test.js
@@ -57,4 +57,25 @@ describe("loadQuestionnaire", () => {
     expect(res.status).toHaveBeenCalledWith(403);
     expect(req.questionnaire).toEqual(undefined);
   });
+
+  it("should load private questionnaire if user is an admin", async () => {
+    const ctx = await buildContext({ isPublic: false });
+    const { questionnaire } = ctx;
+
+    const req = {
+      header: jest.fn().mockReturnValue(questionnaire.id),
+      user: { id: "unauthorizedId", admin: true },
+    };
+
+    const next = jest.fn();
+    const res = {
+      status: jest.fn(() => ({
+        send: jest.fn(),
+      })),
+    };
+
+    await loadQuestionnaire(req, res, next);
+    expect(req.questionnaire).toEqual(questionnaire);
+    expect(next).toHaveBeenCalled();
+  });
 });

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -127,9 +127,10 @@ const Resolvers = {
       const questionnaires = await listQuestionnaires();
 
       return questionnaires.filter(questionnaire => {
-        if (questionnaire.isPublic) {
+        if (ctx.user.admin === true || questionnaire.isPublic) {
           return true;
         }
+
         return [questionnaire.createdBy, ...questionnaire.editors].includes(
           ctx.user.id
         );

--- a/eq-author-api/schema/resolvers/withWritePermission.js
+++ b/eq-author-api/schema/resolvers/withWritePermission.js
@@ -1,6 +1,7 @@
 const hasWritePermission = (questionnaire, user) =>
   questionnaire.createdBy === user.id ||
-  questionnaire.editors.indexOf(user.id) > -1;
+  questionnaire.editors.indexOf(user.id) > -1 ||
+  user.admin === true;
 
 const enforceHasWritePermission = (questionnaire, user) => {
   if (!hasWritePermission(questionnaire, user)) {


### PR DESCRIPTION
### What is the context of this PR?
Currently only owners and editors have write access. We have the ability to specify "Admin" users controlled outside of Author as an offline process.

This PR allows users who have been granted admin privileges write access to all questionnaires.

### How to review 
Spin up an environment.
Create two users.
With user 1 create a questionnaire.
Login as user 2.
You should not be able to change anything on the questionnaire.
Make user 2 an admin. Refresh the page.
You should now be able to make changes to the questionnaire.
