### PR TITLE
Simplify setup of GTM.

### DIFF
--- a/eq-author/README.md
+++ b/eq-author/README.md
@@ -81,10 +81,13 @@ The following environment variables should be placed in a `.env` file in the eq-
 ### Third party services
 
 | Name                      | Description                                     | Required |
-| ------------------------- | ----------------------------------------------- | -------- |
+|---------------------------|-------------------------------------------------|----------|
 | `REACT_APP_SENTRY_DSN`    | Use Sentry for error checking, by providing dsn | No       |
 | `REACT_APP_SENTRY_ENV`    | Use Sentry to sort errors by environment        | No       |
 | `REACT_APP_FULLSTORY_ORG` | Use fullstory, by providing org id              | No       |
+| `REACT_APP_GTM_ID`        | Google tag manager Id                           | No       |
+| `REACT_APP_GTM_AUTH`      | Google tag manager environment Id               | No       |
+| `REACT_APP_GTM_PREVIEW`   | Google tag manager preview Id                   | No       |
 
 ## Folder Structure
 

--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -107,6 +107,7 @@
     "react-apollo": "^2.5.8",
     "react-dom": "latest",
     "react-firebaseui": "latest",
+    "react-gtm-module": "latest",
     "react-hot-loader": "latest",
     "react-modal": "latest",
     "react-redux": "^5.0.7",

--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -66,39 +66,9 @@
       window.config.REACT_APP_SENTRY_DSN = "";
       window.config.REACT_APP_HOT_JAR_ID = "";
       window.config.REACT_APP_GTM_ID = "";
-      window.config.REACT_APP_GTM_ENV_ID = "";
+      window.config.REACT_APP_GTM_AUTH = "";
+      window.config.REACT_APP_GTM_PREVIEW = "";
     </script>
-    <!-- Google Tag Manager -->
-    <script>
-      if (
-        window.config.REACT_APP_GTM_ID &&
-        window.config.REACT_APP_GTM_ENV_ID
-      ) {
-        (function(w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-          var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != "dataLayer" ? "&l=" + l : "";
-          j.async = true;
-          j.src =
-            "https://www.googletagmanager.com/gtm.js?id=" +
-            i +
-            dl +
-            "&gtm_auth=" +
-            window.config.REACT_APP_GTM_ENV_ID +
-            "&gtm_preview=env-8&gtm_cookies_win=x";
-          f.parentNode.insertBefore(j, f);
-        })(
-          window,
-          document,
-          "script",
-          "dataLayer",
-          window.config.REACT_APP_GTM_ID
-        );
-      }
-    </script>
-    <!-- End Google Tag Manager -->
     <script type="text/javascript">
       if (window.config.REACT_APP_HOT_JAR_ID) {
         (function(h, o, t, j, a, r) {
@@ -173,29 +143,6 @@
     </script>
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <script>
-      if (
-        window.config.REACT_APP_GTM_ID &&
-        window.config.REACT_APP_GTM_ENV_ID
-      ) {
-        (function(w, d) {
-          a = d.getElementsByTagName("body")[0];
-          r = d.createElement("iframe");
-          r.src =
-            "https://www.googletagmanager.com/ns.html?id=" +
-            w.config.REACT_APP_GTM_ID +
-            "&gtm_auth=" +
-            w.config.REACT_APP_GTM_ENV_ID +
-            "&gtm_preview=env-8&gtm_cookies_win=x";
-          r.height = "0";
-          r.width = "0";
-          r.style = "display:none;visibility:hidden";
-          a.appendChild(r);
-        })(window, document);
-      }
-    </script>
-    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <div id="toast"></div>
   </body>

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -21,8 +21,10 @@ const config = {
     window.config.REACT_APP_HOT_JAR_ID || process.env.REACT_APP_HOT_JAR_ID,
   REACT_APP_GTM_ID:
     window.config.REACT_APP_GTM_ID || process.env.REACT_APP_GTM_ID,
-  REACT_APP_GTM_ENV_ID:
-    window.config.REACT_APP_GTM_ENV_ID || process.env.REACT_APP_GTM_ENV_ID,
+  REACT_APP_GTM_AUTH:
+    window.config.REACT_APP_GTM_AUTH || process.env.REACT_APP_GTM_AUTH,
+  REACT_APP_GTM_PREVIEW:
+    window.config.REACT_APP_GTM_PREVIEW || process.env.REACT_APP_GTM_PREVIEW,
 };
 
 export default config;

--- a/eq-author/src/index.js
+++ b/eq-author/src/index.js
@@ -10,12 +10,26 @@ import { ApolloLink, split } from "apollo-link";
 import { setContext } from "apollo-link-context";
 import { getMainDefinition } from "apollo-utilities";
 import { WebSocketLink } from "apollo-link-ws";
+import TagManager from "react-gtm-module";
 import config from "config";
 import getIdForObject from "utils/getIdForObject";
 import render from "utils/render";
 import getHeaders from "middleware/headers";
 
 import App from "App";
+
+if (
+  config.REACT_APP_GTM_ID &&
+  config.REACT_APP_GTM_AUTH &&
+  config.REACT_APP_GTM_PREVIEW
+) {
+  const tagManagerArgs = {
+    gtmId: config.REACT_APP_GTM_ID,
+    auth: config.REACT_APP_GTM_AUTH,
+    preview: config.REACT_APP_GTM_PREVIEW,
+  };
+  TagManager.initialize(tagManagerArgs);
+}
 
 if (config.REACT_APP_SENTRY_DSN) {
   Sentry.init({

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -9532,6 +9532,11 @@ react-firebaseui@latest:
   dependencies:
     firebaseui "^3.2.0"
 
+react-gtm-module@latest:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.7.tgz#1d1d085eddac36d522b56d45308ff4472ace09d6"
+  integrity sha512-QYnzQdRpN9qZIc/HaWnpmXUZ31ZsJ4BICp8Gb9VOAh4v5wtytXIrSvQdB7/dS9RgI9cuYN6KCl7NuqiNCPS+DA==
+
 react-hot-loader@latest:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.11.1.tgz#2cabbd0f1c8a44c28837b86d6ce28521e6d9a8ac"


### PR DESCRIPTION
### What is the context of this PR?
The way in which we were setting up GTM was more complex than it needed to be.

There is an existing library which integrates nicely with React applications which takes care of injecting the relevant GTM snippets.

We were also hard coding the preview Id which made it impossible to successfully turn on GTM in both pre-prod and production environments.

This change renames the existing ENV_ID environment variable to GTM_AUTH and introduces a separate GTM_PREVIEW environment variable to simplify the configuration across environments and bring the terminology inline with what GTM calls these variables.

### How to review 
Set the environment variables appropriately.
Observe that google tag manager is injected into the page source.

### Dependencies
- https://github.com/ONSdigital/eq-author-terraform/pull/26