### PR TITLE
Enable publish button when questionnaire becomes unpublished

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -208,6 +208,13 @@ const Resolvers = {
         }
       ),
     },
+    publishStatusUpdated: {
+      resolve: ({ questionnaire }, args, ctx) => {
+        ctx.questionnaire = questionnaire;
+        return questionnaire;
+      },
+      subscribe: () => pubsub.asyncIterator(["publishStatusUpdated"]),
+    },
   },
 
   Mutation: {

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -1,15 +1,21 @@
 const pubsub = require("../../db/pubSub");
-const { PUBLISHED, UNPUBLISHED } = require("../../constants/publishStatus");
-const { saveQuestionnaire } = require("../../utils/datastore");
 const validateQuestionnaire = require("../../src/validation");
-const { AWAITING_APPROVAL } = require("../../constants/publishStatus");
 const { enforceHasWritePermission } = require("./withPermissions");
+
+const { saveQuestionnaire } = require("../../utils/datastore");
 const { addEventToHistory } = require("../../utils/datastore");
 const {
   changedPublishStatusEvent,
 } = require("../../utils/questionnaireEvents");
 
+const {
+  AWAITING_APPROVAL,
+  PUBLISHED,
+  UNPUBLISHED,
+} = require("../../constants/publishStatus");
+
 const createMutation = mutation => async (root, args, ctx) => {
+  let hasBeenUnpublished;
   enforceHasWritePermission(ctx.questionnaire, ctx.user);
   if (ctx.questionnaire.publishStatus === AWAITING_APPROVAL) {
     throw new Error(
@@ -20,6 +26,7 @@ const createMutation = mutation => async (root, args, ctx) => {
   if (ctx.questionnaire.publishStatus === PUBLISHED) {
     ctx.questionnaire.publishStatus = UNPUBLISHED;
     ctx.questionnaire.surveyVersion++;
+    hasBeenUnpublished = true;
     await addEventToHistory(
       ctx.questionnaire.id,
       changedPublishStatusEvent(ctx, ctx.questionnaire.surveyVersion)
@@ -27,6 +34,11 @@ const createMutation = mutation => async (root, args, ctx) => {
   }
   await saveQuestionnaire(ctx.questionnaire);
   ctx.validationErrorInfo = validateQuestionnaire(ctx.questionnaire);
+  if (hasBeenUnpublished) {
+    pubsub.publish("publishStatusUpdated", {
+      questionnaire: ctx.questionnaire,
+    });
+  }
   pubsub.publish("validationUpdated", {
     questionnaire: ctx.questionnaire,
     validationErrorInfo: ctx.validationErrorInfo,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -1078,6 +1078,7 @@ input DeleteCollapsibleInput {
 
 type Subscription {
   validationUpdated(id: ID!): Questionnaire!
+  publishStatusUpdated(id: ID!): Questionnaire!
 }
 
 input PublishQuestionnaireInput {

--- a/eq-author-api/tests/utils/contextBuilder/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/index.js
@@ -1,8 +1,13 @@
 const { SOCIAL } = require("../../../constants/questionnaireTypes");
 const { RADIO } = require("../../../constants/answerTypes");
 
+const { PUBLISHED, UNPUBLISHED } = require("../../../constants/publishStatus");
 const { createUser } = require("../../../utils/datastore");
-const { createQuestionnaire } = require("./questionnaire");
+const {
+  createQuestionnaire,
+  publishQuestionnaire,
+  reviewQuestionnaire,
+} = require("./questionnaire");
 const { createMetadata, updateMetadata } = require("./metadata");
 const { createSection, deleteSection } = require("./section");
 const { deletePage } = require("./page");
@@ -174,6 +179,29 @@ const buildContext = async (questionnaireConfig, userConfig = {}) => {
   }
 
   await buildRouting(ctx, questionnaireConfig);
+
+  if (questionnaireProps.publishStatus === UNPUBLISHED) {
+    return ctx;
+  }
+  if (questionnaireProps.publishStatus) {
+    await publishQuestionnaire(
+      {
+        questionnaireId: questionnaire.id,
+        surveyId: "123",
+        formType: "456",
+      },
+      ctx
+    );
+    if (questionnaireProps.publishStatus === PUBLISHED) {
+      await reviewQuestionnaire(
+        {
+          questionnaireId: questionnaire.id,
+          reviewAction: "Approved",
+        },
+        ctx
+      );
+    }
+  }
 
   return ctx;
 };

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
@@ -1,3 +1,6 @@
+const { filter } = require("graphql-anywhere");
+const gql = require("graphql-tag");
+
 const executeQuery = require("../../executeQuery");
 
 const createQuestionnaireMutation = `
@@ -43,7 +46,24 @@ const createQuestionnaireMutation = `
 const createQuestionnaire = async (ctx, input) => {
   const result = await executeQuery(
     createQuestionnaireMutation,
-    { input },
+    {
+      input: filter(
+        gql`
+          {
+            title
+            description
+            theme
+            navigation
+            surveyId
+            summary
+            type
+            shortTitle
+            isPublic
+          }
+        `,
+        input
+      ),
+    },
     ctx
   );
 

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/updateQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/updateQuestionnaire.js
@@ -1,3 +1,6 @@
+const { filter } = require("graphql-anywhere");
+const gql = require("graphql-tag");
+
 const executeQuery = require("../../executeQuery");
 
 const updateQuestionnaireMutation = `
@@ -12,6 +15,7 @@ const updateQuestionnaireMutation = `
       summary
       shortTitle
       displayName
+      publishStatus
     }
   }
 `;
@@ -19,7 +23,26 @@ const updateQuestionnaireMutation = `
 const updateQuestionnaire = async (ctx, input) => {
   const result = await executeQuery(
     updateQuestionnaireMutation,
-    { input },
+    {
+      input: filter(
+        gql`
+          {
+            id
+            title
+            description
+            theme
+            legalBasis
+            navigation
+            surveyId
+            summary
+            shortTitle
+            editors
+            isPublic
+          }
+        `,
+        input
+      ),
+    },
     ctx
   );
   return result.data.updateQuestionnaire;

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -17,6 +17,7 @@ import { buildQuestionnairePath } from "utils/UrlUtils";
 
 import { colors } from "constants/theme";
 import { WRITE } from "constants/questionnaire-permissions";
+import { AWAITING_APPROVAL } from "constants/publishStatus";
 
 import FormattedDate from "./FormattedDate";
 
@@ -276,7 +277,9 @@ export class Row extends React.Component {
             </TD>
             <TD>
               <TableIconText icon={ColoredStatusDot}>
-                {publishStatus.replace(/([A-Z])/g, " $1").trim()}
+                {publishStatus === AWAITING_APPROVAL
+                  ? "Awaiting approval"
+                  : publishStatus}
               </TableIconText>
             </TD>
             <TD>{createdBy.displayName}</TD>

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.test.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.test.js
@@ -1,11 +1,12 @@
 import React from "react";
 import { shallow } from "enzyme";
+import { render } from "tests/utils/rtl";
 
 import IconButtonDelete from "components/buttons/IconButtonDelete";
 import DeleteConfirmDialog from "components/DeleteConfirmDialog";
 
 import { colors } from "constants/theme";
-import { UNPUBLISHED } from "constants/publishStatus";
+import { UNPUBLISHED, AWAITING_APPROVAL } from "constants/publishStatus";
 
 import {
   Row,
@@ -144,6 +145,27 @@ describe("Row", () => {
     expect(stopPropagation).toHaveBeenCalled();
   });
 
+  it("should show the short title when it is provided", () => {
+    let wrapper = shallow(<Row {...props} />);
+    const shortTitle = wrapper.find(ShortTitle);
+    expect(shortTitle).toMatchSnapshot();
+    props.questionnaire.shortTitle = "";
+    wrapper = shallow(<Row {...props} />);
+    expect(wrapper.find(ShortTitle)).toHaveLength(0);
+  });
+
+  it("should display AwaitingApproval as 'Awaiting approval'", () => {
+    props.questionnaire.publishStatus = AWAITING_APPROVAL;
+    const { getByText } = render(
+      <table>
+        <tbody>
+          <Row {...props} />
+        </tbody>
+      </table>
+    );
+    expect(getByText("Awaiting approval")).toBeTruthy();
+  });
+
   describe("deletion", () => {
     it("should show the confirm delete dialog when the delete button is clicked", () => {
       const wrapper = shallow(<Row {...props} />);
@@ -179,14 +201,5 @@ describe("Row", () => {
         isOpen: false,
       });
     });
-  });
-
-  it("should show the short title when it is provided", () => {
-    let wrapper = shallow(<Row {...props} />);
-    let shortTitle = wrapper.find(ShortTitle);
-    expect(shortTitle).toMatchSnapshot();
-    props.questionnaire.shortTitle = "";
-    wrapper = shallow(<Row {...props} />);
-    expect(wrapper.find(ShortTitle)).toHaveLength(0);
   });
 });

--- a/eq-author/src/App/history/HistoryPage.js
+++ b/eq-author/src/App/history/HistoryPage.js
@@ -57,9 +57,10 @@ const ActionButtons = styled(ButtonGroup)`
   flex: 0 0 auto;
 `;
 
-export const HistoryPageContent = ({ match }) => {
+const HistoryPageContent = ({ match }) => {
+  const { questionnaireId } = match.params;
   const { loading, error, data } = useQuery(questionnaireHistoryQuery, {
-    variables: { input: { questionnaireId: match.params.questionnaireId } },
+    variables: { input: { questionnaireId } },
     fetchPolicy: "network-only",
   });
   const [addNote] = useMutation(CREATE_NOTE, {
@@ -71,9 +72,7 @@ export const HistoryPageContent = ({ match }) => {
     ) {
       cache.writeQuery({
         query: questionnaireHistoryQuery,
-        variables: {
-          input: { questionnaireId: match.params.questionnaireId },
-        },
+        variables: { input: { questionnaireId } },
         data: { history: createHistoryNote },
       });
     },
@@ -120,7 +119,7 @@ export const HistoryPageContent = ({ match }) => {
                 addNote({
                   variables: {
                     input: {
-                      id: match.params.questionnaireId,
+                      id: questionnaireId,
                       bodyText: noteState.value,
                     },
                   },

--- a/eq-author/src/App/metadata/MetadataPage.test.js
+++ b/eq-author/src/App/metadata/MetadataPage.test.js
@@ -5,9 +5,10 @@ import QuestionnaireContext from "components/QuestionnaireContext";
 import { MeContext } from "App/MeContext";
 
 import { UnwrappedMetadataPageContent } from "./MetadataPage";
+import { publishStatusSubscription } from "components/EditorLayout/Header";
 
 describe("Metadata page", () => {
-  let props, questionnaireId, user, signOut;
+  let props, questionnaireId, user, signOut, mocks;
 
   beforeEach(() => {
     questionnaireId = "1";
@@ -38,16 +39,39 @@ describe("Metadata page", () => {
     };
 
     signOut = jest.fn();
+
+    mocks = [
+      {
+        request: {
+          query: publishStatusSubscription,
+          variables: { id: questionnaireId },
+        },
+        result: () => ({
+          data: {
+            publishStatusUpdated: {
+              id: questionnaireId,
+              publishStatus: "Unpublished",
+              __typename: "Questionnaire",
+            },
+          },
+        }),
+      },
+    ];
   });
 
-  const renderWithContext = (component, ...rest) =>
+  const renderWithContext = (component, rest) =>
     render(
       <MeContext.Provider value={{ me: user, signOut }}>
         <QuestionnaireContext.Provider value={props.data.questionnaire}>
           {component}
         </QuestionnaireContext.Provider>
       </MeContext.Provider>,
-      ...rest
+      {
+        route: `/q/${questionnaireId}`,
+        urlParamMatcher: "/q/:questionnaireId",
+        mocks,
+        ...rest,
+      }
     );
 
   it("should render loading state", () => {

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -7,13 +7,15 @@ import { MeContext } from "App/MeContext";
 import { byTestAttr } from "tests/utils/selectors";
 
 import CalculatedSummaryPreview from "./CalculatedSummaryPreview";
+import { publishStatusSubscription } from "components/EditorLayout/Header";
 
 describe("CalculatedSummaryPreview", () => {
-  let page, me;
+  let page, me, mocks, questionnaireId;
 
   actSilenceWarning();
 
   beforeEach(() => {
+    questionnaireId = "111";
     me = {
       id: "123",
       displayName: "Raymond Holt",
@@ -44,6 +46,24 @@ describe("CalculatedSummaryPreview", () => {
       },
       validationErrorInfo: [],
     };
+
+    mocks = [
+      {
+        request: {
+          query: publishStatusSubscription,
+          variables: { id: questionnaireId },
+        },
+        result: () => ({
+          data: {
+            publishStatusUpdated: {
+              id: questionnaireId,
+              publishStatus: "Unpublished",
+              __typename: "Questionnaire",
+            },
+          },
+        }),
+      },
+    ];
   });
 
   it("should render", async () => {
@@ -52,8 +72,9 @@ describe("CalculatedSummaryPreview", () => {
         <CalculatedSummaryPreview page={page} />
       </MeContext.Provider>,
       {
-        route: "/q/1/page/2/preview",
+        route: `/q/${questionnaireId}/page/2/preview`,
         urlParamMatcher: "/q/:questionnaireId/page/:pageId",
+        mocks,
       }
     );
     await flushPromises();

--- a/eq-author/src/App/page/Preview/QuestionPagePreview.test.js
+++ b/eq-author/src/App/page/Preview/QuestionPagePreview.test.js
@@ -8,6 +8,7 @@ import { byTestAttr } from "tests/utils/selectors";
 import { TEXTFIELD } from "constants/answer-types";
 
 import Error from "components/preview/Error";
+import { publishStatusSubscription } from "components/EditorLayout/Header";
 
 import QuestionPagePreview, {
   DetailsContent,
@@ -15,7 +16,7 @@ import QuestionPagePreview, {
 } from "./QuestionPagePreview";
 
 describe("QuestionPagePreview", () => {
-  let page, me;
+  let page, me, mocks, questionnaireId;
 
   actSilenceWarning();
 
@@ -56,6 +57,24 @@ describe("QuestionPagePreview", () => {
       },
       totalValidation: null,
     };
+    questionnaireId = "q123";
+    mocks = [
+      {
+        request: {
+          query: publishStatusSubscription,
+          variables: { id: questionnaireId },
+        },
+        result: () => ({
+          data: {
+            publishStatusUpdated: {
+              id: questionnaireId,
+              publishStatus: "Unpublished",
+              __typename: "Questionnaire",
+            },
+          },
+        }),
+      },
+    ];
   });
 
   it("should render", async () => {
@@ -64,8 +83,9 @@ describe("QuestionPagePreview", () => {
         <QuestionPagePreview page={page} />
       </MeContext.Provider>,
       {
-        route: "/q/1/page/2",
+        route: `/q/${questionnaireId}/page/2`,
         urlParamMatcher: "/q/:questionnaireId/page/:pageId",
+        mocks,
       }
     );
     await flushPromises();


### PR DESCRIPTION
### What is the context of this PR?
Fixed an issue where the publish button was still disabled after the questionnaire went from `Published` to `Unpublished`.

This is done by adding a subscription that sends the updated `publishStatus` if the status goes from `Published` to `Unpublished`. 

This subscription was added as a hook to the header component and was causing a lot of tests to break.

### How to review 
Create a new questionnaire and publish it. Make sure publish status on the front page is now `Published`. Edit the questionnaire and notice that the publish button automatically is enabled again.
