### PR TITLE
Added user to subscription context on api

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -177,15 +177,18 @@ const Resolvers = {
 
   Subscription: {
     validationUpdated: {
-      resolve: ({ questionnaire, validationErrorInfo }, args, ctx) => {
+      resolve: ({ questionnaire, validationErrorInfo, user }, args, ctx) => {
         ctx.questionnaire = questionnaire;
         ctx.validationErrorInfo = validationErrorInfo;
+        ctx.user = user;
         return questionnaire;
       },
       subscribe: withFilter(
         () => pubsub.asyncIterator(["validationUpdated"]),
         (payload, variables, ctx) => {
-          const user = ctx.user;
+          // user in payload not ctx on createQuestionnaire
+          // this covers scenario where changing to private is done immediately on createQuestionnaire
+          const user = ctx.user || payload.user;
           const { questionnaire } = payload;
           if (
             questionnaire.isPublic ||

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -11,6 +11,7 @@ const createMutation = mutation => async (root, args, ctx) => {
   pubsub.publish("validationUpdated", {
     questionnaire: ctx.questionnaire,
     validationErrorInfo: ctx.validationErrorInfo,
+    user: ctx.user,
   });
   return result;
 };


### PR DESCRIPTION
### What is the context of this PR?
Red banner was appearing when questionnaire changed to private. Also new pages could not be added to private questionnaire.

### How to review 
1. On master, observe red banner when switching to private and inability to add new pages.
2. On Branch, no banner and pages can be added.