### PR TITLE
Remove unused operator on rule

### DIFF
--- a/eq-author-api/src/businessLogic/createRoutingRule.js
+++ b/eq-author-api/src/businessLogic/createRoutingRule.js
@@ -1,12 +1,10 @@
 const uuid = require("uuid");
 const createDestination = require("./createDestination");
 const createExpressionGroup = require("./createExpressionGroup");
-const { AND } = require("../../constants/routingOperators");
 
 module.exports = input => ({
   id: uuid.v4(),
   destination: createDestination(),
   expressionGroup: createExpressionGroup(),
-  operator: AND,
   ...input,
 });


### PR DESCRIPTION
### What is the context of this PR?
This operator was added on my PR for enabling any of routing on radios.

<https://github.com/ONSdigital/eq-author-app/commit/8cee5f8b8b64bdf245fa51f6dc9241d034f59a99>

But this was not needed as the operator is inside the `expressionGroup`.

### How to review 
See that everything still works.
