### PR TITLE
Enabled lists in answer guidance

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AdditionalInfo.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AdditionalInfo.js
@@ -20,6 +20,7 @@ const contentControls = {
   bold: true,
   emphasis: true,
   piping: true,
+  list: true,
 };
 
 export const StatelessAdditionalInfo = ({

--- a/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/AdditionalInfo.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/AdditionalInfo.test.js.snap
@@ -40,6 +40,7 @@ exports[`AdditionalInfo should render 1`] = `
           Object {
             "bold": true,
             "emphasis": true,
+            "list": true,
             "piping": true,
           }
         }


### PR DESCRIPTION
### What is the context of this PR?
Was asked to enable list in the additional info boxes. This PR does that

### How to review 
You can use lists in additional info and it publishes correctly.
