### PR TITLE
Enable deletion of last character in validation

### DIFF
--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { kebabCase, get, startCase } from "lodash";
+import { kebabCase, get, startCase, isNull } from "lodash";
 import CustomPropTypes from "custom-prop-types";
 
 import ModalWithNav from "components/modals/ModalWithNav";
@@ -150,7 +150,7 @@ class AnswerValidation extends React.PureComponent {
       }}
     >
       <Title>{title}</Title>
-      {enabled && value && <Detail>{value}</Detail>}
+      {enabled && !isNull(value) && <Detail>{value}</Detail>}
     </SidebarButton>
   );
 

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
@@ -4,9 +4,7 @@ import { shallow } from "enzyme";
 import { NUMBER, CURRENCY, PERCENTAGE, UNIT } from "constants/answer-types";
 import { CENTIMETRES } from "constants/unit-types";
 
-import SidebarButton, {
-  Detail as SidebarButtonDetail,
-} from "components/buttons/SidebarButton";
+import SidebarButton, { Detail } from "components/buttons/SidebarButton";
 import ModalWithNav from "components/modals/ModalWithNav";
 import AnswerValidation, { validationTypes } from "./AnswerValidation";
 
@@ -104,9 +102,8 @@ describe("AnswerValidation", () => {
           NUMBER_TYPES.forEach(type => {
             expect(
               wrapper(type)
-                .find(SidebarButtonDetail)
-                .at(0)
-                .prop("children")
+                .find(SidebarButton)
+                .find(Detail)
             ).toMatchSnapshot();
           });
         });
@@ -129,7 +126,11 @@ describe("AnswerValidation", () => {
             });
 
           NUMBER_TYPES.forEach(type => {
-            expect(wrapper(type).find(SidebarButtonDetail)).toMatchSnapshot();
+            expect(
+              wrapper(type)
+                .find(SidebarButton)
+                .find(Detail)
+            ).toMatchSnapshot();
           });
         });
 
@@ -154,9 +155,8 @@ describe("AnswerValidation", () => {
           NUMBER_TYPES.forEach(type => {
             expect(
               wrapper(type)
-                .find(SidebarButtonDetail)
-                .at(0)
-                .prop("children")
+                .find(SidebarButton)
+                .find(Detail)
             ).toMatchSnapshot();
           });
         });

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/AnswerValidation.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/AnswerValidation.test.js.snap
@@ -8,21 +8,53 @@ exports[`AnswerValidation Numeric answer validation preview maxValue should not 
 
 exports[`AnswerValidation Numeric answer validation preview maxValue should not render when the custom value is null 4`] = `null`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 1`] = `"5%"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 1`] = `
+<SidebarButton__Detail>
+  5%
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 2`] = `5`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 2`] = `
+<SidebarButton__Detail>
+  5
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 3`] = `"£5"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 3`] = `
+<SidebarButton__Detail>
+  £5
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 4`] = `"5 cm"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render custom values 4`] = `
+<SidebarButton__Detail>
+  5 cm
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 1`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 1`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 2`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 2`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 3`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 3`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 4`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview maxValue should render previous answer 4`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
 exports[`AnswerValidation Numeric answer validation preview minValue should not render when the custom value is null 1`] = `null`;
 
@@ -32,21 +64,53 @@ exports[`AnswerValidation Numeric answer validation preview minValue should not 
 
 exports[`AnswerValidation Numeric answer validation preview minValue should not render when the custom value is null 4`] = `null`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 1`] = `"5%"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 1`] = `
+<SidebarButton__Detail>
+  5%
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 2`] = `5`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 2`] = `
+<SidebarButton__Detail>
+  5
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 3`] = `"£5"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 3`] = `
+<SidebarButton__Detail>
+  £5
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 4`] = `"5 cm"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render custom values 4`] = `
+<SidebarButton__Detail>
+  5 cm
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 1`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 1`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 2`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 2`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 3`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 3`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
-exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 4`] = `"foobar"`;
+exports[`AnswerValidation Numeric answer validation preview minValue should render previous answer 4`] = `
+<SidebarButton__Detail>
+  foobar
+</SidebarButton__Detail>
+`;
 
 exports[`AnswerValidation should not render when there are no valid validation types 1`] = `""`;
 

--- a/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.js
+++ b/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.js
@@ -16,7 +16,7 @@ const withCustomNumberValueChange = WrappedComponent => {
     handleCustomValueChange = ({ value }) => {
       // clamp value of input to +/- limit
       if (
-        value !== "" &&
+        value !== null &&
         !inRange(
           parseInt(value, 10),
           0 - this.props.limit,

--- a/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.test.js
+++ b/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.test.js
@@ -44,8 +44,8 @@ describe("withCustomValueChange", () => {
     expect(onChange).toHaveBeenCalledWith({ name: "custom", value: 1 });
   });
 
-  it("should correctly handle min value change with empty string", () => {
-    wrapper.simulate("customNumberValueChange", { value: "" });
+  it("should correctly handle value change with empty field", () => {
+    wrapper.simulate("customNumberValueChange", { value: null });
     expect(onChange).toHaveBeenCalledWith({ name: "custom", value: null });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes a bug that prevented a user from deleting the last character or number when creating a custom validation rule.

The following change was necessary because 0 was evaluated to false.
`{enabled && !isNaN(parseInt(value, 10)) && <Detail>{value}</Detail>}`

### How to review 
1. Create a new questionnaire with a number answer.
1. Create a new min or max validation rule on the number.
1. Fill in a number and try delete it. This should be possible on this branch, not on master.
1. Try with different answer types, for example percentage or currency.