### PR TITLE
Fix issue with answer error count in cache

### DIFF
--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -61,9 +61,9 @@ module.exports = questionnaire => {
     })
     .reduce(
       (structure, error) => {
-        const { id, entityId, type, dataPath } = error;
+        const { entityId, type, dataPath } = error;
         const errorInfo = structure[type][entityId] || {
-          id,
+          id: entityId,
           totalCount: 0,
           errors: [],
         };
@@ -84,7 +84,7 @@ module.exports = questionnaire => {
 
           const page = questionnaire.sections[sectionIndex].pages[pageIndex];
           const errorInfo = structure.pages[page.id] || {
-            id,
+            id: page.id,
             totalCount: 0,
             errors: [],
           };

--- a/eq-author-api/tests/utils/contextBuilder/answer/queryAnswer.js
+++ b/eq-author-api/tests/utils/contextBuilder/answer/queryAnswer.js
@@ -61,6 +61,7 @@ const getAnswerQuery = `
           }
         }
         validationErrorInfo {
+          id
           errors {
             id
             type

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -1141,6 +1141,17 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
                                   "kind": "Field",
                                   "name": Object {
                                     "kind": "Name",
+                                    "value": "id",
+                                  },
+                                  "selectionSet": undefined,
+                                },
+                                Object {
+                                  "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
                                     "value": "totalCount",
                                   },
                                   "selectionSet": undefined,
@@ -1263,7 +1274,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 383,
+        "end": 396,
         "start": 0,
       },
     }

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -300,6 +300,7 @@ const VALIDATION_QUERY = gql`
       sections {
         id
         validationErrorInfo {
+          id
           totalCount
         }
         pages {


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with error count not updating for answers. 


### How to review 
On master the validation count on answers doesnt update correctly.
Check to see that this is now fixed, and that you can switch