### PR TITLE
Enable any of rules for routing

### DIFF
--- a/eq-author-api/migrations/addExpressionOperator.js
+++ b/eq-author-api/migrations/addExpressionOperator.js
@@ -1,0 +1,17 @@
+//This is an auto-generated file.  Do NOT modify the method signature.
+const AND = "And";
+
+module.exports = function addExpressionOperator(questionnaire) {
+  questionnaire.sections.map(section => {
+    section.pages.map(page => {
+      if (page.routing) {
+        page.routing.rules.map(rule => {
+          if (!rule.expressionGroup.operator) {
+            rule.expressionGroup.operator = AND;
+          }
+        });
+      }
+    });
+  });
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addExpressionOperator.test.js
+++ b/eq-author-api/migrations/addExpressionOperator.test.js
@@ -1,0 +1,177 @@
+const { cloneDeep } = require("lodash");
+const addExpressionOperator = require("./addExpressionOperator.js");
+const AND = "And";
+const OR = "Or";
+
+describe("addExpressionOperator", () => {
+  let questionnaire = {};
+  beforeEach(() => {
+    questionnaire = {
+      id: "3e14c1ac-4d05-4929-a7c6-58644dfc514a",
+      title: "Q1",
+      metadata: [],
+      sections: [
+        {
+          id: "1f0a09c8-93fb-46c1-b568-2aecb7f085af",
+          title: "",
+          pages: [
+            {
+              id: "52e3721c-24b7-4906-ab06-dfc78e1f484a",
+              title: "<p>Q1</p>",
+              pageType: "QuestionPage",
+              answers: [
+                {
+                  id: "d091276b-97b1-4eff-a845-a795a2279c46",
+                  type: "Radio",
+                  options: [
+                    {
+                      id: "4d80513f-f285-4cea-8fd0-9b422fcb980a",
+                      label: "A",
+                    },
+                    {
+                      id: "e05b6cdb-91c9-435d-bb25-1766b6415e44",
+                      label: "B",
+                    },
+                    {
+                      id: "4f70ae7b-e650-4424-96f0-880c6ea9bcd5",
+                      label: "C",
+                    },
+                  ],
+                  mutuallyExclusiveOption: null,
+                },
+              ],
+              routing: null,
+            },
+            {
+              id: "d94f7a1a-7fe4-47e4-9d57-11e518e90124",
+              title: "<p>Q2</p>",
+              pageType: "QuestionPage",
+              answers: [
+                {
+                  id: "316bff79-08ad-4379-9b4a-6069c7593da8",
+                  type: "Radio",
+                  label: "a2",
+                  options: [
+                    {
+                      id: "c1e25d8b-8034-466e-9c23-0a24cad64626",
+                      label: "D",
+                    },
+                    {
+                      id: "8d14139d-5f05-44b0-bc91-bf8a42394bf9",
+                      label: "E",
+                    },
+                    {
+                      id: "2cca166e-71f8-473a-be5d-539bdc6ed377",
+                      label: "F",
+                    },
+                  ],
+                },
+              ],
+              routing: {
+                rules: [
+                  {
+                    expressionGroup: {
+                      expressions: [
+                        {
+                          left: {
+                            id: "316bff79-08ad-4379-9b4a-6069c7593da8",
+                            type: "Radio",
+                            options: [
+                              {
+                                id: "c1e25d8b-8034-466e-9c23-0a24cad64626",
+                              },
+                              {
+                                id: "8d14139d-5f05-44b0-bc91-bf8a42394bf9",
+                              },
+                              {
+                                id: "2cca166e-71f8-473a-be5d-539bdc6ed377",
+                              },
+                            ],
+                          },
+                          condition: "OneOf",
+                          right: {
+                            options: [
+                              {
+                                id: "c1e25d8b-8034-466e-9c23-0a24cad64626",
+                                label: "D",
+                              },
+                              {
+                                id: "8d14139d-5f05-44b0-bc91-bf8a42394bf9",
+                                label: "E",
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          left: {
+                            id: "d091276b-97b1-4eff-a845-a795a2279c46",
+                            type: "Radio",
+                            options: [
+                              {
+                                id: "4d80513f-f285-4cea-8fd0-9b422fcb980a",
+                              },
+                              {
+                                id: "e05b6cdb-91c9-435d-bb25-1766b6415e44",
+                              },
+                              {
+                                id: "4f70ae7b-e650-4424-96f0-880c6ea9bcd5",
+                              },
+                            ],
+                          },
+                          condition: "OneOf",
+                          right: {
+                            options: [
+                              {
+                                id: "4d80513f-f285-4cea-8fd0-9b422fcb980a",
+                                label: "A",
+                              },
+                              {
+                                id: "e05b6cdb-91c9-435d-bb25-1766b6415e44",
+                                label: "B",
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                    destination: {
+                      section: {
+                        id: "03dbc0dd-2f05-4bbb-8dc8-e9edeb40b621",
+                      },
+                    },
+                  },
+                ],
+                else: {
+                  section: {
+                    id: "2db427aa-ebf1-4ae5-9c32-611010026da2",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+  });
+  it("should be deterministic", () => {
+    expect(addExpressionOperator(cloneDeep(questionnaire))).toEqual(
+      addExpressionOperator(cloneDeep(questionnaire))
+    );
+  });
+
+  it("should add operator to expressionGroup if it doesnt exist", () => {
+    const result = addExpressionOperator(questionnaire);
+    expect(
+      result.sections[0].pages[1].routing.rules[0].expressionGroup.operator
+    ).toEqual(AND);
+  });
+
+  it("should not add operator if it already exists", () => {
+    const withOperator = cloneDeep(questionnaire);
+    withOperator.sections[0].pages[1].routing.rules[0].expressionGroup.operator = OR;
+    const result = addExpressionOperator(withOperator);
+    expect(
+      result.sections[0].pages[1].routing.rules[0].expressionGroup.operator
+    ).toEqual(OR);
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -8,6 +8,7 @@ const migrations = [
   require("./addTotalValidation"),
   require("./updateCreatedByToUseUsers"),
   require("./addIsPublicFlag"),
+  require("./addExpressionOperator"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/routing2/expressionGroup2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/expressionGroup2/index.js
@@ -1,6 +1,6 @@
 const Resolvers = {};
 
-const { find, flatMap, getOr } = require("lodash/fp");
+const { find, flatMap, get } = require("lodash/fp");
 const { createMutation } = require("../../createMutation");
 
 const { getPages } = require("../../utils");
@@ -15,10 +15,10 @@ Resolvers.Mutation = {
       const expressionGroup = find(
         { id },
         flatMap(
-          rule => rule.expressionGroup,
+          rule => get("expressionGroup", rule),
           flatMap(
-            routing => routing.rules,
-            flatMap(page => getOr([], "routing", page), getPages(ctx))
+            routing => get("rules", routing),
+            flatMap(page => get("routing", page), getPages(ctx))
           )
         )
       );

--- a/eq-author-api/src/businessLogic/createRoutingRule.js
+++ b/eq-author-api/src/businessLogic/createRoutingRule.js
@@ -1,10 +1,12 @@
 const uuid = require("uuid");
 const createDestination = require("./createDestination");
 const createExpressionGroup = require("./createExpressionGroup");
+const { AND } = require("../../constants/routingOperators");
 
 module.exports = input => ({
   id: uuid.v4(),
   destination: createDestination(),
   expressionGroup: createExpressionGroup(),
+  operator: AND,
   ...input,
 });

--- a/eq-author/src/App/page/Routing/DestinationSelector/index.js
+++ b/eq-author/src/App/page/Routing/DestinationSelector/index.js
@@ -50,7 +50,7 @@ export class UnwrappedDestinationSelector extends React.Component {
   };
 
   render() {
-    const { label, id, disabled, value } = this.props;
+    const { label, id, disabled, value, match } = this.props;
     return (
       <RoutingRuleResult key={id}>
         <Grid align="center">
@@ -62,7 +62,7 @@ export class UnwrappedDestinationSelector extends React.Component {
           <Column gutters={false} cols={7}>
             <RoutingDestinationContentPicker
               id={id}
-              pageId={this.props.match.params.pageId}
+              pageId={match.params.pageId}
               selected={value}
               onSubmit={this.handleChange}
               disabled={disabled}

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
@@ -44,6 +44,7 @@ const Label = styled.label`
   font-weight: bold;
   text-align: center;
   align-self: center;
+  text-transform: uppercase;
 `;
 
 const ConnectedPath = styled.div`
@@ -134,7 +135,7 @@ const ERROR_SITUATIONS = [
     condition: props =>
       props.expression.left.reason === SELECTED_ANSWER_DELETED,
     message: () => (
-      <Alert data-test="deleted-answer-msg">
+      <Alert>
         <AlertTitle>
           The question this condition referred to has been deleted
         </AlertTitle>
@@ -148,7 +149,7 @@ const ERROR_SITUATIONS = [
     condition: props =>
       props.expression.left.reason === NO_ROUTABLE_ANSWER_ON_PAGE,
     message: props => (
-      <Alert data-test="no-answer-msg">
+      <Alert>
         <AlertTitle>
           No routable answers have been added to this question yet.
         </AlertTitle>
@@ -163,9 +164,20 @@ const ERROR_SITUATIONS = [
     ),
   },
   {
-    condition: props => !props.canAddAndCondition,
+    condition: props => !props.canAddCondition && props.operator === "Or",
     message: () => (
-      <Alert data-test="and-not-valid-msg">
+      <Alert>
+        <AlertTitle>
+          OR condition is not valid when creating multiple radio rules
+        </AlertTitle>
+        <AlertText>Select a different answer or delete the rule.</AlertText>
+      </Alert>
+    ),
+  },
+  {
+    condition: props => !props.canAddCondition,
+    message: () => (
+      <Alert>
         <AlertTitle>
           AND condition not valid with &lsquo;radio button&rsquo; answer
         </AlertTitle>
@@ -195,7 +207,7 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
     updateLeftSide: PropTypes.func.isRequired,
     deleteBinaryExpression: PropTypes.func.isRequired,
     createBinaryExpression: PropTypes.func.isRequired,
-    canAddAndCondition: PropTypes.bool.isRequired,
+    canAddCondition: PropTypes.bool.isRequired,
     updateRightSide: PropTypes.func.isRequired,
     updateBinaryExpression: PropTypes.func.isRequired,
     match: CustomPropTypes.match,

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.test.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.test.js
@@ -13,6 +13,7 @@ import MultipleChoiceAnswerOptionsSelector from "./MultipleChoiceAnswerOptionsSe
 import NumberAnswerSelector from "./NumberAnswerSelector";
 
 import { AlertTitle } from "./Alert";
+import { OR } from "constants/routingOperators";
 
 describe("BinaryExpressionEditor", () => {
   let defaultProps;
@@ -35,7 +36,7 @@ describe("BinaryExpressionEditor", () => {
         condition: "Equal",
         right: null,
       },
-      canAddAndCondition: true,
+      canAddCondition: true,
       match: {
         params: {
           questionnaireId: "1",
@@ -130,13 +131,30 @@ describe("BinaryExpressionEditor", () => {
 
   it("should display the correct error message when you can't add a second 'And' condition", () => {
     const wrapper = shallow(
-      <BinaryExpressionEditor {...defaultProps} canAddAndCondition={false} />
+      <BinaryExpressionEditor {...defaultProps} canAddCondition={false} />
     );
 
     expect(
       wrapper
         .find(AlertTitle)
         .contains("AND condition not valid with ‘radio button’ answer")
+    ).toBeTruthy();
+  });
+  it("should display the correct error message when you can't add a second 'Or' condition", () => {
+    const wrapper = shallow(
+      <BinaryExpressionEditor
+        {...defaultProps}
+        canAddCondition={false}
+        operator={OR}
+      />
+    );
+
+    expect(
+      wrapper
+        .find(AlertTitle)
+        .contains(
+          "OR condition is not valid when creating multiple radio rules"
+        )
     ).toBeTruthy();
   });
 

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/__snapshots__/index.test.js.snap
@@ -11,18 +11,19 @@ exports[`RuleEditor should render 1`] = `
     >
       Match
       <RuleEditor__SmallSelect
-        defaultValue="all"
-        disabled={true}
+        data-test="match-select"
+        defaultValue="And"
         id="match"
         name="match"
+        onChange={[Function]}
       >
         <option
-          value="all"
+          value="And"
         >
           All of
         </option>
         <option
-          value="any"
+          value="Or"
         >
           Any of
         </option>
@@ -40,29 +41,7 @@ exports[`RuleEditor should render 1`] = `
     <TransitionGroup
       childFactory={[Function]}
       component="div"
-    >
-      <Transition__RoutingComponentTransition
-        key="1"
-        timeout={200}
-      >
-        <Apollo(Apollo(Apollo(Apollo(Apollo(withRouter(UnwrappedBinaryExpressionEditor))))))
-          canAddAndCondition={true}
-          expression={
-            Object {
-              "id": "1",
-              "left": Object {
-                "id": "binaryExpressionId",
-                "type": "Currency",
-              },
-            }
-          }
-          expressionGroupId="expressionGroupId"
-          isLastExpression={true}
-          isOnlyExpression={true}
-          label="IF"
-        />
-      </Transition__RoutingComponentTransition>
-    </TransitionGroup>
+    />
   </RuleEditor__Expressions>
   <withRouter(UnwrappedDestinationSelector)
     data-test="select-then"

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/fragment.graphql
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/fragment.graphql
@@ -16,6 +16,7 @@ fragment RuleEditor on RoutingRule2 {
   }
   expressionGroup {
     id
+    operator
     expressions {
       ...BinaryExpressionEditor
     }

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
@@ -18,6 +18,7 @@ import BinaryExpressionEditor from "./BinaryExpressionEditor";
 import fragment from "./fragment.graphql";
 import withDeleteRule from "./withDeleteRule";
 import withUpdateRule from "./withUpdateRule";
+import withUpdateExpressionGroup from "./withUpdateExpressionGroup";
 
 import { Select, Label } from "components/Forms";
 
@@ -72,6 +73,7 @@ export class UnwrappedRuleEditor extends React.Component {
     ifLabel: PropTypes.string,
     deleteRule: PropTypes.func.isRequired,
     updateRule: PropTypes.func.isRequired,
+    updateExpressionGroup: PropTypes.func.isRequired,
     className: PropTypes.string,
   };
 
@@ -108,9 +110,20 @@ export class UnwrappedRuleEditor extends React.Component {
         <Header>
           <Label inline>
             Match
-            <SmallSelect name="match" id="match" disabled defaultValue="all">
-              <option value="all">All of</option>
-              <option value="any">Any of</option>
+            <SmallSelect
+              name="match"
+              id="match"
+              data-test="match-select"
+              defaultValue={rule.expressionGroup.operator}
+              onChange={({ value }) => {
+                this.props.updateExpressionGroup({
+                  id: rule.expressionGroup.id,
+                  operator: value,
+                });
+              }}
+            >
+              <option value="And">All of</option>
+              <option value="Or">Any of</option>
             </SmallSelect>
             the following rules
           </Label>
@@ -122,19 +135,19 @@ export class UnwrappedRuleEditor extends React.Component {
             Remove rule
           </RemoveRuleButton>
         </Header>
-
         <Expressions>
           <TransitionGroup>
             {expressions.map((expression, index) => {
               const component = (
                 <Transition key={expression.id}>
                   <BinaryExpressionEditor
+                    operator={rule.expressionGroup.operator}
                     expression={expression}
                     expressionGroupId={rule.expressionGroup.id}
-                    label={index > 0 ? "AND" : ifLabel}
+                    label={index > 0 ? rule.expressionGroup.operator : ifLabel}
                     isOnlyExpression={expressions.length === 1}
                     isLastExpression={index === expressions.length - 1}
-                    canAddAndCondition={
+                    canAddCondition={
                       !existingRadioConditions[get("left.id", expression)]
                     }
                   />
@@ -162,7 +175,8 @@ export class UnwrappedRuleEditor extends React.Component {
 
 const withMutations = flow(
   withDeleteRule,
-  withUpdateRule
+  withUpdateRule,
+  withUpdateExpressionGroup
 );
 
 export default withMutations(UnwrappedRuleEditor);

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.test.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.test.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { shallow } from "enzyme";
+import { render, fireEvent } from "tests/utils/rtl";
+
 import RoutingRuleDestinationSelector from "App/page/Routing/DestinationSelector";
-import { CURRENCY, RADIO } from "constants/answer-types";
+import { RADIO } from "constants/answer-types";
+import { AND, OR } from "constants/routingOperators";
 
 import BinaryExpressionEditor from "./BinaryExpressionEditor";
 
@@ -14,18 +17,7 @@ describe("RuleEditor", () => {
     defaultProps = {
       rule: {
         id: "ruleId",
-        expressionGroup: {
-          id: "expressionGroupId",
-          expressions: [
-            {
-              id: "1",
-              left: {
-                id: "binaryExpressionId",
-                type: CURRENCY,
-              },
-            },
-          ],
-        },
+        expressionGroup: { id: "expGrpId", operator: AND, expressions: [] },
         destination: {
           id: "1",
           page: {
@@ -36,9 +28,9 @@ describe("RuleEditor", () => {
           section: null,
         },
       },
-      createBinaryExpression: jest.fn(),
       deleteRule: jest.fn(),
       updateRule: jest.fn(),
+      updateExpressionGroup: jest.fn(),
     };
   });
 
@@ -87,14 +79,28 @@ describe("RuleEditor", () => {
       wrapper
         .find(BinaryExpressionEditor)
         .first()
-        .prop("canAddAndCondition")
+        .prop("canAddCondition")
     ).toBe(true);
 
     expect(
       wrapper
         .find(BinaryExpressionEditor)
         .last()
-        .prop("canAddAndCondition")
+        .prop("canAddCondition")
     ).toBe(false);
+  });
+
+  it("should call updateExpressionGroup with 'Or' when Any of was selected", async () => {
+    const { getByTestId } = render(<RuleEditor {...defaultProps} />, {
+      route: "/q/1/page/2",
+      urlParamMatcher: "/q/:questionnaireId/page/:pageId",
+    });
+
+    fireEvent.change(getByTestId("match-select"), { target: { value: OR } });
+
+    expect(defaultProps.updateExpressionGroup).toHaveBeenCalledWith({
+      id: defaultProps.rule.expressionGroup.id,
+      operator: OR,
+    });
   });
 });

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/updateExpressionGroup.graphql
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/updateExpressionGroup.graphql
@@ -1,0 +1,6 @@
+mutation updateExpressionGroup2($input: UpdateExpressionGroup2Input!) {
+  updateExpressionGroup2(input: $input) {
+    id
+    operator
+  }
+}

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateExpressionGroup.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateExpressionGroup.js
@@ -1,21 +1,20 @@
 import { graphql } from "react-apollo";
 
-import updateRule from "./updateRule.graphql";
+import updateExpressionGroup from "./updateExpressionGroup.graphql";
 
 export const mapMutateToProps = ({ mutate }) => ({
-  updateRule(rule) {
+  updateExpressionGroup({ id, operator }) {
     return mutate({
       variables: {
         input: {
-          id: rule.id,
-          operator: rule.operator,
-          destination: rule.destination,
+          id,
+          operator,
         },
       },
     });
   },
 });
 
-export default graphql(updateRule, {
+export default graphql(updateExpressionGroup, {
   props: mapMutateToProps,
 });

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`components/RoutingRuleSet should render children 1`] = `
       key="2"
       timeout={200}
     >
-      <Apollo(Apollo(UnwrappedRuleEditor))
+      <Apollo(Apollo(Apollo(UnwrappedRuleEditor)))
         ifLabel="IF"
         key="2"
         rule={

--- a/eq-author/src/constants/routingOperators.js
+++ b/eq-author/src/constants/routingOperators.js
@@ -1,0 +1,2 @@
+export const AND = "And";
+export const OR = "Or";

--- a/eq-author/src/tests/utils/rtl.js
+++ b/eq-author/src/tests/utils/rtl.js
@@ -15,6 +15,7 @@ const customRender = (
     history = createMemoryHistory({ initialEntries: [route] }),
     mocks = [],
     storeState = {},
+    urlParamMatcher = "",
     ...renderOptions
   } = {}
 ) => {
@@ -46,7 +47,7 @@ const customRender = (
     <TestProvider reduxProps={{ store }} apolloProps={{ mocks }}>
       <Router history={history}>
         <Switch>
-          <Route path={route}>{children}</Route>
+          <Route path={urlParamMatcher || route}>{children}</Route>
         </Switch>
       </Router>
     </TestProvider>

--- a/eq-publisher/src/constants/routingOperators.js
+++ b/eq-publisher/src/constants/routingOperators.js
@@ -1,0 +1,7 @@
+const AND = "And";
+const OR = "Or";
+
+module.exports = {
+  AND,
+  OR,
+};

--- a/eq-publisher/src/eq_schema/Group.test.js
+++ b/eq-publisher/src/eq_schema/Group.test.js
@@ -329,8 +329,8 @@ describe("Group", () => {
                 {
                   id:
                     "answerconfirmation-answer-for-uu1d-iuhiuwfew-fewfewfewdsf-dsf-1",
-                  condition: "equals",
-                  value: "Wait I can get more?",
+                  condition: "contains any",
+                  values: ["Wait I can get more?"],
                 },
               ],
             },
@@ -407,8 +407,8 @@ describe("Group", () => {
               {
                 id:
                   "answerconfirmation-answer-for-uu1d-iuhiuwfew-fewfewfewdsf-dsf-1",
-                condition: "equals",
-                value: "Wait I can get more?",
+                condition: "contains any",
+                values: ["Wait I can get more?"],
               },
             ],
           },
@@ -419,8 +419,8 @@ describe("Group", () => {
             when: [
               {
                 id: "answer1",
-                condition: "equals",
-                value: "2.3",
+                condition: "contains any",
+                values: ["2.3"],
               },
             ],
           },

--- a/eq-publisher/src/eq_schema/builders/routing2/index.test.js
+++ b/eq-publisher/src/eq_schema/builders/routing2/index.test.js
@@ -1,19 +1,23 @@
 const translateAuthorRouting = require("./");
 const { RADIO, CURRENCY } = require("../../../constants/answerTypes");
 const questionnaireJson = require("./basicQuestionnaireJSON");
+const { AND, OR } = require("../../../constants/routingOperators");
 
 describe("Routing2", () => {
-  it("Should translate a complex example", () => {
-    const routingGotos = [];
-    const ctx = {
+  let routingGotos, ctx;
+  beforeEach(() => {
+    routingGotos = [];
+    ctx = {
       questionnaireJson,
       routingGotos,
     };
+  });
+  it("should translate a complex example with 'And' correctly", () => {
     const authorRouting = {
       rules: [
         {
           expressionGroup: {
-            operator: "AND",
+            operator: AND,
             expressions: [
               {
                 left: {
@@ -33,7 +37,7 @@ describe("Routing2", () => {
         },
         {
           expressionGroup: {
-            operator: "AND",
+            operator: AND,
             expressions: [
               {
                 left: {
@@ -67,14 +71,16 @@ describe("Routing2", () => {
     };
 
     const runnerRouting = translateAuthorRouting(authorRouting, "1", "1", ctx);
-
     expect(ctx.routingGotos).toMatchObject([
       {
         group: "confirmation-group",
         groupId: "group1",
         when: [
-          { condition: "equals", id: "answer2", value: "red" },
-          { condition: "equals", id: "answer2", value: "white" },
+          {
+            condition: "contains any",
+            id: "answer2",
+            values: ["red", "white"],
+          },
         ],
       },
     ]);
@@ -95,17 +101,119 @@ describe("Routing2", () => {
       {
         goto: {
           group: "confirmation-group",
-
           when: [
             {
               id: "answer2",
-              condition: "equals",
-              value: "red",
+              condition: "contains any",
+              values: ["red", "white"],
             },
+          ],
+        },
+      },
+      {
+        goto: {
+          block: "block3",
+        },
+      },
+    ]);
+  });
+
+  it("should translate example with 'Or' correctly", () => {
+    const authorRouting = {
+      rules: [
+        {
+          expressionGroup: {
+            operator: OR,
+            expressions: [
+              {
+                left: {
+                  id: "1",
+                  type: RADIO,
+                  options: [
+                    {
+                      label: "A",
+                    },
+                    {
+                      label: "B",
+                    },
+                  ],
+                },
+                condition: "OneOf",
+                right: {
+                  options: [
+                    {
+                      label: "A",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          destination: {
+            logical: "NextPage",
+          },
+        },
+        {
+          expressionGroup: {
+            operator: OR,
+            expressions: [
+              {
+                left: {
+                  id: "2",
+                  type: RADIO,
+                  options: [
+                    {
+                      label: "D",
+                    },
+                    {
+                      label: "E",
+                    },
+                  ],
+                },
+                condition: "OneOf",
+                right: {
+                  options: [
+                    {
+                      label: "E",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          destination: {
+            logical: "EndOfQuestionnaire",
+          },
+        },
+      ],
+      else: {
+        page: {
+          id: "3",
+        },
+      },
+    };
+    const runnerRouting = translateAuthorRouting(authorRouting, "1", "1", ctx);
+    expect(runnerRouting).toMatchObject([
+      {
+        goto: {
+          block: "block2",
+          when: [
+            {
+              id: "answer1",
+              condition: "contains any",
+              values: ["A"],
+            },
+          ],
+        },
+      },
+      {
+        goto: {
+          group: "confirmation-group",
+          when: [
             {
               id: "answer2",
-              condition: "equals",
-              value: "white",
+              condition: "contains any",
+              values: ["E"],
             },
           ],
         },

--- a/eq-publisher/src/eq_schema/builders/routing2/translateBinaryExpression.js
+++ b/eq-publisher/src/eq_schema/builders/routing2/translateBinaryExpression.js
@@ -8,31 +8,26 @@ const {
 } = require("../../../constants/answerTypes");
 const conditionConverter = require("../../../utils/convertRoutingConditions");
 
-const buildMuiltpleChoiceAnswerBinaryExpression = binaryExpression => {
-  if (isEmpty(binaryExpression.right.options)) {
-    return [
-      {
-        id: `answer${binaryExpression.left.id}`,
-        condition: "not set",
-      },
-    ];
-  } else {
-    return binaryExpression.right.options.map(option => ({
-      id: `answer${binaryExpression.left.id}`,
-      condition: "equals",
-      value: option.label,
-    }));
+const buildMuiltpleChoiceAnswerBinaryExpression = ({ left, right }) => {
+  if (isEmpty(right.options)) {
+    return {
+      id: `answer${left.id}`,
+      condition: "not set",
+    };
   }
+  return {
+    id: `answer${left.id}`,
+    condition: "contains any",
+    values: right.options.map(op => op.label),
+  };
 };
 
 const buildBasicAnswerBinaryExpression = ({ left, condition, right }) => {
-  return [
-    {
-      id: `answer${left.id}`,
-      condition: conditionConverter(condition),
-      value: right.number,
-    },
-  ];
+  return {
+    id: `answer${left.id}`,
+    condition: conditionConverter(condition),
+    value: right.number,
+  };
 };
 
 const translateBinaryExpression = binaryExpression => {

--- a/eq-publisher/src/eq_schema/builders/routing2/translateBinaryExpression.test.js
+++ b/eq-publisher/src/eq_schema/builders/routing2/translateBinaryExpression.test.js
@@ -60,13 +60,11 @@ describe("Should build a runner representation of a binary expression", () => {
 
       const runnerExpression = translateBinaryExpression(expression);
 
-      expect(runnerExpression).toMatchObject([
-        {
-          id: "answer1",
-          condition: "equals",
-          value: "no",
-        },
-      ]);
+      expect(runnerExpression).toMatchObject({
+        id: "answer1",
+        condition: "contains any",
+        values: ["no"],
+      });
     });
 
     it("With a radio answer and no selected options", () => {
@@ -74,9 +72,10 @@ describe("Should build a runner representation of a binary expression", () => {
 
       const runnerExpression = translateBinaryExpression(expression);
 
-      expect(runnerExpression).toMatchObject([
-        { condition: "not set", id: "answer1" },
-      ]);
+      expect(runnerExpression).toMatchObject({
+        condition: "not set",
+        id: "answer1",
+      });
     });
 
     it("With a radio answer and multiple selected options", () => {
@@ -86,19 +85,11 @@ describe("Should build a runner representation of a binary expression", () => {
       );
 
       const runnerExpression = translateBinaryExpression(expression);
-
-      expect(runnerExpression).toMatchObject([
-        {
-          id: "answer1",
-          condition: "equals",
-          value: "no",
-        },
-        {
-          id: "answer1",
-          condition: "equals",
-          value: "maybe",
-        },
-      ]);
+      expect(runnerExpression).toMatchObject({
+        id: "answer1",
+        condition: "contains any",
+        values: ["no", "maybe"],
+      });
     });
   });
 
@@ -117,13 +108,11 @@ describe("Should build a runner representation of a binary expression", () => {
           },
         };
         const runnerExpression = translateBinaryExpression(expression);
-        expect(runnerExpression).toMatchObject([
-          {
-            id: "answer1",
-            condition: "equals",
-            value: 5,
-          },
-        ]);
+        expect(runnerExpression).toMatchObject({
+          id: "answer1",
+          condition: "equals",
+          value: 5,
+        });
       });
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
This PR enables a user to route by using Any of (OR) or All of (AND) routing rules.

### How to review 
**author**
1. Create a new questionnaire
1. Fill in a question title and create a new answer (radio, number or currency).
1. Go to routing and add two new expressions to the rule.
1. Switch between "Match All of" and "Match Any of" and see that the AND and OR labels change on the left hand side.

**author-api**
* Check that the migration is okay

**publisher**
...
