### PR TITLE
Added total piping to variable piping

### DIFF
--- a/eq-author/src/components/ContentPickerv2/VariablePicker.js
+++ b/eq-author/src/components/ContentPickerv2/VariablePicker.js
@@ -1,0 +1,140 @@
+import React from "react";
+import PropTypes from "prop-types";
+import CustomPropTypes from "custom-prop-types";
+
+import styled from "styled-components";
+
+import { colors } from "constants/theme";
+import {
+  SubMenuItem,
+  MenuItemType,
+  MenuItemTitle,
+  MenuItemSubtitle,
+} from "./Menu";
+import Truncated from "components/Truncated";
+
+import ScrollPane from "components/ScrollPane";
+
+const ModalTitle = styled.div`
+  font-weight: bold;
+  font-size: 1.2em;
+  color: ${colors.textLight};
+`;
+
+const ModalHeader = styled.div`
+  padding: 2em 1em;
+  border-bottom: 1px solid ${colors.bordersLight};
+`;
+
+const MenuContainer = styled.div`
+  overflow: hidden;
+  height: 25em;
+`;
+
+const Table = styled.div`
+  display: table;
+  width: 100%;
+`;
+
+const RightPositioner = styled.div`
+  float: right;
+`;
+
+const TableHeader = styled.div`
+  display: table-header-group;
+  background: ${colors.lighterGrey};
+  font-size: 11px;
+  padding: 0.3rem 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: bold;
+  color: ${colors.darkGrey};
+  line-height: 1.1;
+`;
+
+const Col = styled.div`
+  display: table-cell;
+  padding: 0 1rem;
+  vertical-align: middle;
+  margin: auto;
+  border-bottom: 1px solid ${colors.lightGrey};
+`;
+
+const TableHeadCol = styled.div`
+  display: table-cell;
+  padding: 1em 3em 1em 1.5em;
+`;
+
+const VariableItem = styled(SubMenuItem)`
+  display: table-row;
+`;
+
+const VariableItemList = styled.ul`
+  display: table-row-group;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const VariablePicker = ({ onSelected, isSelected }) => {
+  const onEnterUp = (event, item) => {
+    if (event.keyCode === 13) {
+      //13 is the enter keycode
+      onSelected(item);
+    }
+  };
+
+  const totalObject = { id: "total", displayName: "total" };
+
+  return (
+    <>
+      <ModalHeader>
+        <ModalTitle>Select a variable</ModalTitle>
+      </ModalHeader>
+      <MenuContainer>
+        <ScrollPane>
+          <Table>
+            <TableHeader>
+              <TableHeadCol>Name</TableHeadCol>
+              <TableHeadCol>
+                <RightPositioner>Type</RightPositioner>
+              </TableHeadCol>
+            </TableHeader>
+            <VariableItemList>
+              <VariableItem
+                key="total"
+                onClick={() => onSelected(totalObject)}
+                aria-selected={isSelected(totalObject)}
+                aria-label={"total"}
+                tabIndex="0"
+                onKeyUp={event => onEnterUp(event, totalObject)}
+              >
+                <Col>
+                  <MenuItemTitle>
+                    <Truncated>Total</Truncated>
+                  </MenuItemTitle>
+                  <MenuItemSubtitle>
+                    <Truncated>Calculated summary</Truncated>
+                  </MenuItemSubtitle>
+                </Col>
+                <Col>
+                  <RightPositioner>
+                    <MenuItemType>Number</MenuItemType>
+                  </RightPositioner>
+                </Col>
+              </VariableItem>
+            </VariableItemList>
+          </Table>
+        </ScrollPane>
+      </MenuContainer>
+    </>
+  );
+};
+
+VariablePicker.propTypes = {
+  data: PropTypes.arrayOf(CustomPropTypes.metadata),
+  onSelected: PropTypes.func.isRequired,
+  isSelected: PropTypes.func.isRequired,
+};
+
+export default VariablePicker;

--- a/eq-author/src/components/ContentPickerv2/index.js
+++ b/eq-author/src/components/ContentPickerv2/index.js
@@ -5,9 +5,14 @@ import { colors } from "constants/theme";
 import Modal, { CloseButton } from "components/modals/Modal";
 import Button from "components/buttons/Button";
 import ButtonGroup from "components/buttons/ButtonGroup";
-import { ANSWER, METADATA } from "components/ContentPickerSelect/content-types";
+import {
+  ANSWER,
+  METADATA,
+  VARIABLES,
+} from "components/ContentPickerSelect/content-types";
 import AnswerPicker from "./AnswerPicker";
 import MetadataPicker from "./MetadataPicker";
+import VariablePicker from "./VariablePicker";
 
 const ModalFooter = styled.div`
   padding: 1.5em;
@@ -107,6 +112,18 @@ const ContentPicker = ({
             data={data}
             multiselect={multiselect}
             firstSelectedItemId={getFirstSelectedItemId()}
+          />
+        );
+
+      case VARIABLES:
+        return (
+          <VariablePicker
+            onConfirm={handleConfirm}
+            onSelected={item =>
+              handleSelected({ ...item, pipingType: "variable" })
+            }
+            isSelected={isSelected}
+            data={data}
           />
         );
 

--- a/eq-author/src/components/ContentPickerv2/index.test.js
+++ b/eq-author/src/components/ContentPickerv2/index.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, fireEvent } from "tests/utils/rtl";
-import { ANSWER, METADATA } from "components/ContentPickerSelect/content-types";
+import {
+  ANSWER,
+  METADATA,
+  VARIABLES,
+} from "components/ContentPickerSelect/content-types";
 
 import ContentPicker from "./";
 
@@ -447,6 +451,77 @@ describe("Content picker", () => {
       expect(onSubmit).toHaveBeenCalledWith([
         { ...meta2, pipingType: "metadata" },
       ]);
+    });
+  });
+  describe("variable content", () => {
+    beforeEach(() => {
+      props = {
+        ...props,
+        contentType: VARIABLES,
+      };
+    });
+
+    it("should render variable picker when specified", () => {
+      const { getByText } = renderContentPicker();
+
+      const modalHeader = getByText("Select a variable");
+      expect(modalHeader).toBeTruthy();
+    });
+
+    it("should call onSubmit with selected variable", () => {
+      const { getByText } = renderContentPicker();
+
+      const variableItem = getByText("Total");
+      const confirmButton = getByText("Confirm");
+
+      fireEvent.click(variableItem);
+      fireEvent.click(confirmButton);
+
+      expect(onSubmit).toHaveBeenCalledWith({
+        id: "total",
+        displayName: "total",
+        pipingType: "variable",
+      });
+    });
+
+    it("should select item via keyboard enter", () => {
+      const { getByText } = renderContentPicker();
+
+      const variableItem = getByText("Total");
+      const confirmButton = getByText("Confirm");
+
+      fireEvent.keyUp(variableItem, { keyCode: 13 });
+      fireEvent.click(confirmButton);
+
+      expect(onSubmit).toHaveBeenCalledWith({
+        id: "total",
+        displayName: "total",
+        pipingType: "variable",
+      });
+    });
+
+    it("should not select item via any key other than enter", () => {
+      const { getByText } = renderContentPicker();
+
+      const variableItem = getByText("Total");
+      const confirmButton = getByText("Confirm");
+
+      fireEvent.keyUp(variableItem, { keyCode: 32 });
+      fireEvent.click(confirmButton);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("should unselect selected item", () => {
+      const { getByText } = renderContentPicker();
+
+      const variableItem = getByText("Total").closest("li");
+
+      fireEvent.click(variableItem);
+      expect(variableItem).toHaveAttribute("aria-selected", "true");
+
+      fireEvent.click(variableItem);
+      expect(variableItem).toHaveAttribute("aria-selected", "false");
     });
   });
 });

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -12,9 +12,14 @@ import CustomPropTypes from "custom-prop-types";
 
 import IconPiping from "components/RichTextEditor/icon-piping.svg?inline";
 import IconPipingMetadata from "components/RichTextEditor/icon-piping-metadata.svg?inline";
+import IconPipingVariable from "components/RichTextEditor/icon-piping-variable.svg?inline";
 import ToolbarButton from "components/RichTextEditor/ToolbarButton";
 
-import { ANSWER, METADATA } from "components/ContentPickerSelect/content-types";
+import {
+  ANSWER,
+  METADATA,
+  VARIABLES,
+} from "components/ContentPickerSelect/content-types";
 
 export const MenuButton = styled(ToolbarButton)`
   height: 100%;
@@ -44,6 +49,10 @@ export class Menu extends React.Component {
     ),
   };
 
+  static defaultProps = {
+    allowableTypes: [ANSWER, METADATA],
+  };
+
   state = {
     pickerContent: "",
   };
@@ -70,6 +79,7 @@ export class Menu extends React.Component {
       disabled,
       loading,
       canFocus,
+      allowableTypes,
     } = this.props;
 
     const { pickerContent } = this.state;
@@ -78,24 +88,39 @@ export class Menu extends React.Component {
 
     return (
       <React.Fragment>
-        <MenuButton
-          title="Pipe value"
-          disabled={loading || disabled || isEmpty(answerData)}
-          onClick={() => this.handleButtonClick(ANSWER)}
-          canFocus={canFocus}
-          data-test="piping-button"
-        >
-          <IconPiping />
-        </MenuButton>
-        <MenuButton
-          title="Pipe metadata"
-          disabled={loading || disabled || isEmpty(metadataData)}
-          onClick={() => this.handleButtonClick(METADATA)}
-          canFocus={canFocus}
-          data-test="piping-button-metadata"
-        >
-          <IconPipingMetadata />
-        </MenuButton>
+        {allowableTypes.includes(ANSWER) && (
+          <MenuButton
+            title="Pipe value"
+            disabled={loading || disabled || isEmpty(answerData)}
+            onClick={() => this.handleButtonClick(ANSWER)}
+            canFocus={canFocus}
+            data-test="piping-button"
+          >
+            <IconPiping />
+          </MenuButton>
+        )}
+        {allowableTypes.includes(METADATA) && (
+          <MenuButton
+            title="Pipe metadata"
+            disabled={loading || disabled || isEmpty(metadataData)}
+            onClick={() => this.handleButtonClick(METADATA)}
+            canFocus={canFocus}
+            data-test="piping-button-metadata"
+          >
+            <IconPipingMetadata />
+          </MenuButton>
+        )}
+        {allowableTypes.includes(VARIABLES) && (
+          <MenuButton
+            title="Pipe variable"
+            disabled={loading || disabled}
+            onClick={() => this.handleButtonClick(VARIABLES)}
+            canFocus={canFocus}
+            data-test="piping-button-variable"
+          >
+            <IconPipingVariable />
+          </MenuButton>
+        )}
         <ContentPicker
           isOpen={Boolean(this.state.pickerContent)}
           data={data}
@@ -161,34 +186,52 @@ const postProcessPipingContent = entity => {
   };
 };
 
-export const UnwrappedPipingMenu = props => {
-  if (!props.canFocus) {
+export const UnwrappedPipingMenu = ({
+  canFocus,
+  allowableTypes,
+  match,
+  ...otherProps
+}) => {
+  if (!canFocus) {
     return (
       <>
-        <MenuButton title="Pipe value" disabled data-test="piping-button">
-          <IconPiping />
-        </MenuButton>
-        <MenuButton
-          title="Pipe metadata"
-          disabled
-          data-test="piping-button-metadata"
-        >
-          <IconPipingMetadata />
-        </MenuButton>
+        {allowableTypes.includes(ANSWER) && (
+          <MenuButton title="Pipe value" disabled data-test="piping-button">
+            <IconPiping />
+          </MenuButton>
+        )}
+        {allowableTypes.includes(METADATA) && (
+          <MenuButton
+            title="Pipe metadata"
+            disabled
+            data-test="piping-button-metadata"
+          >
+            <IconPipingMetadata />
+          </MenuButton>
+        )}
+        {allowableTypes.includes(VARIABLES) && (
+          <MenuButton
+            title="Pipe variable"
+            disabled
+            data-test="piping-button-variable"
+          >
+            <IconPipingVariable />
+          </MenuButton>
+        )}
       </>
     );
   }
 
   return (
     <AvailablePipingContentQuery
-      questionnaireId={props.match.params.questionnaireId}
-      pageId={props.match.params.pageId}
-      sectionId={props.match.params.sectionId}
-      confirmationId={props.match.params.confirmationId}
-      introductionId={props.match.params.introductionId}
+      questionnaireId={match.params.questionnaireId}
+      pageId={match.params.pageId}
+      sectionId={match.params.sectionId}
+      confirmationId={match.params.confirmationId}
+      introductionId={match.params.introductionId}
     >
       {({ data = {}, ...innerProps }) => {
-        const entityName = calculateEntityName(props.match.params);
+        const entityName = calculateEntityName(match.params);
         const entity = postProcessPipingContent(data[entityName]) || {};
 
         return (
@@ -197,7 +240,10 @@ export const UnwrappedPipingMenu = props => {
             metadataData={entity.availablePipingMetadata}
             entity={entity}
             entityName={entityName}
-            {...props}
+            allowableTypes={allowableTypes}
+            canFocus={canFocus}
+            match={match}
+            {...otherProps}
             {...innerProps}
           />
         );
@@ -209,6 +255,11 @@ export const UnwrappedPipingMenu = props => {
 UnwrappedPipingMenu.propTypes = {
   match: CustomPropTypes.match.isRequired,
   canFocus: PropTypes.bool,
+  allowableTypes: PropTypes.arrayOf(PropTypes.string),
+};
+
+UnwrappedPipingMenu.defaultProps = {
+  allowableTypes: [ANSWER, METADATA],
 };
 
 export default withRouter(UnwrappedPipingMenu);

--- a/eq-author/src/components/RichTextEditor/PipingMenu.test.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.test.js
@@ -9,6 +9,12 @@ import {
   UnwrappedPipingMenu,
 } from "components/RichTextEditor/PipingMenu";
 
+import {
+  ANSWER,
+  METADATA,
+  VARIABLES,
+} from "components/ContentPickerSelect/content-types";
+
 const PIPING_BUTTON_VALUE = byTestAttr("piping-button");
 
 describe("PipingMenu", () => {
@@ -22,6 +28,7 @@ describe("PipingMenu", () => {
         answerData={answerData}
         metadataData={metadataData}
         entityName={"section"}
+        allowableTypes={[ANSWER, METADATA, VARIABLES]}
         canFocus
         {...props}
       />
@@ -125,6 +132,7 @@ describe("PipingMenu", () => {
           },
         }}
         canFocus={false}
+        allowableTypes={[ANSWER, METADATA, VARIABLES]}
       />
     );
 
@@ -140,6 +148,12 @@ describe("PipingMenu", () => {
   it("should open the metadata picker when clicked", () => {
     const wrapper = render();
     wrapper.find("[data-test='piping-button-metadata']").simulate("click");
+    expect(wrapper.find("[data-test='picker']").prop("isOpen")).toBe(true);
+  });
+
+  it("should open the variable picker when clicked", () => {
+    const wrapper = render();
+    wrapper.find("[data-test='piping-button-variable']").simulate("click");
     expect(wrapper.find("[data-test='picker']").prop("isOpen")).toBe(true);
   });
 
@@ -235,6 +249,7 @@ describe("PipingMenu", () => {
           canFocus
           entityName={name}
           entity={data[name]}
+          allowableTypes={[ANSWER, METADATA, VARIABLES]}
         />
       );
       const result = wrapper.find(AvailablePipingContentQuery).prop("children")(
@@ -313,6 +328,7 @@ describe("PipingMenu", () => {
           canFocus
           entityName={name}
           entity={data[name]}
+          allowableTypes={[ANSWER, METADATA, VARIABLES]}
         />
       );
       const result = wrapper.find(AvailablePipingContentQuery).prop("children")(
@@ -384,6 +400,7 @@ describe("PipingMenu", () => {
         canFocus
         entityName={name}
         entity={data[name]}
+        allowableTypes={[ANSWER, METADATA, VARIABLES]}
       />
     );
     const result = wrapper.find(AvailablePipingContentQuery).prop("children")({

--- a/eq-author/src/components/RichTextEditor/__snapshots__/PipingMenu.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/PipingMenu.test.js.snap
@@ -20,6 +20,14 @@ exports[`PipingMenu should render 1`] = `
   >
     <Component />
   </PipingMenu__MenuButton>
+  <PipingMenu__MenuButton
+    canFocus={true}
+    data-test="piping-button-variable"
+    onClick={[Function]}
+    title="Pipe variable"
+  >
+    <Component />
+  </PipingMenu__MenuButton>
   <ContentPicker
     contentType=""
     data={


### PR DESCRIPTION
### What is the context of this PR?
When we moved to the new content picker a few weeks back the picker responsible for piping the total variable into the calculated summary page got left out. This PR re-adds the functionality on this page type. 

### How to review 
Check you can pipe total into the calculated summary page title and all the tests pass. 
