### PR TITLE
Fix issue when adding routing rule to a page that has no answers.

### DIFF
--- a/eq-author-api/constants/answerTypes.js
+++ b/eq-author-api/constants/answerTypes.js
@@ -10,6 +10,13 @@ const PERCENTAGE = "Percentage";
 const UNIT = "Unit";
 
 const BASIC_ANSWERS = [TEXTFIELD, TEXTAREA, CURRENCY, NUMBER, UNIT];
+const NON_RADIO_ANSWERS = [
+  ...BASIC_ANSWERS,
+  CHECKBOX,
+  DATE,
+  DATE_RANGE,
+  PERCENTAGE,
+];
 
 module.exports = {
   CHECKBOX,
@@ -23,4 +30,5 @@ module.exports = {
   DATE_RANGE,
   UNIT,
   BASIC_ANSWERS,
+  NON_RADIO_ANSWERS,
 };

--- a/eq-author-api/src/businessLogic/createRightSide.js
+++ b/eq-author-api/src/businessLogic/createRightSide.js
@@ -1,6 +1,10 @@
 const { RADIO } = require("../../constants/answerTypes");
 
 module.exports = firstAnswer => {
+  if (!firstAnswer) {
+    return;
+  }
+
   if (firstAnswer.type === RADIO) {
     return { type: "SelectedOptions", optionIds: [] };
   }

--- a/eq-author-api/src/businessLogic/createRightSide.test.js
+++ b/eq-author-api/src/businessLogic/createRightSide.test.js
@@ -1,0 +1,21 @@
+const createRightSide = require("./createRightSide");
+const { RADIO, NON_RADIO_ANSWERS } = require("../../constants/answerTypes");
+
+describe("createRightSide", () => {
+  it("should return undefined when there is no answer on the page", () => {
+    expect(createRightSide(null)).toBeUndefined();
+  });
+
+  it("should return empty selected options array for radio answers", () => {
+    expect(createRightSide({ type: RADIO })).toMatchObject({
+      type: "SelectedOptions",
+      optionIds: [],
+    });
+  });
+
+  it("should return undefined for answer types other than RADIO", () => {
+    NON_RADIO_ANSWERS.forEach(type => {
+      expect(createRightSide({ type })).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
When creating a routing rule, there was an incorrect assumption being made in the business logic that the page will always have an answer. This fix checks if an answer exists and sets the routing rule right hand side value accordingly.

### How to review
Changes look good. Tests pass.
Should be able to add a routing rule to a page that has no answers.