### PR TITLE
Added a publish status to questionnaires

### DIFF
--- a/eq-author-api/constants/publishStatus.js
+++ b/eq-author-api/constants/publishStatus.js
@@ -1,0 +1,7 @@
+const UNPUBLISHED = "Unpublished";
+const PUBLISHED = "Published";
+
+module.exports = {
+  PUBLISHED,
+  UNPUBLISHED,
+};

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -51,6 +51,9 @@ const baseQuestionnaireSchema = {
   shortTitle: {
     type: String,
   },
+  publishStatus: {
+    type: String,
+  },
   introduction: {
     type: Object,
   },

--- a/eq-author-api/migrations/addPublishStatusToQuestionnaire.js
+++ b/eq-author-api/migrations/addPublishStatusToQuestionnaire.js
@@ -1,0 +1,10 @@
+//This is an auto-generated file.  Do NOT modify the method signature.
+
+const UNPUBLISHED = "Unpublished";
+
+module.exports = function addPublishStatusToQuestionnaire(questionnaire) {
+  if (!questionnaire.hasOwnProperty("publishStatus")) {
+    questionnaire.publishStatus = UNPUBLISHED;
+  }
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addPublishStatusToQuestionnaire.test.js
+++ b/eq-author-api/migrations/addPublishStatusToQuestionnaire.test.js
@@ -1,0 +1,43 @@
+const { cloneDeep } = require("lodash");
+const addPublishStatusToQuestionnaire = require("./addPublishStatusToQuestionnaire.js");
+const UNPUBLISHED = "Unpublished";
+const PUBLISHED = "Published";
+
+describe("addPublishStatusToQuestionnaire", () => {
+  let questionnaire = {};
+  beforeEach(() => {
+    questionnaire = {
+      id: "aca64645-98ef-43ae-8b77-d749b4e89a05",
+      title: "laa",
+      description: null,
+      type: "Social",
+      theme: "default",
+      introduction: null,
+      navigation: false,
+      surveyId: null,
+      summary: false,
+      metadata: [],
+      sections: [],
+    };
+  });
+  // This test must remain for your migration to always work
+  it("should be deterministic", () => {
+    expect(addPublishStatusToQuestionnaire(cloneDeep(questionnaire))).toEqual(
+      addPublishStatusToQuestionnaire(cloneDeep(questionnaire))
+    );
+  });
+
+  it("should add publishStatus if it is missing", () => {
+    expect(addPublishStatusToQuestionnaire(questionnaire)).toEqual({
+      ...questionnaire,
+      publishStatus: UNPUBLISHED,
+    });
+  });
+  it("should not change existing Publish states", () => {
+    const newQuestionnaire = { ...questionnaire, publishStatus: PUBLISHED };
+    expect(addPublishStatusToQuestionnaire(newQuestionnaire)).toEqual({
+      ...newQuestionnaire,
+      publishStatus: PUBLISHED,
+    });
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -9,6 +9,7 @@ const migrations = [
   require("./updateCreatedByToUseUsers"),
   require("./addIsPublicFlag"),
   require("./addExpressionOperator"),
+  require("./addPublishStatusToQuestionnaire"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -1,4 +1,5 @@
 const pubsub = require("../../db/pubSub");
+const { PUBLISHED, UNPUBLISHED } = require("../../constants/publishStatus");
 const { saveQuestionnaire } = require("../../utils/datastore");
 const validateQuestionnaire = require("../../src/validation");
 const { enforceHasWritePermission } = require("./withWritePermission");
@@ -6,6 +7,9 @@ const { enforceHasWritePermission } = require("./withWritePermission");
 const createMutation = mutation => async (root, args, ctx) => {
   enforceHasWritePermission(ctx.questionnaire, ctx.user);
   const result = await mutation(root, args, ctx);
+  if (ctx.questionnaire.publishStatus === PUBLISHED) {
+    ctx.questionnaire.publishStatus = UNPUBLISHED;
+  }
   await saveQuestionnaire(ctx.questionnaire);
   ctx.validationErrorInfo = validateQuestionnaire(ctx.questionnaire);
   pubsub.publish("validationUpdated", {

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -13,6 +13,7 @@ fetch.mockImplementation(() =>
 );
 
 const { SOCIAL, BUSINESS } = require("../../constants/questionnaireTypes");
+const { PUBLISHED, UNPUBLISHED } = require("../../constants/publishStatus");
 
 const { buildContext } = require("../../tests/utils/contextBuilder");
 const {
@@ -208,7 +209,7 @@ describe("questionnaire", () => {
     });
 
     it("should publish a questionnaire", async () => {
-      const result = await publishQuestionnaire(ctx.questionnaire.id);
+      const result = await publishQuestionnaire(ctx.questionnaire.id, ctx);
       expect(fetch).toHaveBeenCalledWith(
         `${process.env.SURVEY_REGISTER_URL}${ctx.questionnaire.id}`,
         { method: "put" }
@@ -217,6 +218,35 @@ describe("questionnaire", () => {
         id: ctx.questionnaire.id,
         launchUrl: "https://best.url.ever.com",
       });
+
+      expect(ctx.questionnaire.publishStatus).toEqual(PUBLISHED);
+    });
+
+    it("should set publish status to unpublished after updating the questionnaire", async () => {
+      const result = await publishQuestionnaire(ctx.questionnaire.id, ctx);
+      expect(fetch).toHaveBeenCalledWith(
+        `${process.env.SURVEY_REGISTER_URL}${ctx.questionnaire.id}`,
+        { method: "put" }
+      );
+      expect(result).toMatchObject({
+        id: ctx.questionnaire.id,
+        launchUrl: "https://best.url.ever.com",
+      });
+
+      expect(ctx.questionnaire.publishStatus).toEqual(PUBLISHED);
+
+      const update = {
+        id: ctx.questionnaire.id,
+        title: "Questionnaire-updated",
+        description: "Description-updated",
+        theme: "census",
+        navigation: true,
+        surveyId: "2-updated",
+        summary: true,
+        shortTitle: "short title updated",
+      };
+      await updateQuestionnaire(ctx, update);
+      expect(ctx.questionnaire.publishStatus).toEqual(UNPUBLISHED);
     });
   });
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -55,7 +55,13 @@ type Questionnaire {
   editors: [User!]!
   permission: Permission!
   isPublic: Boolean!
+  publishStatus: PublishStatus!
   totalErrorCount: Int!
+}
+
+enum PublishStatus {
+  Published
+  Unpublished
 }
 
 type DeletedQuestionnaire {

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
@@ -9,10 +9,14 @@ query triggerPublish($input: ID!) {
   }
 `;
 
-const publishQuestionnaire = async questionnaireId => {
-  const result = await executeQuery(publishQuestionnaireQuery, {
-    input: questionnaireId,
-  });
+const publishQuestionnaire = async (questionnaireId, ctx) => {
+  const result = await executeQuery(
+    publishQuestionnaireQuery,
+    {
+      input: questionnaireId,
+    },
+    ctx
+  );
 
   return result.data.triggerPublish;
 };

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
@@ -30,6 +30,7 @@ const getQuestionnaireQuery = `
         id
       }
       totalErrorCount
+      publishStatus
     }
   }
 `;

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/__snapshots__/index.test.js.snap
@@ -51,6 +51,11 @@ exports[`Row should render 1`] = `
         />
       </Row__TD>
       <Row__TD>
+        <Row__TableIconText
+          icon={[Function]}
+        />
+      </Row__TD>
+      <Row__TD>
         Alan
       </Row__TD>
       <Row__TD>

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -11,6 +11,7 @@ import DuplicateButton from "components/buttons/DuplicateButton";
 import FadeTransition from "components/transitions/FadeTransition";
 import DeleteConfirmDialog from "components/DeleteConfirmDialog";
 import Truncated from "components/Truncated";
+import IconText from "components/IconText";
 
 import { buildQuestionnairePath } from "utils/UrlUtils";
 
@@ -20,6 +21,11 @@ import { WRITE } from "constants/questionnaire-permissions";
 import FormattedDate from "./FormattedDate";
 
 import questionConfirmationIcon from "./icon-questionnaire.svg";
+
+const publishColors = {
+  Published: `#12C864`,
+  Unpublished: `#595959`,
+};
 
 export const QuestionnaireLink = styled(NavLink)`
   text-decoration: none;
@@ -45,6 +51,19 @@ export const ShortTitle = styled.span`
 
 const ButtonGroup = styled.div`
   display: flex;
+`;
+
+const TableIconText = styled(IconText)`
+  display: inline;
+`;
+
+const StatusDot = styled.div`
+  height: 0.75em;
+  width: 0.75em;
+  background-color: ${({ publishStatus }) => publishColors[publishStatus]};
+  border-radius: 50%;
+  display: inline-flex;
+  margin-right: 0.5em;
 `;
 
 export const TR = styled.tr`
@@ -212,11 +231,14 @@ export class Row extends React.Component {
         displayName,
         updatedAt,
         permission,
+        publishStatus,
       },
       ...rest
     } = this.props;
 
     const hasWritePermisson = permission === WRITE;
+
+    const ColoredStatusDot = () => <StatusDot publishStatus={publishStatus} />;
 
     return (
       <>
@@ -250,6 +272,11 @@ export class Row extends React.Component {
             </TD>
             <TD>
               <FormattedDate date={updatedAt} />
+            </TD>
+            <TD>
+              <TableIconText icon={ColoredStatusDot}>
+                {publishStatus}
+              </TableIconText>
             </TD>
             <TD>{createdBy.displayName}</TD>
             <TD>

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/TableHead/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/TableHead/index.js
@@ -113,7 +113,7 @@ const TableHead = props => {
       <tr>
         <SortableTH
           sortColumn="title"
-          colWidth="38%"
+          colWidth="18%"
           dataTest="title-sort-button"
           {...props}
         >
@@ -135,9 +135,10 @@ const TableHead = props => {
         >
           Modified
         </SortableTH>
+        <UnsortableTH colWidth="14%">Status</UnsortableTH>
         <SortableTH
           sortColumn="createdBy.displayName"
-          colWidth="22%"
+          colWidth="18%"
           dataTest="owner-sort-button"
           {...props}
         >

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/index.js
@@ -74,6 +74,7 @@ QuestionnairesTable.fragments = {
         displayName
       }
       permission
+      publishStatus
     }
   `,
 };

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
@@ -19,6 +19,8 @@ jest.mock("lodash", () => ({
 }));
 
 describe("QuestionnairesView", () => {
+  const PUBLISHED = "Published";
+  const UNPUBLISHED = "Unpublished";
   const user = {
     id: "3",
     name: "Foo",
@@ -35,6 +37,7 @@ describe("QuestionnairesView", () => {
     updatedAt: `2019-05-${30 - index}T12:36:50.984Z`,
     createdBy: user,
     permission: WRITE,
+    publishStatus: UNPUBLISHED,
     ...overrides,
   });
   let props;
@@ -109,6 +112,17 @@ describe("QuestionnairesView", () => {
 
       expect(getByText("Questionnaire 1 Title")).toBeTruthy();
       expect(getByText("Questionnaire 2 Title")).toBeTruthy();
+    });
+
+    it("should render a published questionnaire", () => {
+      let questionnaires = [
+        buildQuestionnaire(1, { publishStatus: PUBLISHED }),
+      ];
+      const { getByText } = render(
+        <QuestionnairesView {...props} questionnaires={questionnaires} />
+      );
+
+      expect(getByText("Published")).toBeTruthy();
     });
 
     it("should render the questionnaires when the storage is corrupted", () => {

--- a/eq-author/src/App/QuestionnairesPage/index.js
+++ b/eq-author/src/App/QuestionnairesPage/index.js
@@ -31,7 +31,7 @@ const QuestionnairesPage = ({
   onCreateQuestionnaire,
 }) => (
   <Layout title="Your Questionnaires">
-    <Query fetchPolicy="cache-and-network" query={QUESTIONNAIRES_QUERY}>
+    <Query fetchPolicy="network-only" query={QUESTIONNAIRES_QUERY}>
       {response => {
         const { loading, error, data } = response;
 

--- a/eq-author/src/App/QuestionnairesPage/index.test.js
+++ b/eq-author/src/App/QuestionnairesPage/index.test.js
@@ -98,6 +98,7 @@ describe("QuestionnairesPage", () => {
                   createdAt: Date.now().toString(),
                   displayName: "UKIS",
                   permission: WRITE,
+                  publishStatus: "Unpublished",
                   createdBy: {
                     id: "1",
                     name: "A Dude",


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a status to the questionnaire table showing wether the questinnaire is currently published and present in the survey register. Right now there are only 2 modes Published and un published however this will be expanded upon as more and more publish features are added.

### How to review 
Tests pass changes look good.

### THIS CHANGE WILL NEED THE BULK MIGRATE SCRIPT TO BE RUN.
