### PR TITLE
Prevent empty data from rendering move page modal.

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -228,7 +228,7 @@ const Resolvers = {
       const section = find(ctx.questionnaire.sections, { id: input.id });
       remove(ctx.questionnaire.sections, section);
       onPageDeleted(ctx, input.id);
-      return section;
+      return ctx.questionnaire;
     }),
     moveSection: createMutation((_, { input }, ctx) => {
       const removedSection = first(

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -554,7 +554,7 @@ type Mutation {
   duplicateQuestionnaire(input: DuplicateQuestionnaireInput!): Questionnaire
   createSection(input: CreateSectionInput!): Section
   updateSection(input: UpdateSectionInput!): Section
-  deleteSection(input: DeleteSectionInput!): Section
+  deleteSection(input: DeleteSectionInput!): Questionnaire
   moveSection(input: MoveSectionInput!): Section
   duplicateSection(input: DuplicateSectionInput!): Section
   updatePage(input: UpdatePageInput!): Page

--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -73,10 +73,10 @@
     "svgo-loader": "latest",
     "terser-webpack-plugin": "latest",
     "url-loader": "latest",
+    "wait-for-expect": "latest",
     "webpack": "latest",
     "webpack-dev-server": "latest",
-    "webpack-manifest-plugin": "latest",
-    "wait-for-expect": "latest"
+    "webpack-manifest-plugin": "latest"
   },
   "dependencies": {
     "@sentry/browser": "latest",
@@ -104,7 +104,7 @@
     "lodash": "latest",
     "polished": "latest",
     "react": "latest",
-    "react-apollo": "latest",
+    "react-apollo": "^2.5.8",
     "react-dom": "latest",
     "react-firebaseui": "latest",
     "react-hot-loader": "latest",

--- a/eq-author/src/App/page/Design/MovePageModal/MovePageQuery.js
+++ b/eq-author/src/App/page/Design/MovePageModal/MovePageQuery.js
@@ -4,7 +4,11 @@ import query from "graphql/getQuestionnaire.graphql";
 import PropTypes from "prop-types";
 
 const MovePageQuery = ({ questionnaireId, children }) => (
-  <Query query={query} variables={{ input: { questionnaireId } }}>
+  <Query
+    query={query}
+    partialRefetch
+    variables={{ input: { questionnaireId } }}
+  >
     {({ loading, data }) => children({ loading, data })}
   </Query>
 );

--- a/eq-author/src/App/section/Design/SectionEditor/MoveSectionModal/MoveSectionQuery.js
+++ b/eq-author/src/App/section/Design/SectionEditor/MoveSectionModal/MoveSectionQuery.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 const MoveSectionQuery = ({ questionnaireId, children }) => (
   <Query
     query={query}
+    partialRefetch
     variables={{
       input: {
         questionnaireId,

--- a/eq-author/src/App/section/Design/withDeleteSection.test.js
+++ b/eq-author/src/App/section/Design/withDeleteSection.test.js
@@ -1,9 +1,4 @@
-import {
-  mapMutateToProps,
-  deleteUpdater,
-  handleDeletion,
-} from "./withDeleteSection";
-import fragment from "graphql/questionnaireFragment.graphql";
+import { mapMutateToProps, handleDeletion } from "./withDeleteSection";
 
 describe("withDeleteSection", () => {
   let history, mutate, result, ownProps, onAddSection, showToast;
@@ -43,7 +38,10 @@ describe("withDeleteSection", () => {
 
     result = {
       data: {
-        deleteSection: deletedPage,
+        deleteSection: {
+          id: "questionnaire",
+          sections: [],
+        },
       },
     };
 
@@ -68,25 +66,6 @@ describe("withDeleteSection", () => {
     };
 
     mutate = jest.fn(() => Promise.resolve(result));
-  });
-
-  describe("deleteUpdater", () => {
-    it("should remove the section from the cache", () => {
-      const id = `Questionnaire${questionnaire.id}`;
-      const readFragment = jest.fn(() => questionnaire);
-      const writeFragment = jest.fn();
-
-      const updater = deleteUpdater(questionnaire.id, currentSection.id);
-      updater({ readFragment, writeFragment }, result);
-
-      expect(readFragment).toHaveBeenCalledWith({ id, fragment });
-      expect(writeFragment).toHaveBeenCalledWith({
-        id,
-        fragment,
-        data: questionnaire,
-      });
-      expect(questionnaire.sections).not.toContain(currentSection);
-    });
   });
 
   describe("mapMutateToProps", () => {
@@ -152,19 +131,18 @@ describe("withDeleteSection", () => {
 
   describe("handleDeletion", () => {
     describe("when only one section in questionnaire", () => {
-      beforeEach(() => {
-        questionnaire.sections = [currentSection];
-      });
-
       it("should add new section", () => {
-        handleDeletion(ownProps, questionnaire);
+        handleDeletion(ownProps, result, {});
         expect(onAddSection).toHaveBeenCalled();
       });
     });
 
     describe("when more than one section in questionnaire", () => {
       it("should redirect to another section", () => {
-        handleDeletion(ownProps, questionnaire);
+        result.data.deleteSection.sections = [
+          { id: "section 1", pages: [{ id: "page 1" }] },
+        ];
+        handleDeletion(ownProps, result, questionnaire);
         expect(history.push).toHaveBeenCalled();
       });
     });

--- a/eq-author/src/graphql/deleteSection.graphql
+++ b/eq-author/src/graphql/deleteSection.graphql
@@ -1,11 +1,11 @@
 mutation DeleteSection($input: DeleteSectionInput!) {
   deleteSection(input: $input) {
     id
-    questionnaire {
+    sections {
       id
-      questionnaireInfo {
-        totalSectionCount
-      }
+    }
+    questionnaireInfo {
+      totalSectionCount
     }
   }
 }

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -9467,12 +9467,13 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@latest:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.6.tgz#98a59d0eea31432ed001e6a033e11a58139ffc31"
-  integrity sha512-WWX5UykTtmW6+awjqEsSWSdvVyZv/vsavUgpdI4ddn4CBdz47INC+iTdJBnYaUFMB24GmqjFFSoSd98gu1xqKA==
+react-apollo@^2.5.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
+  integrity sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==
   dependencies:
     apollo-utilities "^1.3.0"
+    fast-json-stable-stringify "^2.0.0"
     hoist-non-react-statics "^3.3.0"
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"


### PR DESCRIPTION
### What is the context of this PR?
There seems to be an issue where sometimes, possibly when a value is both simultaneously being mutated and queried from the cache, where a Query component will return an empty data object, even though the query has finished loading and there are no errors.

This was causing our application to crash because the modal assumes that it is being passed a valid data object, based on assumptions being made in the PropTypes.

This is a known issue and this fix uses refetchPartial which according to the docs this is fine however we may have to keep an eye on this issue as it moves along apollographql/react-apollo/issues/2114

### How to review 
1. Checkout master
1. Add question page
1. Observe crash and error
1. Checkout this branch
1. Add a question page
1. Should no longer crash.
