### PR TITLE
Fixed properties panel scrolling when banner displayed

### DIFF
--- a/eq-author/src/components/EditorLayout/index.js
+++ b/eq-author/src/components/EditorLayout/index.js
@@ -30,7 +30,7 @@ const Margin = styled.div`
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
 `;
 
 const PanelWrapper = styled.div`


### PR DESCRIPTION
### What is the context of this PR?
Properties panel does not scroll to bottom if banner is being displayed.

### How to review
On master: 
1. Create several number/currency answers on page so properties panel is longer than browser window.
2. Trigger the banner e.g. disable network
3. Observe that the last property in panel cannot be fully scrolled to
4. repeat steps in this branch and check last property can be scrolled to
