### PR TITLE
Fix issue with metadata info text disappearing

### DIFF
--- a/eq-author/src/App/metadata/MetadataPage.js
+++ b/eq-author/src/App/metadata/MetadataPage.js
@@ -34,7 +34,7 @@ const StyledGrid = styled(Grid)`
 `;
 
 const Info = styled(IconText)`
-  margin: 2em 5.75em;
+  padding: 2em;
   justify-content: left;
 `;
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with overflowing info text on metadata page disappears when screen width is less than 1750px.

![Screenshot 2019-10-07 at 16 04 33](https://user-images.githubusercontent.com/11583422/66323750-2e7fe300-e91c-11e9-8776-ce03f81354f4.png)


### How to review 
Reduce screen width and see that the text overflows to the next line.
