### PR TITLE
1332 edit and delete a note

### DIFF
--- a/eq-author-api/migrations/addTypeToHistoryEvent.js
+++ b/eq-author-api/migrations/addTypeToHistoryEvent.js
@@ -1,0 +1,17 @@
+const { getQuestionnaireMetaById, saveModel } = require("../utils/datastore");
+const { QuestionnaireModel } = require("../db/models/DynamoDB");
+
+module.exports = async function addTypeToHistoryEvent(questionnaire) {
+  const metadata = await getQuestionnaireMetaById(questionnaire.id);
+
+  metadata.history.map(item => {
+    if (!item.type) {
+      item.type = item.hasOwnProperty("bodyText") ? "note" : "system";
+    }
+    return item;
+  });
+
+  await saveModel(new QuestionnaireModel(metadata));
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addTypeToHistoryEvent.test.js
+++ b/eq-author-api/migrations/addTypeToHistoryEvent.test.js
@@ -1,0 +1,102 @@
+const { cloneDeep } = require("lodash");
+const addTypeToHistoryEvent = require("./addTypeToHistoryEvent.js");
+
+const { getQuestionnaireMetaById, saveModel } = require("../utils/datastore");
+const { QuestionnaireModel } = require("../db/models/DynamoDB");
+
+describe("addTypeToHistoryEvent", () => {
+  let questionnaire, historyEvent, metadata, creationEvent;
+  const questionnaireId = "aca64645-98ef-43ae-8b77-d749b4e89a05";
+
+  beforeEach(async () => {
+    questionnaire = { id: questionnaireId };
+    creationEvent = {
+      id: "123",
+      publishStatus: "Questionnaire created",
+      questionnaireTitle: `Test questionnaire (Version 1)`,
+      userId: "user-123",
+      time: 1574682388976,
+    };
+    historyEvent = {
+      id: "fdfsdfds-sdfsdf-dfdsf-dsfdsf",
+      publishStatus: "Published",
+      questionnaireTitle: `This is a test`,
+      userId: "12345",
+      time: new Date(),
+    };
+    metadata = {
+      id: questionnaireId,
+      isPublic: true,
+      createdAt: 1574682388976,
+      updatedAt: 1574682388976,
+      type: "Social",
+      history: [creationEvent],
+    };
+
+    await saveModel(new QuestionnaireModel(metadata));
+  });
+
+  it("should be deterministic", () => {
+    expect(addTypeToHistoryEvent(cloneDeep(questionnaire))).toEqual(
+      addTypeToHistoryEvent(cloneDeep(questionnaire))
+    );
+  });
+
+  it("should add system type when there is no body text", async () => {
+    metadata.history[1] = historyEvent;
+
+    const createdMetadata = await saveModel(new QuestionnaireModel(metadata));
+    expect(createdMetadata.history[1].type).toBeUndefined();
+
+    await addTypeToHistoryEvent(questionnaire);
+
+    const migratedMetadata = await getQuestionnaireMetaById(questionnaireId);
+    expect(migratedMetadata.history[0].type).toBe("system");
+  });
+
+  it("should add note type when there is body text", async () => {
+    metadata.history[1] = { ...historyEvent, bodyText: "Some note.." };
+
+    const createdMetadata = await saveModel(new QuestionnaireModel(metadata));
+    expect(createdMetadata.history[1].type).toBeUndefined();
+
+    await addTypeToHistoryEvent(questionnaire);
+
+    const migratedMetadata = await getQuestionnaireMetaById(questionnaireId);
+    expect(migratedMetadata.history[1].type).toBe("note");
+  });
+
+  it("should not change type when it already exists", async () => {
+    metadata.history[1] = {
+      ...historyEvent,
+      bodyText: "Some note..",
+      type: "note",
+    };
+
+    const createdMetadata = await saveModel(new QuestionnaireModel(metadata));
+    expect(createdMetadata.history[1].type).toBe("note");
+
+    await addTypeToHistoryEvent(questionnaire);
+
+    const migratedMetadata = await getQuestionnaireMetaById(questionnaireId);
+    expect(migratedMetadata.history[0].type).toBe("system");
+    expect(migratedMetadata.history[1].type).toBe("note");
+  });
+
+  it("should work with multiple history items", async () => {
+    metadata.history = [
+      creationEvent,
+      { ...historyEvent, bodyText: "Some note.." },
+      { ...historyEvent, type: "testType" },
+    ];
+
+    await saveModel(new QuestionnaireModel(metadata));
+
+    await addTypeToHistoryEvent(questionnaire);
+
+    const migratedMetadata = await getQuestionnaireMetaById(questionnaireId);
+    expect(migratedMetadata.history[0].type).toBe("system");
+    expect(migratedMetadata.history[1].type).toBe("note");
+    expect(migratedMetadata.history[2].type).toBe("testType");
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -11,6 +11,7 @@ const migrations = [
   require("./addExpressionOperator"),
   require("./addPublishStatusToQuestionnaire"),
   require("./addHistoryToQuestionnaire"),
+  require("./addTypeToHistoryEvent"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -3,7 +3,7 @@ const validateQuestionnaire = require("../../src/validation");
 const { enforceHasWritePermission } = require("./withPermissions");
 
 const { saveQuestionnaire } = require("../../utils/datastore");
-const { addEventToHistory } = require("../../utils/datastore");
+const { createHistoryEvent } = require("../../utils/datastore");
 const { publishStatusEvent } = require("../../utils/questionnaireEvents");
 
 const {
@@ -25,7 +25,7 @@ const createMutation = mutation => async (root, args, ctx) => {
     ctx.questionnaire.publishStatus = UNPUBLISHED;
     ctx.questionnaire.surveyVersion++;
     hasBeenUnpublished = true;
-    await addEventToHistory(ctx.questionnaire.id, publishStatusEvent(ctx));
+    await createHistoryEvent(ctx.questionnaire.id, publishStatusEvent(ctx));
   }
   await saveQuestionnaire(ctx.questionnaire);
   ctx.validationErrorInfo = validateQuestionnaire(ctx.questionnaire);

--- a/eq-author-api/schema/tests/history.test.js
+++ b/eq-author-api/schema/tests/history.test.js
@@ -1,0 +1,232 @@
+const { buildContext } = require("../../tests/utils/contextBuilder");
+const {
+  queryHistory,
+  createHistoryNote,
+  deleteHistoryNote,
+  updateHistoryNote,
+} = require("../../tests/utils/contextBuilder/history");
+
+describe("history", () => {
+  let ctx, user, notes;
+
+  beforeEach(() => {
+    notes = [];
+    user = {
+      id: "uid-123",
+      email: "test@mail.com",
+      name: "Jester Tester",
+      displayName: "Jester Tester",
+    };
+  });
+
+  it("should create a history event on questionnaire creation", async () => {
+    ctx = await buildContext({});
+    const history = await queryHistory(ctx);
+    expect(history).toMatchObject([
+      {
+        bodyText: null,
+        publishStatus: "Questionnaire created",
+        questionnaireTitle: "Questionnaire (Version 1)",
+        user: {
+          email: "eq-team@ons.gov.uk",
+        },
+      },
+    ]);
+  });
+
+  it("should be able to add a note", async () => {
+    ctx = await buildContext({});
+    await createHistoryNote(ctx, {
+      id: ctx.questionnaire.id,
+      bodyText: "I am note",
+    });
+    const history = await queryHistory(ctx);
+    expect(history).toMatchObject([
+      {
+        bodyText: "I am note",
+        publishStatus: "Unpublished",
+        questionnaireTitle: "Questionnaire (Version 1)",
+        user: {
+          email: "eq-team@ons.gov.uk",
+        },
+      },
+      {
+        bodyText: null,
+        publishStatus: "Questionnaire created",
+        questionnaireTitle: "Questionnaire (Version 1)",
+        user: {
+          email: "eq-team@ons.gov.uk",
+        },
+      },
+    ]);
+  });
+
+  describe("deleting notes", () => {
+    it("should be able to delete your own note", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+
+      expect(notes).toHaveLength(2);
+
+      const noteToDelete = notes.find(note => note.bodyText === "I am note");
+
+      notes = await deleteHistoryNote(ctx, {
+        id: noteToDelete.id,
+        questionnaireId: ctx.questionnaire.id,
+      });
+
+      expect(notes).toHaveLength(1);
+      expect(notes).toMatchObject([{ publishStatus: "Questionnaire created" }]);
+      expect(notes).not.toMatchObject([{ bodyText: "I am note" }]);
+    });
+
+    it("should not be able to delete another users note", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+
+      const noteToDelete = notes.find(note => note.bodyText === "I am note");
+      ctx.user.id = "uid-234";
+
+      await expect(
+        deleteHistoryNote(ctx, {
+          id: noteToDelete.id,
+          questionnaireId: ctx.questionnaire.id,
+        })
+      ).rejects.toThrow("User doesnt have access");
+
+      notes = await queryHistory(ctx);
+      expect(notes).toHaveLength(2);
+      expect(notes[0]).toMatchObject({ bodyText: "I am note" });
+    });
+
+    it("should not be able to delete a system note", async () => {
+      ctx = await buildContext({}, user);
+      notes = await queryHistory(ctx);
+
+      const systemNote = notes.find(note => note.type === "system");
+
+      await expect(
+        deleteHistoryNote(ctx, {
+          id: systemNote.id,
+          questionnaireId: ctx.questionnaire.id,
+        })
+      ).rejects.toThrow("Cannot delete system event message");
+      expect(notes).toMatchObject([{ publishStatus: "Questionnaire created" }]);
+    });
+
+    it("should allow admins to delete other users notes", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+
+      expect(notes).toHaveLength(2);
+
+      const noteToDelete = notes.find(note => note.bodyText === "I am note");
+      ctx.user.id = "uid-234";
+      ctx.user.admin = true;
+
+      notes = await deleteHistoryNote(ctx, {
+        id: noteToDelete.id,
+        questionnaireId: ctx.questionnaire.id,
+      });
+
+      expect(notes).toHaveLength(1);
+      expect(notes[0]).not.toMatchObject({ bodyText: "I am note" });
+    });
+  });
+  describe("updating notes", () => {
+    it("should be able to update your own note", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+      const noteToUpdate = notes.find(note => note.bodyText === "I am note");
+
+      notes = await updateHistoryNote(ctx, {
+        id: noteToUpdate.id,
+        questionnaireId: ctx.questionnaire.id,
+        bodyText: "This has been updated",
+      });
+
+      expect(notes[0]).toMatchObject({ bodyText: "This has been updated" });
+      expect(notes[0]).not.toMatchObject([{ bodyText: "I am note" }]);
+    });
+
+    it("should not be able to update another users note", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+
+      const noteToUpdate = notes.find(note => note.bodyText === "I am note");
+
+      ctx.user.id = "uid-234";
+
+      await expect(
+        updateHistoryNote(ctx, {
+          id: noteToUpdate.id,
+          questionnaireId: ctx.questionnaire.id,
+          bodyText: "This has been updated",
+        })
+      ).rejects.toThrow("User doesnt have access");
+
+      notes = await queryHistory(ctx);
+      expect(notes[0]).toMatchObject({ bodyText: "I am note" });
+      expect(notes[0]).not.toMatchObject({ bodyText: "This has been updated" });
+    });
+
+    it("should not be able to update a system note", async () => {
+      ctx = await buildContext({}, user);
+      notes = await queryHistory(ctx);
+
+      const systemNote = notes.find(note => note.type === "system");
+
+      await expect(
+        updateHistoryNote(ctx, {
+          id: systemNote.id,
+          questionnaireId: ctx.questionnaire.id,
+          bodyText: "This has been updated",
+        })
+      ).rejects.toThrow("Cannot update system event message");
+
+      expect(notes).toMatchObject([{ publishStatus: "Questionnaire created" }]);
+    });
+
+    it("should allow admins to update other users notes", async () => {
+      ctx = await buildContext({}, user);
+
+      notes = await createHistoryNote(ctx, {
+        id: ctx.questionnaire.id,
+        bodyText: "I am note",
+      });
+
+      const noteToDelete = notes.find(note => note.bodyText === "I am note");
+      ctx.user.id = "uid-234";
+      ctx.user.admin = true;
+
+      notes = await updateHistoryNote(ctx, {
+        id: noteToDelete.id,
+        questionnaireId: ctx.questionnaire.id,
+        bodyText: "This has been updated",
+      });
+
+      expect(notes[0]).toMatchObject({ bodyText: "This has been updated" });
+      expect(notes[0]).not.toMatchObject({ bodyText: "I am note" });
+    });
+  });
+});

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -29,8 +29,6 @@ const {
   listQuestionnaires,
   publishQuestionnaire,
   reviewQuestionnaire,
-  queryHistory,
-  createHistoryNote,
 } = require("../../tests/utils/contextBuilder/questionnaire");
 
 const {
@@ -443,49 +441,6 @@ describe("questionnaire", () => {
       const deletedQuestionnaire = await queryQuestionnaire(ctx);
       expect(deletedQuestionnaire).toBeNull();
       questionnaire = null;
-    });
-  });
-
-  describe("history", () => {
-    it("should create a history event on questionnaire creation", async () => {
-      ctx = await buildContext({});
-      const history = await queryHistory(ctx);
-      expect(history).toMatchObject([
-        {
-          bodyText: null,
-          publishStatus: "Questionnaire created",
-          questionnaireTitle: "Questionnaire (Version 1)",
-          user: {
-            email: "eq-team@ons.gov.uk",
-          },
-        },
-      ]);
-    });
-    it("should be able to add a note", async () => {
-      ctx = await buildContext({});
-      await createHistoryNote(ctx, {
-        id: ctx.questionnaire.id,
-        bodyText: "I am note",
-      });
-      const history = await queryHistory(ctx);
-      expect(history).toMatchObject([
-        {
-          bodyText: "I am note",
-          publishStatus: "Unpublished",
-          questionnaireTitle: "Questionnaire (Version 1)",
-          user: {
-            email: "eq-team@ons.gov.uk",
-          },
-        },
-        {
-          bodyText: null,
-          publishStatus: "Questionnaire created",
-          questionnaireTitle: "Questionnaire (Version 1)",
-          user: {
-            email: "eq-team@ons.gov.uk",
-          },
-        },
-      ]);
     });
   });
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -64,12 +64,17 @@ type Questionnaire {
   publishDetails: PublishDetails
   totalErrorCount: Int!
 }
+enum HistoryEventTypes {
+  system
+  note
+}
 
 type History {
   id: ID!
   publishStatus: String!
   questionnaireTitle: String!
   bodyText: String
+  type: HistoryEventTypes!
   user: User!
   time: DateTime!
 }
@@ -614,6 +619,8 @@ type Mutation {
   deleteQuestionnaire(input: DeleteQuestionnaireInput!): DeletedQuestionnaire
   duplicateQuestionnaire(input: DuplicateQuestionnaireInput!): Questionnaire
   createHistoryNote(input: createHistoryNoteInput!): [History!]!
+  updateHistoryNote(input: updateHistoryNoteInput!): [History!]!
+  deleteHistoryNote(input: deleteHistoryNoteInput!): [History!]!
   createSection(input: CreateSectionInput!): Section
   updateSection(input: UpdateSectionInput!): Section
   deleteSection(input: DeleteSectionInput!): Questionnaire
@@ -1111,5 +1118,16 @@ input ReviewQuestionnaireInput {
   questionnaireId: ID!
   reviewAction: ReviewAction!
   reviewComment: String
+}
+
+input updateHistoryNoteInput {
+  questionnaireId: ID!
+  bodyText: String!
+  id: ID!
+}
+
+input deleteHistoryNoteInput {
+  questionnaireId: ID!
+  id: ID!
 }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/history/createHistoryNote.js
+++ b/eq-author-api/tests/utils/contextBuilder/history/createHistoryNote.js
@@ -14,6 +14,7 @@ mutation CreateHistoryNote($input: createHistoryNoteInput!) {
         displayName
       }
       time
+      type
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/history/deleteHistoryNote.js
+++ b/eq-author-api/tests/utils/contextBuilder/history/deleteHistoryNote.js
@@ -1,0 +1,30 @@
+const executeQuery = require("../../executeQuery");
+
+const deleteHistoryNoteMutation = `
+mutation DeleteHistoryNote($input: deleteHistoryNoteInput!) {
+    deleteHistoryNote(input: $input) {
+      id
+      publishStatus
+      questionnaireTitle
+      bodyText
+      user {
+        id
+        email
+        name
+        displayName
+      }
+      time
+      type
+    }
+  }
+`;
+
+const deleteHistoryNote = async (ctx, input) => {
+  const result = await executeQuery(deleteHistoryNoteMutation, { input }, ctx);
+  return result.data.deleteHistoryNote;
+};
+
+module.exports = {
+  deleteHistoryNoteMutation,
+  deleteHistoryNote,
+};

--- a/eq-author-api/tests/utils/contextBuilder/history/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/history/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require("./queryHistory"),
+  ...require("./createHistoryNote"),
+  ...require("./updateHistoryNote"),
+  ...require("./deleteHistoryNote"),
+};

--- a/eq-author-api/tests/utils/contextBuilder/history/queryHistory.js
+++ b/eq-author-api/tests/utils/contextBuilder/history/queryHistory.js
@@ -14,6 +14,7 @@ query History($input: QueryInput!) {
         displayName
       }
       time
+      type
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/history/updateHistoryNote.js
+++ b/eq-author-api/tests/utils/contextBuilder/history/updateHistoryNote.js
@@ -1,0 +1,30 @@
+const executeQuery = require("../../executeQuery");
+
+const updateHistoryNoteMutation = `
+mutation UpdateHistoryNote($input: updateHistoryNoteInput!) {
+    updateHistoryNote(input: $input) {
+      id
+      publishStatus
+      questionnaireTitle
+      bodyText
+      user {
+        id
+        email
+        name
+        displayName
+      }
+      time
+      type
+    }
+  }
+`;
+
+const updateHistoryNote = async (ctx, input) => {
+  const result = await executeQuery(updateHistoryNoteMutation, { input }, ctx);
+  return result.data.updateHistoryNote;
+};
+
+module.exports = {
+  updateHistoryNoteMutation,
+  updateHistoryNote,
+};

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
@@ -7,6 +7,4 @@ module.exports = {
   ...require("./listQuestionnaires"),
   ...require("./publishQuestionnaire"),
   ...require("./reviewQuestionnaire"),
-  ...require("./queryHistory"),
-  ...require("./createHistoryNote"),
 };

--- a/eq-author-api/utils/datastore.js
+++ b/eq-author-api/utils/datastore.js
@@ -124,7 +124,7 @@ const createQuestionnaire = async (questionnaire, ctx) => {
   );
 };
 
-const addEventToHistory = (questionnaireId, historyEvent) =>
+const createHistoryEvent = (questionnaireId, historyEvent) =>
   new Promise((resolve, reject) => {
     QuestionnaireModel.queryOne({ id: { eq: questionnaireId } }).exec(
       async (err, questionnaire) => {
@@ -139,14 +139,14 @@ const addEventToHistory = (questionnaireId, historyEvent) =>
     );
   });
 
-const getHistoryById = id =>
+const getQuestionnaireMetaById = id =>
   new Promise((resolve, reject) => {
     QuestionnaireModel.queryOne({ id: { eq: id } }).exec(
       async (err, questionnaire) => {
         if (err) {
           reject(err);
         }
-        resolve(questionnaire.history);
+        resolve(questionnaire);
       }
     );
   });
@@ -294,8 +294,8 @@ module.exports = {
   updateUser,
   saveModel,
   listUsers,
-  addEventToHistory,
-  getHistoryById,
+  createHistoryEvent,
+  getQuestionnaireMetaById,
   getCommentsForQuestionnaire,
   saveComments,
   createComments,

--- a/eq-author-api/utils/questionnaireEvents.js
+++ b/eq-author-api/utils/questionnaireEvents.js
@@ -5,6 +5,7 @@ const questionnaireCreationEvent = (questionnaire, ctx) => ({
   publishStatus: "Questionnaire created",
   questionnaireTitle: `${questionnaire.title} (Version ${questionnaire.surveyVersion})`,
   userId: ctx.user.id,
+  type: "system",
   time: questionnaire.createdAt,
 });
 
@@ -13,6 +14,7 @@ const noteCreationEvent = (ctx, bodyText) => ({
   publishStatus: ctx.questionnaire.publishStatus,
   questionnaireTitle: `${ctx.questionnaire.title} (Version ${ctx.questionnaire.surveyVersion})`,
   bodyText,
+  type: "note",
   userId: ctx.user.id,
   time: new Date(),
 });

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavigationHeader.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavigationHeader.js
@@ -104,6 +104,7 @@ export class UnwrappedNavigationHeader extends React.Component {
     const { match } = this.props;
     const metadataUrl = buildMetadataPath(match.params);
     const historyUrl = buildHistoryPath(match.params);
+
     return (
       <>
         <QuestionnaireLinks>

--- a/eq-author/src/App/history/HistoryItem.js
+++ b/eq-author/src/App/history/HistoryItem.js
@@ -1,18 +1,44 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import moment from "moment";
-import { colors } from "constants/theme";
 import PropTypes from "prop-types";
+import CustomPropTypes from "custom-prop-types";
 
-const StyledItem = styled.span`
+import Button from "components/buttons/Button";
+import ButtonGroup from "components/buttons/ButtonGroup";
+import RichTextEditor from "components/RichTextEditor";
+import IconButton from "components/buttons/IconButton";
+
+import { colors } from "constants/theme";
+
+import IconEdit from "./icon-edit.svg?inline";
+import IconDelete from "./icon-close.svg?inline";
+
+const EditableItem = styled.div`
+  width: 100%;
+  margin-bottom: 0.5em;
+`;
+
+const StyledGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-basis: 100%;
+`;
+
+const StyledItem = styled.div`
   display: flex;
   flex-wrap: wrap;
-  padding: 0 1em 0 0;
+  padding: 0 2em 0 0;
   border: 1px solid ${colors.lightGrey};
   background-color: ${colors.lighterGrey};
   width: 100%;
-  margin: 0.5em 1em 0 0;
+  margin: 0;
   justify-content: space-between;
+`;
+
+const EditHeader = styled.div`
+  background-color: ${props => (props.active ? colors.blue : colors.darkGrey)};
+  color: ${colors.white};
 `;
 
 const QuestionnaireTitle = styled.div`
@@ -29,6 +55,11 @@ const BreakLine = styled.div`
   flex-basis: 100%;
   height: 0;
 `;
+
+const ActionButtons = styled(ButtonGroup)`
+  flex: 0 0 auto;
+`;
+
 const EventText = styled.div`
   padding: 0 1em 0.5em;
   p {
@@ -45,37 +76,132 @@ const translations = {
   "Questionnaire created": "Questionnaire created",
 };
 
-const formatDate = unformattedDate =>
-  moment(unformattedDate).format("DD/MM/YYYY [at] HH:mm");
+const HistoryButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const SaveButton = styled(Button)`
+  font-size: 0.75em;
+  margin-right: -1em;
+  margin-bottom: 1em;
+`;
+
+const formatDate = date => moment(date).format("DD/MM/YYYY [at] HH:mm");
+
+const RTEWrapper = styled.div`
+  margin: 0 2em 0 1em;
+  padding-bottom: 1em;
+  width: 100%;
+`;
 
 const HistoryItem = ({
+  handleDeleteNote,
+  handleUpdateNote,
   questionnaireTitle,
+  itemId,
   publishStatus,
   userName,
+  currentUser,
+  userId,
   bodyText,
+  type,
   createdAt,
 }) => {
+  const [isEditActive, setIsEditActive] = useState(false);
+  const [noteState, setNoteState] = useState(bodyText);
+
+  const isEditable =
+    (currentUser.id === userId || currentUser.admin) && type === "note";
+  const renderBodyText = () => {
+    if (!isEditActive && bodyText) {
+      return <EventText dangerouslySetInnerHTML={{ __html: bodyText }} />;
+    }
+    if (isEditActive) {
+      return (
+        <StyledGrid>
+          <RTEWrapper>
+            <RichTextEditor
+              id={`update-note-textbox`}
+              name="note"
+              onUpdate={e => setNoteState(e.value)}
+              label=""
+              value={noteState}
+              controls={{
+                heading: true,
+                emphasis: true,
+                list: true,
+                bold: true,
+              }}
+              multiline
+              autoFocus
+            />
+          </RTEWrapper>
+          <ActionButtons horizontal align="right">
+            <SaveButton
+              data-test="save-note-btn"
+              onClick={() =>
+                handleUpdateNote(itemId, noteState).then(() =>
+                  setIsEditActive(false)
+                )
+              }
+            >
+              Save
+            </SaveButton>
+          </ActionButtons>
+        </StyledGrid>
+      );
+    }
+  };
   return (
-    <StyledItem>
-      <QuestionnaireTitle>
-        {questionnaireTitle} -{" "}
-        <strong>{translations[publishStatus] || publishStatus}</strong>
-      </QuestionnaireTitle>
-      <QuestionnaireUserName>
-        {userName} - {formatDate(createdAt)}
-      </QuestionnaireUserName>
-      <BreakLine />
-      {bodyText && <EventText dangerouslySetInnerHTML={{ __html: bodyText }} />}
-    </StyledItem>
+    <EditableItem>
+      {isEditable && (
+        <EditHeader active={isEditActive}>
+          <HistoryButtonGroup horizontal align="right">
+            <IconButton
+              icon={IconEdit}
+              data-test="edit-note-btn"
+              aria-label="Edit"
+              onClick={() => setIsEditActive(true)}
+            />
+
+            <IconButton
+              icon={IconDelete}
+              data-test="delete-note-btn"
+              aria-label="Delete"
+              onClick={() => handleDeleteNote(itemId)}
+            />
+          </HistoryButtonGroup>
+        </EditHeader>
+      )}
+      <StyledItem>
+        <QuestionnaireTitle>
+          {questionnaireTitle} -{" "}
+          <strong>{translations[publishStatus] || publishStatus}</strong>
+        </QuestionnaireTitle>
+        <QuestionnaireUserName>
+          {userName} - {formatDate(createdAt)}
+        </QuestionnaireUserName>
+
+        <BreakLine />
+        {renderBodyText()}
+      </StyledItem>
+    </EditableItem>
   );
 };
 
 HistoryItem.propTypes = {
+  handleDeleteNote: PropTypes.func.isRequired,
+  handleUpdateNote: PropTypes.func.isRequired,
   questionnaireTitle: PropTypes.string.isRequired,
   userName: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
   publishStatus: PropTypes.string.isRequired,
   bodyText: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  itemId: PropTypes.string.isRequired,
+  currentUser: CustomPropTypes.user.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 export default HistoryItem;

--- a/eq-author/src/App/history/HistoryItem.test.js
+++ b/eq-author/src/App/history/HistoryItem.test.js
@@ -2,12 +2,31 @@ import React from "react";
 import { render } from "tests/utils/rtl";
 import HistoryItem from "./HistoryItem";
 
+//eslint-disable-next-line react/prop-types
+jest.mock("components/RichTextEditor", () => ({ onUpdate }) => {
+  const handleInputChange = event =>
+    onUpdate({
+      value: event.target.value,
+    });
+  return <input data-test="textbox" onChange={handleInputChange} />;
+});
+
 describe("History page", () => {
   let props = {
+    itemId: "item-1",
+    questionnaireId: "q-1",
     questionnaireTitle: "my wonderful thing",
     userName: "Me",
+    userId: "user-1",
+    currentUser: {
+      id: "user-2",
+      email: "wubbalubba@dubdub.com",
+    },
     createdAt: "2019-09-26T18:22:58.461",
     publishStatus: "Questionnaire created",
+    type: "system",
+    handleDeleteNote: jest.fn(),
+    handleUpdateNote: jest.fn(),
   };
 
   it("should format date correctly", () => {

--- a/eq-author/src/App/history/HistoryPage.test.js
+++ b/eq-author/src/App/history/HistoryPage.test.js
@@ -8,7 +8,9 @@ import { MeContext } from "App/MeContext";
 import HistoryPageContent from "./HistoryPage";
 
 import questionnaireHistoryQuery from "./questionnaireHistory.graphql";
-import createHistoryNoteMutation from "./createHistoryNoteMutation.graphql";
+import createNoteMutation from "./createHistoryNoteMutation.graphql";
+import updateNoteMutation from "./updateHistoryNoteMutation.graphql";
+import deleteNoteMutation from "./deleteHistoryNoteMutation.graphql";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
 
 import { UNPUBLISHED } from "constants/publishStatus";
@@ -19,12 +21,11 @@ jest.mock("components/RichTextEditor", () => ({ onUpdate }) => {
     onUpdate({
       value: event.target.value,
     });
-  return <input data-test="textbox" onChange={handleInputChange} />;
+  return <input data-test="rtl-textbox" onChange={handleInputChange} />;
 });
 
 describe("History page", () => {
   let props, questionnaireId, user, queryWasCalled, mutationWasCalled, mocks;
-
   actSilenceWarning();
 
   beforeEach(() => {
@@ -69,8 +70,9 @@ describe("History page", () => {
                   publishStatus: "Questionnaire created",
                   questionnaireTitle: "Test 2",
                   bodyText: null,
+                  type: "system",
                   user: {
-                    id: "7c0abf65-9c8f-491c-bcd5-76f53f3983a9",
+                    id: "123",
                     email: "sam@hello.com",
                     name: "sam",
                     displayName: "sam",
@@ -80,12 +82,13 @@ describe("History page", () => {
                   __typename: "History",
                 },
                 {
-                  id: "aa94b4ef-e717-40b6-aba5-7c99557d283c",
+                  id: "item-id-123",
                   publishStatus: UNPUBLISHED,
                   questionnaireTitle: "Test 2",
                   bodyText: "Hello Moto",
+                  type: "note",
                   user: {
-                    id: "7c0abf65-9c8f-491c-bcd5-76f53f3983a9",
+                    id: "123",
                     email: "sam@hello.com",
                     name: "sam",
                     displayName: "sam",
@@ -101,7 +104,7 @@ describe("History page", () => {
       },
       {
         request: {
-          query: createHistoryNoteMutation,
+          query: createNoteMutation,
           variables: {
             input: {
               id: props.match.params.questionnaireId,
@@ -119,8 +122,9 @@ describe("History page", () => {
                   publishStatus: "Questionnaire created",
                   questionnaireTitle: "Test 2",
                   bodyText: null,
+                  type: "system",
                   user: {
-                    id: "7c0abf65-9c8f-491c-bcd5-76f53f3983a9",
+                    id: "123",
                     email: "sam@hello.com",
                     name: "sam",
                     displayName: "sam",
@@ -134,8 +138,9 @@ describe("History page", () => {
                   publishStatus: UNPUBLISHED,
                   questionnaireTitle: "Test 2",
                   bodyText: "Hello Moto",
+                  type: "note",
                   user: {
-                    id: "7c0abf65-9c8f-491c-bcd5-76f53f3983a9",
+                    id: "123",
                     email: "sam@hello.com",
                     name: "sam",
                     displayName: "sam",
@@ -149,8 +154,9 @@ describe("History page", () => {
                   publishStatus: UNPUBLISHED,
                   questionnaireTitle: "Test 2",
                   bodyText: "New note",
+                  type: "note",
                   user: {
-                    id: "7c0abf65-9c8f-491c-bcd5-76f53f3983a9",
+                    id: "123",
                     email: "sam@hello.com",
                     name: "sam",
                     displayName: "sam",
@@ -167,9 +173,7 @@ describe("History page", () => {
       {
         request: {
           query: publishStatusSubscription,
-          variables: {
-            id: questionnaireId,
-          },
+          variables: { id: questionnaireId },
         },
         result: () => ({
           data: {
@@ -192,50 +196,27 @@ describe("History page", () => {
         </QuestionnaireContext.Provider>
       </MeContext.Provider>,
       {
-        route: `/q/${questionnaireId}/page/2`,
+        route: `/q/${questionnaireId}`,
         urlParamMatcher: "/q/:questionnaireId",
         mocks,
       }
     );
 
   it("renders History page with correct events", async () => {
-    const { getByText } = renderWithContext(<HistoryPageContent {...props} />);
+    const { getByText } = renderWithContext(<HistoryPageContent {...props} />, {
+      mocks,
+    });
     await flushPromises();
     expect(getByText("History")).toBeTruthy();
     expect(getByText("Questionnaire created")).toBeTruthy();
     expect(getByText("Hello Moto")).toBeTruthy();
   });
 
-  it("can create a note", async () => {
-    const { getByText, getByTestId } = renderWithContext(
-      <HistoryPageContent {...props} />
-    );
-    await flushPromises();
-    fireEvent.change(getByTestId("textbox"), {
-      target: { value: "New note" },
-    });
-    fireEvent.click(getByTestId("add-note-btn"));
-
-    await flushPromises();
-
-    expect(getByText("Questionnaire created")).toBeTruthy();
-    expect(getByText("Hello Moto")).toBeTruthy();
-    expect(getByText("New note")).toBeTruthy();
-  });
-
-  it("wont create an empty note", async () => {
-    const { getByTestId } = renderWithContext(
-      <HistoryPageContent {...props} />
-    );
-    await flushPromises();
-    fireEvent.click(getByTestId("add-note-btn"));
-    await flushPromises();
-    expect(mutationWasCalled).toBeFalsy();
-  });
-
   it("should request questionnaire history", async () => {
     queryWasCalled = false;
-    renderWithContext(<HistoryPageContent {...props} />);
+    renderWithContext(<HistoryPageContent {...props} />, {
+      mocks,
+    });
     await flushPromises();
     expect(queryWasCalled).toBeTruthy();
   });
@@ -259,5 +240,288 @@ describe("History page", () => {
     const { getByText } = renderWithContext(<HistoryPageContent {...props} />);
     await flushPromises();
     expect(getByText("Oops! Something went wrong")).toBeTruthy();
+  });
+
+  describe("user notes", () => {
+    beforeEach(() => {
+      user.admin = false;
+    });
+
+    describe("creating notes", () => {
+      it("can create a note", async () => {
+        const { getByText, getByTestId } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          {
+            mocks,
+          }
+        );
+        await flushPromises();
+        fireEvent.change(getByTestId("rtl-textbox"), {
+          target: { value: "New note" },
+        });
+        fireEvent.click(getByTestId("add-note-btn"));
+
+        await flushPromises();
+        expect(getByText("Questionnaire created")).toBeTruthy();
+        expect(getByText("Hello Moto")).toBeTruthy();
+        expect(getByText("New note")).toBeTruthy();
+      });
+
+      it("wont create an empty note", async () => {
+        const { getByTestId } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          {
+            mocks,
+          }
+        );
+
+        await flushPromises();
+        fireEvent.click(getByTestId("add-note-btn"));
+
+        await flushPromises();
+        expect(mutationWasCalled).toBeFalsy();
+      });
+    });
+
+    describe("update notes", () => {
+      beforeEach(() => {
+        mocks = [
+          ...mocks,
+          {
+            request: {
+              query: updateNoteMutation,
+              variables: {
+                input: {
+                  id: "item-id-123",
+                  questionnaireId,
+                  bodyText: "this is an edited message",
+                },
+              },
+            },
+            result: () => {
+              mutationWasCalled = true;
+              return {
+                data: {
+                  updateHistoryNote: [
+                    {
+                      id: "item-id-123",
+                      publishStatus: "Questionnaire created",
+                      questionnaireTitle: "my wonderful thing",
+                      bodyText: "this is an edited message",
+                      type: "note",
+                      user: {
+                        id: "123",
+                        name: "Rick Sanchez",
+                        displayName: "Rick Sanchez",
+                        email: "wubbalubba@dubdub.com",
+                        picture: "http://img.com/avatar.jpg",
+                        admin: true,
+                        __typename: "User",
+                      },
+                      time: "2019-10-11T09:48:28.584Z",
+                      __typename: "History",
+                    },
+                  ],
+                },
+              };
+            },
+          },
+        ];
+      });
+      it("should be able to update your own note", async () => {
+        const { getByTestId, getAllByTestId, getByText } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          { mocks }
+        );
+
+        await flushPromises();
+        expect(getByText("Hello Moto")).toBeTruthy();
+
+        const editButton = getByTestId("edit-note-btn");
+        fireEvent.click(editButton);
+
+        const textEditor = getAllByTestId("rtl-textbox")[1];
+        fireEvent.change(textEditor, {
+          target: { value: "this is an edited message" },
+        });
+
+        const saveButton = getByTestId("save-note-btn");
+        fireEvent.click(saveButton);
+
+        await flushPromises();
+        expect(mutationWasCalled).toBeTruthy();
+        expect(getByText("this is an edited message")).toBeTruthy();
+      });
+
+      it("should allow admins to update any notes", async () => {
+        user.id = "uauthorized-uid-123";
+        user.admin = true;
+        const { getByTestId, getAllByTestId, getByText } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          {
+            mocks,
+          }
+        );
+        await flushPromises();
+
+        const editButton = getByTestId("edit-note-btn");
+        fireEvent.click(editButton);
+
+        const textEditor = getAllByTestId("rtl-textbox")[1];
+
+        fireEvent.change(textEditor, {
+          target: { value: "this is an edited message" },
+        });
+        const saveButton = getByTestId("save-note-btn");
+        fireEvent.click(saveButton);
+
+        await flushPromises();
+        expect(mutationWasCalled).toBeTruthy();
+        expect(getByText("this is an edited message")).toBeTruthy();
+      });
+    });
+
+    describe("deleting notes", () => {
+      beforeEach(() => {
+        mocks = [
+          ...mocks,
+          {
+            request: {
+              query: deleteNoteMutation,
+              variables: {
+                input: {
+                  id: "item-id-123",
+                  questionnaireId,
+                },
+              },
+            },
+            result: () => {
+              mutationWasCalled = true;
+              return {
+                data: {
+                  deleteHistoryNote: [
+                    {
+                      id: "161deb98-fdbe-4906-aea5-39d3de2d78a2",
+                      publishStatus: "Questionnaire created",
+                      questionnaireTitle: "Test 2",
+                      bodyText: null,
+                      type: "system",
+                      user: {
+                        id: "123",
+                        email: "sam@hello.com",
+                        name: "sam",
+                        displayName: "sam",
+                        __typename: "User",
+                      },
+                      time: "2019-10-11T09:48:28.584Z",
+                      __typename: "History",
+                    },
+                  ],
+                },
+              };
+            },
+          },
+        ];
+      });
+
+      it("should be able to delete your own note", async () => {
+        const { getByTestId, queryByText } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          { mocks }
+        );
+
+        await flushPromises();
+        expect(queryByText("Hello Moto")).toBeTruthy();
+
+        const deleteButton = getByTestId("delete-note-btn");
+        fireEvent.click(deleteButton);
+
+        await flushPromises();
+        expect(mutationWasCalled).toBeTruthy();
+        expect(queryByText("Hello Moto")).toBeFalsy();
+      });
+
+      it("should allow admins to delete any notes", async () => {
+        user.id = "uauthorized-uid-123";
+        user.admin = true;
+        const { getByTestId, queryByText, getByText } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          {
+            mocks,
+          }
+        );
+
+        await flushPromises();
+        expect(getByText("Hello Moto")).toBeTruthy();
+
+        const deleteButton = getByTestId("delete-note-btn");
+        fireEvent.click(deleteButton);
+
+        await flushPromises();
+        expect(mutationWasCalled).toBeTruthy();
+        expect(queryByText("Hello Moto")).toBeFalsy();
+      });
+    });
+
+    describe("update and delete notes", () => {
+      it("should not be able to update or delete another users note", async () => {
+        user.id = "uauthorized-uid-123";
+        const { queryByTestId } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          { mocks }
+        );
+
+        await flushPromises();
+        expect(queryByTestId("edit-note-btn")).toBeFalsy();
+        expect(queryByTestId("delete-note-btn")).toBeFalsy();
+      });
+
+      it("should not be able to update or delete system events", async () => {
+        user.admin = true;
+        mocks[0] = {
+          request: {
+            query: questionnaireHistoryQuery,
+            variables: {
+              input: { questionnaireId: props.match.params.questionnaireId },
+            },
+          },
+          result: () => {
+            queryWasCalled = true;
+            return {
+              data: {
+                history: [
+                  {
+                    id: "161deb98-fdbe-4906-aea5-39d3de2d78a2",
+                    publishStatus: "Questionnaire created",
+                    questionnaireTitle: "Test 2",
+                    bodyText: null,
+                    type: "system",
+                    user: {
+                      id: "123",
+                      email: "sam@hello.com",
+                      name: "sam",
+                      displayName: "sam",
+                      __typename: "User",
+                    },
+                    time: "2019-10-11T09:48:28.584Z",
+                    __typename: "History",
+                  },
+                ],
+              },
+            };
+          },
+        };
+        const { queryByTestId } = renderWithContext(
+          <HistoryPageContent {...props} />,
+          {
+            mocks,
+          }
+        );
+
+        await flushPromises();
+        expect(queryByTestId("edit-note-btn")).toBeFalsy();
+        expect(queryByTestId("delete-note-btn")).toBeFalsy();
+      });
+    });
   });
 });

--- a/eq-author/src/App/history/createHistoryNoteMutation.graphql
+++ b/eq-author/src/App/history/createHistoryNoteMutation.graphql
@@ -1,15 +1,7 @@
+#import "./historyNoteFragment.graphql"
+
 mutation CreateHistoryNote($input: createHistoryNoteInput!) {
   createHistoryNote(input: $input) {
-    id
-    publishStatus
-    questionnaireTitle
-    bodyText
-    user {
-      id
-      displayName
-      email
-      name
-    }
-    time
+    ...HistoryNoteInfo
   }
 }

--- a/eq-author/src/App/history/deleteHistoryNoteMutation.graphql
+++ b/eq-author/src/App/history/deleteHistoryNoteMutation.graphql
@@ -1,0 +1,7 @@
+#import "./historyNoteFragment.graphql"
+
+mutation DeleteHistoryNote($input: deleteHistoryNoteInput!) {
+  deleteHistoryNote(input: $input) {
+    ...HistoryNoteInfo
+  }
+}

--- a/eq-author/src/App/history/historyNoteFragment.graphql
+++ b/eq-author/src/App/history/historyNoteFragment.graphql
@@ -1,0 +1,14 @@
+fragment HistoryNoteInfo on History {
+  id
+  publishStatus
+  questionnaireTitle
+  bodyText
+  type
+  user {
+    id
+    displayName
+    email
+    name
+  }
+  time
+}

--- a/eq-author/src/App/history/icon-close.svg
+++ b/eq-author/src/App/history/icon-close.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<g id="icon-close" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+		<polygon id="close---material" fill="#4A4A4A" points="21.82 11.36 17.18 16 21.82 20.64 20.64 21.82 16 17.18 11.36 21.82 10.18 20.64 14.82 16 10.18 11.36 11.36 10.18 16 14.82 20.64 10.18">
+		</polygon>
+	</g>
+</svg>

--- a/eq-author/src/App/history/icon-edit.svg
+++ b/eq-author/src/App/history/icon-edit.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>Edit History</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="edit-24px" transform="translate(10.000000, 10.000000)" fill="#FFFFFF" fill-rule="nonzero">
+            <polygon id="Path" points="0.560434255 9.07318424 0.560434255 11.3133816 2.80063162 11.3133816 9.40772038 4.70629284 7.16752301 2.46609548"></polygon>
+            <path d="M11.1401397,2.97387355 C11.3731202,2.74089302 11.3731202,2.36453986 11.1401397,2.13155934 L9.74225652,0.733676184 C9.50927599,0.500695658 9.13292283,0.500695658 8.89994231,0.733676184 L7.80672599,1.8268925 L10.0469234,4.06708986 L11.1401397,2.97387355 Z" id="Path"></path>
+        </g>
+    </g>
+</svg>

--- a/eq-author/src/App/history/questionnaireHistory.graphql
+++ b/eq-author/src/App/history/questionnaireHistory.graphql
@@ -1,15 +1,7 @@
+#import "./historyNoteFragment.graphql"
+
 query History($input: QueryInput!) {
   history(input: $input) {
-    id
-    publishStatus
-    questionnaireTitle
-    bodyText
-    user {
-      id
-      email
-      name
-      displayName
-    }
-    time
+    ...HistoryNoteInfo
   }
 }

--- a/eq-author/src/App/history/updateHistoryNoteMutation.graphql
+++ b/eq-author/src/App/history/updateHistoryNoteMutation.graphql
@@ -1,0 +1,7 @@
+#import "./historyNoteFragment.graphql"
+
+mutation UpdateHistoryNote($input: updateHistoryNoteInput!) {
+  updateHistoryNote(input: $input) {
+    ...HistoryNoteInfo
+  }
+}

--- a/eq-author/src/components/buttons/IconButton/index.js
+++ b/eq-author/src/components/buttons/IconButton/index.js
@@ -1,0 +1,49 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import { colors } from "constants/theme";
+
+const Button = styled.button`
+  color: ${colors.white};
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: color 200ms ease-in, opacity 300ms ease-in;
+  width: 3em;
+  height: 3em;
+  padding: 0;
+  display: block;
+
+  :hover {
+    color: ${colors.lightGrey};
+  }
+
+  :focus {
+    outline: 3px solid ${colors.orange};
+  }
+
+  svg {
+    pointer-events: none;
+    flex: 0 0 2em;
+    path {
+      fill: currentColor;
+    }
+    :hover {
+      color: ${colors.black};
+    }
+  }
+`;
+
+const IconButton = ({ icon: Icon, onClick, ...otherProps }) => (
+  <Button onClick={onClick} {...otherProps}>
+    <Icon />
+  </Button>
+);
+
+IconButton.propTypes = {
+  icon: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default IconButton;

--- a/eq-author/src/components/buttons/IconButton/index.test.js
+++ b/eq-author/src/components/buttons/IconButton/index.test.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, fireEvent } from "tests/utils/rtl";
+
+import IconButton from ".";
+import Icon from "App/history/icon-close.svg?inline";
+
+describe("IconButton", () => {
+  it("should render", () => {
+    render(<IconButton icon={Icon} onClick={jest.fn()} />);
+  });
+
+  it("should execute onClick function when clicked", () => {
+    const testFunction = jest.fn();
+    const { getByTestId } = render(
+      <IconButton icon={Icon} onClick={testFunction} data-test="test" />
+    );
+    const button = getByTestId("test");
+    fireEvent.click(button);
+    expect(testFunction).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
Allows a user to delete or edit their own history comments. Also allows admin accounts to edit and delete other users comments.

### How to review 
Go to History page and make a comment with the existing Rich Text Editor. There will be a new message that if permissions allow will show a bar with the edit and delete icons. Clicking the edit icon will open up a RTE and then on saving via the save button the message will be changed. The delete icon "X" will delete this message. You will need to login both as an admin and non admin to test
