### PR TITLE
Fix routing any of dropdown border

### DIFF
--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
@@ -55,6 +55,7 @@ const SmallSelect = styled(Select)`
   display: inline-block;
   width: auto;
   margin: 0 0.5em;
+  line-height: 1.25;
 `;
 
 const RemoveRuleButton = styled(Button).attrs({


### PR DESCRIPTION
### What is the context of this PR?
Fixes an issue with the bottom border of the dropdown when selecting between `any of` and `all of` in routing. 

### How to review 
Open up chrome on windows and change the styling in the same place and see that it fixes the issue.