### PR TITLE
Fix validation error info not returning an id field.

### DIFF
--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -84,6 +84,7 @@ module.exports = questionnaire => {
 
           const page = questionnaire.sections[sectionIndex].pages[pageIndex];
           const errorInfo = structure.pages[page.id] || {
+            id,
             totalCount: 0,
             errors: [],
           };


### PR DESCRIPTION
### What is the context of this PR?
When resolving a question page validationErrorInfo field, an Id value is not being returned but it is required in the graphql schema.
This is causing adding an answer to a page to break.

### How to review 
all tests should pass, should be able to add answers to a page.
