### PR TITLE
Fix stay on page when refreshing.

### DIFF
--- a/eq-author/src/App/MeContext.js
+++ b/eq-author/src/App/MeContext.js
@@ -25,7 +25,13 @@ const signIn = (setSignInSuccess, history, user) => {
       if (!res.ok) {
         throw Error(`Server responded with a ${res.status} code.`);
       }
-      history.push(get(history, "location.state.returnURL", "/"));
+      history.push(
+        get(
+          history,
+          "location.state.returnURL",
+          get(history, "location.pathname", "/")
+        )
+      );
       setSignInSuccess(true);
     })
     .catch(e => {


### PR DESCRIPTION
### What is the context of this PR?
There was a small bug where refreshing the page would take you back to the list page.
This PR aims to fix.

The issue seemed to be that the history location state was undefined when refreshing after returning from the signIn fetch call.

This PR aims to fix by using the current pathname where possible and falling back to the list page when it is not possible to do that.

### How to review 
- Checkout master.
- Create a questionnaire.
- Go to the questionnaire design page.
- Refresh the browser.
- It will take you back to the questionnaire list page.
- Repeat on this branch and observe that you stay on the same page.
