### PR TITLE
Moved create introduction to util to prevent redis initilising

### DIFF
--- a/eq-author-api/migrations/addBusinessQuestionnaireIntroduction.js
+++ b/eq-author-api/migrations/addBusinessQuestionnaireIntroduction.js
@@ -5,9 +5,7 @@ const { BUSINESS } = require("../constants/questionnaireTypes");
 const {
   createDefaultBusinessSurveyMetadata,
 } = require("../utils/defaultMetadata");
-const {
-  createQuestionnaireIntroduction,
-} = require("../schema/resolvers/questionnaireIntroduction");
+const createQuestionnaireIntroduction = require("../utils/createQuestionnaireIntroduction");
 
 module.exports = function addBusinessQuestionnaireIntroduction(questionnaire) {
   if (questionnaire.type !== BUSINESS) {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -80,9 +80,7 @@ const {
 
 const { listQuestionnaires } = require("../../utils/datastore");
 
-const {
-  createQuestionnaireIntroduction,
-} = require("./questionnaireIntroduction");
+const createQuestionnaireIntroduction = require("../../utils/createQuestionnaireIntroduction");
 
 const {
   enforceHasWritePermission,

--- a/eq-author-api/schema/resolvers/questionnaireIntroduction.js
+++ b/eq-author-api/schema/resolvers/questionnaireIntroduction.js
@@ -1,7 +1,5 @@
-const { find, omit, first, remove } = require("lodash");
+const { omit, first, remove } = require("lodash");
 const uuid = require("uuid").v4;
-
-const { NOTICE_1 } = require("../../constants/legalBases");
 
 const { createMutation } = require("./createMutation");
 
@@ -57,23 +55,3 @@ Resolvers.Collapsible = {
 };
 
 module.exports = [Resolvers];
-module.exports.createQuestionnaireIntroduction = metadata => {
-  return {
-    id: uuid.v4(),
-    title: `<p>You are completing this for <span data-piped="metadata" data-id="${
-      find(metadata, { key: "trad_as" }).id
-    }">trad_as</span> (<span data-piped="metadata" data-id="${
-      find(metadata, { key: "ru_name" }).id
-    }">ru_name</span>)</p>`,
-    description:
-      "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. </li><li>You can provide info estimates if actual figures aren’t available.</li><li>We will treat your data securely and confidentially.</li></ul>",
-    legalBasis: NOTICE_1,
-    secondaryTitle: "<p>Information you need</p>",
-    secondaryDescription:
-      "<p>You can select the dates of the period you are reporting for, if the given dates are not appropriate.</p>",
-    collapsibles: [],
-    tertiaryTitle: "<p>How we use your data</p>",
-    tertiaryDescription:
-      "<ul><li>You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.</li><li>The information you provide contributes to Gross Domestic Product (GDP).</li></ul>",
-  };
-};

--- a/eq-author-api/utils/createQuestionnaireIntroduction.js
+++ b/eq-author-api/utils/createQuestionnaireIntroduction.js
@@ -1,0 +1,25 @@
+const { find } = require("lodash");
+const uuid = require("uuid").v4;
+
+const { NOTICE_1 } = require("../constants/legalBases");
+
+module.exports = metadata => {
+  return {
+    id: uuid.v4(),
+    title: `<p>You are completing this for <span data-piped="metadata" data-id="${
+      find(metadata, { key: "trad_as" }).id
+    }">trad_as</span> (<span data-piped="metadata" data-id="${
+      find(metadata, { key: "ru_name" }).id
+    }">ru_name</span>)</p>`,
+    description:
+      "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. </li><li>You can provide info estimates if actual figures aren’t available.</li><li>We will treat your data securely and confidentially.</li></ul>",
+    legalBasis: NOTICE_1,
+    secondaryTitle: "<p>Information you need</p>",
+    secondaryDescription:
+      "<p>You can select the dates of the period you are reporting for, if the given dates are not appropriate.</p>",
+    collapsibles: [],
+    tertiaryTitle: "<p>How we use your data</p>",
+    tertiaryDescription:
+      "<ul><li>You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.</li><li>The information you provide contributes to Gross Domestic Product (GDP).</li></ul>",
+  };
+};


### PR DESCRIPTION
### What is the context of this PR?
One of the migrations was importing from a resolver meaning that the bulk migration was trying to initilise redis. This Pr stops this by moving the import into a unitl folder and importing it in both places. 

### How to review 
Run the bulk migrate script and make sure redis doesn't complain.
