### PR TITLE
Made Section title disabled rather than hidden when nav disabled

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -572,7 +572,12 @@ const Resolvers = {
   Section: {
     pages: section => section.pages,
     questionnaire: (section, args, ctx) => ctx.questionnaire,
-    displayName: section => getName(section, "Section"),
+    title: (section, args, ctx) =>
+      ctx.questionnaire.navigation ? section.title : "",
+    displayName: (section, args, ctx) =>
+      ctx.questionnaire.navigation
+        ? getName(section, "Section")
+        : getName(omit(section, "title"), "Section"),
     position: ({ id }, args, ctx) => {
       return findIndex(ctx.questionnaire.sections, { id });
     },

--- a/eq-author-api/schema/tests/duplication.test.js
+++ b/eq-author-api/schema/tests/duplication.test.js
@@ -28,6 +28,7 @@ describe("Duplication", () => {
   let ctx, questionnaire, section;
   let config = {
     shortTitle: "short title",
+    navigation: true,
     sections: [
       {
         title: "section-title-1",

--- a/eq-author-api/schema/tests/section.test.js
+++ b/eq-author-api/schema/tests/section.test.js
@@ -27,7 +27,7 @@ describe("section", () => {
 
   describe("create", () => {
     beforeAll(async () => {
-      ctx = await buildContext({});
+      ctx = await buildContext({ navigation: true });
       questionnaire = ctx.questionnaire;
     });
 
@@ -63,6 +63,7 @@ describe("section", () => {
   describe("mutate", () => {
     beforeAll(async () => {
       ctx = await buildContext({
+        navigation: true,
         sections: [{}],
       });
       questionnaire = ctx.questionnaire;
@@ -128,6 +129,7 @@ describe("section", () => {
 
     beforeEach(async () => {
       ctx = await buildContext({
+        navigation: true,
         metadata: [{}],
         sections: [
           {
@@ -157,6 +159,21 @@ describe("section", () => {
         questionnaire: expect.any(Object),
         availablePipingAnswers: expect.any(Array),
         availablePipingMetadata: expect.any(Array),
+      });
+    });
+
+    it("should resolve title to empty string if navigation is off", async () => {
+      ctx.questionnaire.sections[1].title = "Test title";
+      queriedSection = await querySection(ctx, questionnaire.sections[1].id);
+      expect(queriedSection).toMatchObject({
+        title: "Test title",
+        displayName: "Alias",
+      });
+      ctx.questionnaire.navigation = false;
+      queriedSection = await querySection(ctx, questionnaire.sections[1].id);
+      expect(queriedSection).toMatchObject({
+        title: "",
+        displayName: "Alias",
       });
     });
 

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -92,7 +92,7 @@ describe("SectionEditor", () => {
     });
   });
 
-  it("should show the section title when navigation is enabled", () => {
+  it("should enable the section title when navigation is enabled", () => {
     const section = {
       ...section1,
       questionnaire: {
@@ -101,12 +101,15 @@ describe("SectionEditor", () => {
       },
     };
     const wrapper = render({ section });
-    expect(wrapper.find("[testSelector='txt-section-title']").length).toEqual(
-      1
-    );
+    expect(
+      wrapper
+        .find(RichTextEditor)
+        .first()
+        .prop("disabled")
+    ).toEqual(false);
   });
 
-  it("should not show the section title when navigation is disabled", () => {
+  it("should disable the section title when navigation is disabled", () => {
     const section = {
       ...section1,
       questionnaire: {
@@ -115,9 +118,12 @@ describe("SectionEditor", () => {
       },
     };
     const wrapper = render({ section });
-    expect(wrapper.find("[testSelector='txt-section-title']").length).toEqual(
-      0
-    );
+    expect(
+      wrapper
+        .find(RichTextEditor)
+        .first()
+        .prop("disabled")
+    ).toEqual(true);
   });
 
   it("should not autofocus the section title when its empty and navigation has just been turned on", () => {
@@ -165,8 +171,7 @@ describe("SectionEditor", () => {
 
     expect(getValidationError).toHaveBeenCalledWith({
       field: "title",
-      message:
-        "Enter a section title. If section navigation is not required, disable in 'settings'.",
+      message: "Enter a section title",
     });
   });
 

--- a/eq-author/src/App/section/Design/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/eq-author/src/App/section/Design/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -30,7 +30,7 @@ exports[`SectionEditor should render 1`] = `
       id="section-title"
       label={
         <DescribedText
-          description="Displayed in section navigation"
+          description="This is displayed in the section navigation. You can enable or disable it in 'settings'"
         >
           Section title
         </DescribedText>
@@ -49,7 +49,7 @@ exports[`SectionEditor should render 1`] = `
       <DescribedText
         description="If you do not want an introduction page, leave these blank"
       >
-        Section introduction
+        Section introduction page
       </DescribedText>
     </Label>
     <SectionEditor__IntroCanvas>
@@ -127,7 +127,7 @@ exports[`SectionEditor should render 2`] = `
       id="section-title"
       label={
         <DescribedText
-          description="Displayed in section navigation"
+          description="This is displayed in the section navigation. You can enable or disable it in 'settings'"
         >
           Section title
         </DescribedText>
@@ -146,7 +146,7 @@ exports[`SectionEditor should render 2`] = `
       <DescribedText
         description="If you do not want an introduction page, leave these blank"
       >
-        Section introduction
+        Section introduction page
       </DescribedText>
     </Label>
     <SectionEditor__IntroCanvas>

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -112,6 +112,7 @@ export class SectionEditor extends React.Component {
 
     const autoFocusTitle = !navHasChanged && !hasTitle;
 
+    const hasNav = section.questionnaire.navigation;
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>
         <DeleteConfirmDialog
@@ -127,31 +128,29 @@ export class SectionEditor extends React.Component {
           {this.renderMoveSectionModal}
         </MoveSectionQuery>
         <Padding>
-          {section.questionnaire.navigation && (
-            <RichTextEditor
-              id="section-title"
-              name="title"
-              label={
-                <DescribedText description="Displayed in section navigation">
-                  Section title
-                </DescribedText>
-              }
-              value={section.title}
-              onUpdate={handleUpdate}
-              controls={titleControls}
-              size="large"
-              testSelector="txt-section-title"
-              autoFocus={autoFocusTitle}
-              errorValidationMsg={this.props.getValidationError({
-                field: "title",
-                message:
-                  "Enter a section title. If section navigation is not required, disable in 'settings'.",
-              })}
-            />
-          )}
+          <RichTextEditor
+            id="section-title"
+            name="title"
+            label={
+              <DescribedText description="This is displayed in the section navigation. You can enable or disable it in 'settings'">
+                Section title
+              </DescribedText>
+            }
+            value={section.title}
+            disabled={!hasNav}
+            onUpdate={handleUpdate}
+            controls={titleControls}
+            size="large"
+            testSelector="txt-section-title"
+            autoFocus={autoFocusTitle}
+            errorValidationMsg={this.props.getValidationError({
+              field: "title",
+              message: "Enter a section title",
+            })}
+          />
           <Label>
             <DescribedText description="If you do not want an introduction page, leave these blank">
-              Section introduction
+              Section introduction page
             </DescribedText>
           </Label>
           <IntroCanvas>

--- a/eq-author/src/graphql/updateQuestionnaire.graphql
+++ b/eq-author/src/graphql/updateQuestionnaire.graphql
@@ -6,6 +6,8 @@ mutation UpdateQuestionnaire($input: UpdateQuestionnaireInput!) {
     ...Questionnaire
     sections {
       id
+      title
+      displayName
       validationErrorInfo {
         ...ValidationErrorInfo
       }


### PR DESCRIPTION
### What is the context of this PR?
There was a bit of awkwardness around section titles being hidden when section navigation is disabled, this PR instead just nulls the fields and hides the data when the nav is disabled. 

### How to review 
Changes make sense, and changing the navigation enabled setting changes the section editor display as expected.
