### PR TITLE
Author now understands multiple versions of the same questionnaire

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -130,6 +130,9 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
     publishDetails: {
       type: Object,
     },
+    surveyVersion: {
+      type: String,
+    },
   },
   {
     throughput: throughput,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -25,8 +25,8 @@ type QuestionnaireInfo {
 }
 
 type PublishDetails {
-  surveyId: String
-  formType: String
+  surveyId: String!
+  formType: String!
 }
 
 enum QuestionnaireType {

--- a/eq-author-api/utils/questionnaireEvents.js
+++ b/eq-author-api/utils/questionnaireEvents.js
@@ -3,7 +3,7 @@ const uuid = require("uuid");
 const questionnaireCreationEvent = (questionnaire, ctx) => ({
   id: uuid.v4(),
   publishStatus: "Questionnaire created",
-  questionnaireTitle: questionnaire.title,
+  questionnaireTitle: `${questionnaire.title} (Version ${questionnaire.surveyVersion})`,
   userId: ctx.user.id,
   time: questionnaire.createdAt,
 });
@@ -11,8 +11,16 @@ const questionnaireCreationEvent = (questionnaire, ctx) => ({
 const noteCreationEvent = (ctx, bodyText) => ({
   id: uuid.v4(),
   publishStatus: ctx.questionnaire.publishStatus,
-  questionnaireTitle: ctx.questionnaire.title,
+  questionnaireTitle: `${ctx.questionnaire.title} (Version ${ctx.questionnaire.surveyVersion})`,
   bodyText,
+  userId: ctx.user.id,
+  time: new Date(),
+});
+
+const changedPublishStatusEvent = (ctx, questionnaireVersion) => ({
+  id: uuid.v4(),
+  publishStatus: ctx.questionnaire.publishStatus,
+  questionnaireTitle: `${ctx.questionnaire.title} (Version ${questionnaireVersion})`,
   userId: ctx.user.id,
   time: new Date(),
 });
@@ -20,4 +28,5 @@ const noteCreationEvent = (ctx, bodyText) => ({
 module.exports = {
   questionnaireCreationEvent,
   noteCreationEvent,
+  changedPublishStatusEvent,
 };

--- a/eq-author/src/App/history/HistoryPage.js
+++ b/eq-author/src/App/history/HistoryPage.js
@@ -60,6 +60,7 @@ const ActionButtons = styled(ButtonGroup)`
 export const HistoryPageContent = ({ match }) => {
   const { loading, error, data } = useQuery(questionnaireHistoryQuery, {
     variables: { input: { questionnaireId: match.params.questionnaireId } },
+    fetchPolicy: "network-only",
   });
   const [addNote] = useMutation(CREATE_NOTE, {
     update(
@@ -87,6 +88,7 @@ export const HistoryPageContent = ({ match }) => {
     return <Error>Oops! Something went wrong</Error>;
   }
   const { history } = data;
+
   return (
     <Container>
       <Header title="History" />


### PR DESCRIPTION
I have changes the API so that:

- Questionnaires are built with an initial version of 1
- TriggerPublish sends the version number of a questionnaire to the registry for storage
- createMutation increments a new version number IF the publish status was set to 'Published'
- History page will update when a questionnaire has been published and unpublished
- History items now show the version of the questionnaire at the time of the history item being added

I have also removed some remnants of discarded code relating to publishing a questionnaire

### What is the context of this PR?
Describe what you have changed and why, link to other PRs or Issues as appropriate.

### How to review 
Test alongside https://github.com/ONSdigital/eq-survey-register/pull/4; ensure all tests pass and that you can publish multiple versions. Ensure that the history page updates as per the designs.
