### PR TITLE
Min/Max val text reads 'must be (higher/lower) than' when given val is included

### DIFF
--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.js
@@ -38,6 +38,9 @@ import {
   UNIT,
 } from "constants/answer-types";
 
+export const MIN_INCLUSIVE_TEXT = "must be more than";
+export const MAX_INCLUSIVE_TEXT = "must be less than";
+
 const formatValue = (value, { type, properties }) => {
   if (typeof value !== "number") {
     return null;
@@ -57,7 +60,7 @@ const formatValue = (value, { type, properties }) => {
 export const validationTypes = [
   {
     id: "minValue",
-    title: "Min Value",
+    title: "Min value",
     render: () => (
       <MinValue>{props => <NumericValidation {...props} />}</MinValue>
     ),
@@ -69,7 +72,7 @@ export const validationTypes = [
   },
   {
     id: "maxValue",
-    title: "Max Value",
+    title: "Max value",
     render: () => (
       <MaxValue>{props => <NumericValidation {...props} />}</MaxValue>
     ),
@@ -153,7 +156,7 @@ export class UnwrappedAnswerValidation extends React.PureComponent {
 
   handleModalClose = () => this.setState({ modalIsOpen: false });
 
-  renderButton = ({ id, title, value, enabled, hasError }) => (
+  renderButton = ({ id, title, value, enabled, hasError, inclusive }) => (
     <SidebarButton
       key={id}
       data-test={`sidebar-button-${kebabCase(title)}`}
@@ -162,7 +165,12 @@ export class UnwrappedAnswerValidation extends React.PureComponent {
       }}
       hasError={hasError}
     >
-      <Title>{title}</Title>
+      <Title>
+        {title}{" "}
+        {enabled &&
+          !inclusive &&
+          (id.includes("max") ? MAX_INCLUSIVE_TEXT : MIN_INCLUSIVE_TEXT)}
+      </Title>
       {enabled && !isNull(value) && <Detail>{value}</Detail>}
     </SidebarButton>
   );
@@ -182,7 +190,7 @@ export class UnwrappedAnswerValidation extends React.PureComponent {
           const validation = get(answer, `validation.${validationType.id}`, {});
           const errors = get(validation, `validationErrorInfo.errors`, []);
           validationErrors.push(...errors);
-          const { enabled, previousAnswer, metadata } = validation;
+          const { enabled, previousAnswer, metadata, inclusive } = validation;
           const value = enabled
             ? validationType.preview(validation, answer)
             : "";
@@ -194,6 +202,7 @@ export class UnwrappedAnswerValidation extends React.PureComponent {
             previousAnswer,
             metadata,
             hasError: errors.length > 0,
+            inclusive,
           });
         })}
 

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
@@ -7,7 +7,12 @@ import { CENTIMETRES } from "constants/unit-types";
 
 import SidebarButton, { Detail } from "components/buttons/SidebarButton";
 import ModalWithNav from "components/modals/ModalWithNav";
-import { UnwrappedAnswerValidation, validationTypes } from "./AnswerValidation";
+import {
+  UnwrappedAnswerValidation,
+  validationTypes,
+  MIN_INCLUSIVE_TEXT,
+  MAX_INCLUSIVE_TEXT,
+} from "./AnswerValidation";
 
 const render = (props, render = shallow) => {
   return render(<UnwrappedAnswerValidation {...props} />);
@@ -161,6 +166,44 @@ describe("AnswerValidation", () => {
                 .find(SidebarButton)
                 .find(Detail)
             ).toMatchSnapshot();
+          });
+        });
+
+        it("should render with additional inclusive text when appropriate on all number types", () => {
+          props = {
+            ...props,
+            answer: {
+              id: "1",
+              validation: {
+                [validation]: {
+                  enabled: true,
+                  inclusive: false,
+                  previousAnswer: {
+                    displayName: "foobar",
+                  },
+                },
+              },
+            },
+          };
+
+          NUMBER_TYPES.forEach(type => {
+            props.answer.type = type;
+
+            const { getAllByText } = rtlRender(
+              <UnwrappedAnswerValidation {...props} />
+            );
+
+            if (validation === VALIDATIONS[0]) {
+              expect(
+                getAllByText(`Max value ${MAX_INCLUSIVE_TEXT}`)
+              ).toBeTruthy();
+            }
+
+            if (validation === VALIDATIONS[1]) {
+              expect(
+                getAllByText(`Min value ${MIN_INCLUSIVE_TEXT}`)
+              ).toBeTruthy();
+            }
           });
         });
       });

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/AnswerValidation.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/AnswerValidation.test.js.snap
@@ -146,7 +146,8 @@ exports[`AnswerValidation should render 1`] = `
     onClick={[Function]}
   >
     <SidebarButton__Title>
-      Min Value
+      Min value
+       
     </SidebarButton__Title>
   </SidebarButton>
   <SidebarButton
@@ -156,7 +157,8 @@ exports[`AnswerValidation should render 1`] = `
     onClick={[Function]}
   >
     <SidebarButton__Title>
-      Max Value
+      Max value
+       
     </SidebarButton__Title>
   </SidebarButton>
   <ModalWithNav
@@ -168,7 +170,7 @@ exports[`AnswerValidation should render 1`] = `
           "id": "minValue",
           "preview": [Function],
           "render": [Function],
-          "title": "Min Value",
+          "title": "Min value",
           "types": Array [
             "Currency",
             "Number",
@@ -180,7 +182,7 @@ exports[`AnswerValidation should render 1`] = `
           "id": "maxValue",
           "preview": [Function],
           "render": [Function],
-          "title": "Max Value",
+          "title": "Max value",
           "types": Array [
             "Currency",
             "Number",
@@ -227,7 +229,7 @@ exports[`AnswerValidation validation object array should render the Max Duration
 </Component>
 `;
 
-exports[`AnswerValidation validation object array should render the Max Value validation 1`] = `
+exports[`AnswerValidation validation object array should render the Max value validation 1`] = `
 <Component
   displayName="Max value"
   readKey="maxValue"
@@ -247,7 +249,7 @@ exports[`AnswerValidation validation object array should render the Min Duration
 </Component>
 `;
 
-exports[`AnswerValidation validation object array should render the Min Value validation 1`] = `
+exports[`AnswerValidation validation object array should render the Min value validation 1`] = `
 <Component
   displayName="Min value"
   readKey="minValue"


### PR DESCRIPTION
Link to Trello story: https://trello.com/c/VCD3FsH7/1353-min-max-text-on-numerical-values-3

### What is the context of this PR?
Modified AnswerValidation to make it so that the 'Min value' and 'Max value' text shows 'must be higher than' and 'must be lower than', respectively, when the given value is specified to be included. When it is not included, the word 'value' is now lowercase (previous uppercase). Tests made and are passing when evaluating every number type (number, percentage, etc.) for both min and max value phrases.

### How to review 
The code should be reviewed on GitHub to make sure it's clean and nice (linter passed locally, yay); run tests to ensure they pass too.
