### PR TITLE
Fixed deleting of page used in ELSE route of another page

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -50,6 +50,7 @@ const updateMetadata = require("../../src/businessLogic/updateMetadata");
 const getPreviousAnswersForPage = require("../../src/businessLogic/getPreviousAnswersForPage");
 const getPreviousAnswersForSection = require("../../src/businessLogic/getPreviousAnswersForSection");
 const createOption = require("../../src/businessLogic/createOption");
+const onPageDeleted = require("../../src/businessLogic/onPageDeleted");
 const addPrefix = require("../../utils/addPrefix");
 const { createQuestionPage } = require("./pages/questionPage");
 
@@ -226,6 +227,7 @@ const Resolvers = {
     deleteSection: createMutation((root, { input }, ctx) => {
       const section = find(ctx.questionnaire.sections, { id: input.id });
       remove(ctx.questionnaire.sections, section);
+      onPageDeleted(ctx, input.id);
       return section;
     }),
     moveSection: createMutation((_, { input }, ctx) => {

--- a/eq-author-api/src/businessLogic/onPageDeleted.js
+++ b/eq-author-api/src/businessLogic/onPageDeleted.js
@@ -1,4 +1,5 @@
 const { getPages } = require("../../schema/resolvers/utils");
+const { NEXT_PAGE } = require("../../constants/logicalDestinations");
 
 const onPageDeleted = (ctx, removedPageId) => {
   const allPages = getPages(ctx);
@@ -8,8 +9,21 @@ const onPageDeleted = (ctx, removedPageId) => {
       return;
     }
 
+    const elseRoute = page.routing.else;
+    if (
+      elseRoute.pageId === removedPageId ||
+      elseRoute.sectionId === removedPageId
+    ) {
+      elseRoute.sectionId = null;
+      elseRoute.pageId = null;
+      elseRoute.logical = NEXT_PAGE;
+    }
+
     const validRules = page.routing.rules.filter(
-      rule => rule.destination && rule.destination.pageId !== removedPageId
+      rule =>
+        rule.destination &&
+        rule.destination.pageId !== removedPageId &&
+        rule.destination.sectionId !== removedPageId
     );
 
     if (validRules.length) {

--- a/eq-author-api/tests/utils/contextBuilder/buildRouting.js
+++ b/eq-author-api/tests/utils/contextBuilder/buildRouting.js
@@ -27,7 +27,7 @@ const convertPathToDestination = (
     };
   } else if (!isNull(section)) {
     return {
-      pageId: get(questionnaire, `sections[${section}].id`),
+      sectionId: get(questionnaire, `sections[${section}].id`),
     };
   } else {
     throw new Error("Not a valid destination in the input config");


### PR DESCRIPTION
### What is the context of this PR?
Routing page crashed when page or section referred to in ELSE route is deleted

### How to review 
1. Create 3 pages
2. Create a page route and specify ELSE destination another page
3. Delete the ELSE destination page
4. ELSE destination of page route should now be changed to next page

Repeat for using Section pages as rule and else destinations