### PR TITLE
Changed confirmation page positive/negative validation message

### DIFF
--- a/eq-author/src/App/questionConfirmation/Design/ConfirmationOption.js
+++ b/eq-author/src/App/questionConfirmation/Design/ConfirmationOption.js
@@ -40,7 +40,7 @@ export const UnwrappedConfirmationOption = ({
             errorValidationMsg={getValidationError({
               field: "label",
               label: "Confirmation label",
-              requiredMsg: `Enter a ${label.toLowerCase()}`,
+              requiredMsg: `Enter ${label.toLowerCase()}`,
             })}
           />
         </OptionField>


### PR DESCRIPTION
### What is the context of this PR?
Positive/Negative validation message needs changing from:
"Enter a positive confirmation text"
"Enter a negative confirmation text"

to

"Enter positive confirmation text"
"Enter negative confirmation text"

### How to review 
Create confirmation page and check validation messages are correct as above.
