### PR TITLE
Implemented publish Survey for admins only

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - NODE_ENV=development
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
       - PUBLISHER_URL=http://localhost:9000/publish/
+      - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit/
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api
       - JAEGER_ENDPOINT=http://jaeger:14268/api/traces
@@ -57,4 +58,3 @@ services:
       - 14250
       - 14268
       - 16686:16686
-

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -18,6 +18,7 @@ const {
 const GraphQLJSON = require("graphql-type-json");
 const uuid = require("uuid");
 const { withFilter } = require("apollo-server-express");
+const fetch = require("node-fetch");
 
 const pubsub = require("../../db/pubSub");
 const { getName } = require("../../utils/getName");
@@ -161,6 +162,17 @@ const Resolvers = {
     },
     me: (root, args, ctx) => ctx.user,
     users: () => listUsers(),
+    triggerPublish: async (root, { questionnaireId }) => {
+      const result = await fetch(
+        `${process.env.SURVEY_REGISTER_URL}${questionnaireId}`,
+        { method: "put" }
+      )
+        .then(res => res.json())
+        .catch(e => {
+          throw Error(e);
+        });
+      return { id: questionnaireId, launchUrl: result.publishedSurveyUrl };
+    },
   },
 
   Subscription: {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -17,6 +17,7 @@ type User {
   picture: String
   email: String
   displayName: String!
+  admin: Boolean!
 }
 
 type QuestionnaireInfo {
@@ -529,6 +530,11 @@ type QuestionnaireIntroduction {
   availablePipingMetadata: [Metadata!]!
 }
 
+type PublishRequest {
+  id: ID!
+  launchUrl: String!
+}
+
 type Query {
   questionnaires: [Questionnaire]
   questionnaire(input: QueryInput!): Questionnaire
@@ -540,6 +546,7 @@ type Query {
   pagesAffectedByDeletion(pageId: ID!): [Page]! @deprecated(reason: "Not implemented")
   questionConfirmation(id: ID!): QuestionConfirmation
   questionnaireIntroduction(id: ID!): QuestionnaireIntroduction
+  triggerPublish(questionnaireId: ID!): PublishRequest
   me: User!
   users: [User!]!
 }

--- a/eq-author-api/scripts/test.sh
+++ b/eq-author-api/scripts/test.sh
@@ -45,4 +45,5 @@ ENABLE_OPENTRACING=false \
 FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID} \
 REDIS_DOMAIN_NAME=0.0.0.0 \
 REDIS_PORT=${REDIS_PORT} \
+SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit/ \
 yarn jest --runInBand --detectOpenHandles --forceExit "$@"

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
@@ -5,4 +5,5 @@ module.exports = {
   ...require("./updateQuestionnaire"),
   ...require("./queryQuestionnaire"),
   ...require("./listQuestionnaires"),
+  ...require("./publishQuestionnaire"),
 };

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
@@ -1,0 +1,23 @@
+const executeQuery = require("../../executeQuery");
+
+const publishQuestionnaireQuery = `
+query triggerPublish($input: ID!) {
+    triggerPublish(questionnaireId: $input) {
+      id
+      launchUrl
+    }
+  }
+`;
+
+const publishQuestionnaire = async questionnaireId => {
+  const result = await executeQuery(publishQuestionnaireQuery, {
+    input: questionnaireId,
+  });
+
+  return result.data.triggerPublish;
+};
+
+module.exports = {
+  publishQuestionnaireQuery,
+  publishQuestionnaire,
+};

--- a/eq-author/src/App/MeContext.js
+++ b/eq-author/src/App/MeContext.js
@@ -59,6 +59,7 @@ export const CURRENT_USER_QUERY = gql`
       displayName
       picture
       email
+      admin
     }
   }
 `;

--- a/eq-author/src/App/MeContext.test.js
+++ b/eq-author/src/App/MeContext.test.js
@@ -52,6 +52,7 @@ describe("MeContext", () => {
                   displayName: "Rob",
                   email: "Rob@Stark.com",
                   picture: "a//image_file.bmp",
+                  admin: true,
                   __typename: "User",
                 },
               },

--- a/eq-author/src/components/EditorLayout/Header/SharingModal/index.test.js
+++ b/eq-author/src/components/EditorLayout/Header/SharingModal/index.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { omit } from "lodash";
-import { render, fireEvent } from "tests/utils/rtl";
-import flushPromises from "tests/utils/flushPromises";
+import { render, fireEvent, flushPromises } from "tests/utils/rtl";
 
 import SharingModal, { ALL_USERS_QUERY } from "./";
 import { ADD_REMOVE_EDITOR_MUTATION } from "./withAddRemoveEditor";

--- a/eq-author/src/components/EditorLayout/Header/TriggerPublishQuery.js
+++ b/eq-author/src/components/EditorLayout/Header/TriggerPublishQuery.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { ApolloConsumer } from "react-apollo";
+import PropTypes from "prop-types";
+import gql from "graphql-tag";
+
+export const TRIGGER_PUBLISH_QUERY = gql`
+  query triggerPublish($input: ID!) {
+    triggerPublish(questionnaireId: $input) {
+      id
+      launchUrl
+    }
+  }
+`;
+
+const TriggerPublishQuery = ({ children }) => {
+  const triggerPublish = client => questionnaireId =>
+    client.query({
+      query: TRIGGER_PUBLISH_QUERY,
+      variables: { input: questionnaireId },
+      fetchPolicy: "no-cache",
+    });
+  return (
+    <ApolloConsumer>
+      {client => children({ triggerPublish: triggerPublish(client) })}
+    </ApolloConsumer>
+  );
+};
+
+TriggerPublishQuery.propTypes = {
+  children: PropTypes.func.isRequired,
+};
+
+export default TriggerPublishQuery;

--- a/eq-author/src/components/EditorLayout/Header/icon-publish.svg
+++ b/eq-author/src/components/EditorLayout/Header/icon-publish.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group" transform="translate(9.000000, 8.000000)" fill="#FFFFFF" fill-rule="nonzero">
+            <path d="M0,2 L9,2 L14,2 L14,0 L0,0 L0,2 Z M0,10 L4,10 L4,16 L10,16 L10,10 L14,10 L7,3 L0,10 Z" id="Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/eq-author/src/components/EditorLayout/Header/index.js
+++ b/eq-author/src/components/EditorLayout/Header/index.js
@@ -18,9 +18,11 @@ import ButtonGroup from "components/buttons/ButtonGroup";
 import { withQuestionnaire } from "components/QuestionnaireContext";
 import UserProfile from "components/UserProfile";
 
+import TriggerPublishQuery from "./TriggerPublishQuery";
 import shareIcon from "./icon-share.svg?inline";
 import viewIcon from "./icon-view.svg?inline";
 import settingsIcon from "./icon-cog.svg?inline";
+import publishIcon from "./icon-publish.svg?inline";
 import SharingModal from "./SharingModal";
 import PageTitle from "./PageTitle";
 import UpdateQuestionnaireSettingsModal from "./UpdateQuestionnaireSettingsModal";
@@ -127,6 +129,28 @@ export class UnconnectedHeader extends React.Component {
                   >
                     <IconText icon={viewIcon}>View survey</IconText>
                   </LinkButton>
+                  {me.admin && (
+                    <TriggerPublishQuery>
+                      {({ triggerPublish }) => (
+                        <Button
+                          variant="tertiary-light"
+                          onClick={() => {
+                            triggerPublish(questionnaire.id).then(({ data }) =>
+                              window.alert(
+                                `Your survey has been published at: ${data.triggerPublish.launchUrl}`
+                              )
+                            );
+                          }}
+                          data-test="btn-publish"
+                          small
+                          disabled={questionnaire.totalErrorCount > 0}
+                        >
+                          <IconText icon={publishIcon}>Publish</IconText>
+                        </Button>
+                      )}
+                    </TriggerPublishQuery>
+                  )}
+
                   <Button
                     variant="tertiary-light"
                     onClick={this.handleShare}


### PR DESCRIPTION
### What is the context of this PR?
Added the button to publish a survey

To spin up locally: 

1. Checkout runner and remove https://github.com/ONSdigital/eq-survey-runner/blob/413b66e5b8278f9708ab67c4cd9fecddfd189fd1/docker-compose.yml#L27 to line 33.
2. Spin up runner using `docker-compose up`
3. Make sure Author, the api and publisher are all running.
4. Checkout https://github.com/ONSdigital/eq-survey-register/pull/2 and spin it up using `docker-compose up`
5. Make yourself an admin by following the instructions in https://github.com/ONSdigital/eq-author-app/pull/359
6. See the new publish button in the header, click it and follow the link! 

### How to review 
Tests pass and pipeline works.
