### PR TITLE
1296 reject content

### DIFF
--- a/eq-author-api/constants/publishStatus.js
+++ b/eq-author-api/constants/publishStatus.js
@@ -1,9 +1,11 @@
 const UNPUBLISHED = "Unpublished";
 const PUBLISHED = "Published";
+const UPDATES_REQUIRED = "UpdatesRequired";
 const AWAITING_APPROVAL = "AwaitingApproval";
 
 module.exports = {
   PUBLISHED,
   UNPUBLISHED,
   AWAITING_APPROVAL,
+  UPDATES_REQUIRED,
 };

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -4,9 +4,7 @@ const { enforceHasWritePermission } = require("./withPermissions");
 
 const { saveQuestionnaire } = require("../../utils/datastore");
 const { addEventToHistory } = require("../../utils/datastore");
-const {
-  changedPublishStatusEvent,
-} = require("../../utils/questionnaireEvents");
+const { publishStatusEvent } = require("../../utils/questionnaireEvents");
 
 const {
   AWAITING_APPROVAL,
@@ -27,10 +25,7 @@ const createMutation = mutation => async (root, args, ctx) => {
     ctx.questionnaire.publishStatus = UNPUBLISHED;
     ctx.questionnaire.surveyVersion++;
     hasBeenUnpublished = true;
-    await addEventToHistory(
-      ctx.questionnaire.id,
-      changedPublishStatusEvent(ctx, ctx.questionnaire.surveyVersion)
-    );
+    await addEventToHistory(ctx.questionnaire.id, publishStatusEvent(ctx));
   }
   await saveQuestionnaire(ctx.questionnaire);
   ctx.validationErrorInfo = validateQuestionnaire(ctx.questionnaire);

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -17,6 +17,7 @@ const {
   PUBLISHED,
   UNPUBLISHED,
   AWAITING_APPROVAL,
+  UPDATES_REQUIRED,
 } = require("../../constants/publishStatus");
 
 const { buildContext } = require("../../tests/utils/contextBuilder");
@@ -239,6 +240,34 @@ describe("questionnaire", () => {
           )
         ).rejects.toBeTruthy();
         expect(ctx.questionnaire.publishStatus).toEqual(AWAITING_APPROVAL);
+      });
+
+      it("should be able to reject a questionnaire awaiting approval", async () => {
+        ctx.questionnaire.publishStatus = AWAITING_APPROVAL;
+        await reviewQuestionnaire(
+          {
+            questionnaireId: ctx.questionnaire.id,
+            reviewAction: "Rejected",
+            reviewComment: "Ooga booga OOK OOK!",
+          },
+          ctx
+        );
+
+        expect(ctx.questionnaire.publishStatus).toEqual(UPDATES_REQUIRED);
+      });
+
+      it("should throw an error if a reject comment has not been given when rejecting", async () => {
+        ctx.questionnaire.publishStatus = AWAITING_APPROVAL;
+
+        await expect(
+          reviewQuestionnaire(
+            {
+              questionnaireId: ctx.questionnaire.id,
+              reviewAction: "Rejected",
+            },
+            ctx
+          )
+        ).rejects.toBeTruthy();
       });
 
       it("should throw error if adding questionnaire to register fails", async () => {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -78,6 +78,7 @@ enum PublishStatus {
   Published
   Unpublished
   AwaitingApproval
+  UpdatesRequired
 }
 
 type DeletedQuestionnaire {
@@ -1089,10 +1090,12 @@ input PublishQuestionnaireInput {
 
 enum ReviewAction {
   Approved
+  Rejected
 }
 
 input ReviewQuestionnaireInput {
   questionnaireId: ID!
   reviewAction: ReviewAction!
+  reviewComment: String
 }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/reviewQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/reviewQuestionnaire.js
@@ -9,11 +9,14 @@ mutation reviewQuestionnaire($input: ReviewQuestionnaireInput!) {
   }
 `;
 
-const reviewQuestionnaire = async ({ questionnaireId, reviewAction }, ctx) => {
+const reviewQuestionnaire = async (
+  { questionnaireId, reviewAction, reviewComment },
+  ctx
+) => {
   const result = await executeQuery(
     reviewQuestionnaireMutation,
     {
-      input: { questionnaireId, reviewAction },
+      input: { questionnaireId, reviewAction, reviewComment },
     },
     ctx
   );

--- a/eq-author-api/utils/questionnaireEvents.js
+++ b/eq-author-api/utils/questionnaireEvents.js
@@ -17,10 +17,12 @@ const noteCreationEvent = (ctx, bodyText) => ({
   time: new Date(),
 });
 
-const changedPublishStatusEvent = (ctx, questionnaireVersion) => ({
+const publishStatusEvent = (ctx, bodyText) => ({
   id: uuid.v4(),
   publishStatus: ctx.questionnaire.publishStatus,
-  questionnaireTitle: `${ctx.questionnaire.title} (Version ${questionnaireVersion})`,
+  questionnaireTitle: `${ctx.questionnaire.title} (Version ${ctx.questionnaire.surveyVersion})`,
+  bodyText,
+  type: "system",
   userId: ctx.user.id,
   time: new Date(),
 });
@@ -28,5 +30,5 @@ const changedPublishStatusEvent = (ctx, questionnaireVersion) => ({
 module.exports = {
   questionnaireCreationEvent,
   noteCreationEvent,
-  changedPublishStatusEvent,
+  publishStatusEvent,
 };

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -24,9 +24,10 @@ import FormattedDate from "./FormattedDate";
 import questionConfirmationIcon from "./icon-questionnaire.svg";
 
 const publishColors = {
-  Published: `#12C864`,
-  Unpublished: `#595959`,
+  Published: "#12C864",
+  Unpublished: "#595959",
   AwaitingApproval: colors.amber,
+  UpdatesRequired: colors.negative,
 };
 
 export const QuestionnaireLink = styled(NavLink)`

--- a/eq-author/src/App/history/HistoryItem.js
+++ b/eq-author/src/App/history/HistoryItem.js
@@ -37,6 +37,14 @@ const EventText = styled.div`
   }
 `;
 
+const translations = {
+  Published: "Published",
+  Unpublished: "Unpublished",
+  AwaitingApproval: "Awaiting approval",
+  UpdatesRequired: "Updates required",
+  "Questionnaire created": "Questionnaire created",
+};
+
 const formatDate = unformattedDate =>
   moment(unformattedDate).format("DD/MM/YYYY [at] HH:mm");
 
@@ -50,7 +58,8 @@ const HistoryItem = ({
   return (
     <StyledItem>
       <QuestionnaireTitle>
-        {questionnaireTitle} - <strong>{publishStatus}</strong>
+        {questionnaireTitle} -{" "}
+        <strong>{translations[publishStatus] || publishStatus}</strong>
       </QuestionnaireTitle>
       <QuestionnaireUserName>
         {userName} - {formatDate(createdAt)}

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -8,12 +8,12 @@ import { useMe } from "App/MeContext";
 import { useQuestionnaire } from "components/QuestionnaireContext";
 
 import { colors } from "constants/theme";
-import { UNPUBLISHED } from "constants/publishStatus";
+import { AWAITING_APPROVAL, PUBLISHED } from "constants/publishStatus";
 
 import { Field, Input, Label } from "components/Forms";
 import { Column } from "components/Grid";
 import Button from "components/buttons/Button";
-import Panel from "components/Panel";
+import { InformationPanel } from "components/Panel";
 import ScrollPane from "components/ScrollPane";
 import Header from "components/EditorLayout/Header";
 
@@ -54,16 +54,6 @@ const Caption = styled.p`
   margin-bottom: 0.6em;
 `;
 
-const InformationPanel = styled(Panel)`
-  background-color: ${colors.paleBlue};
-  border: 0;
-  border-radius: 0;
-  border-left: 0.5em solid ${colors.darkerBlue};
-  padding: 1em;
-  margin: 1em 0;
-  max-width: 50%;
-`;
-
 const PublishPage = ({ match, history }) => {
   const questionnaireId = match.params.questionnaireId;
   const originalInputs = { surveyId: "", formType: "" };
@@ -80,7 +70,11 @@ const PublishPage = ({ match, history }) => {
     });
 
   const publishStatus = questionnaire && questionnaire.publishStatus;
-  if (!me.admin || publishStatus !== UNPUBLISHED) {
+  if (
+    !me.admin ||
+    publishStatus === AWAITING_APPROVAL ||
+    publishStatus === PUBLISHED
+  ) {
     return <Redirect to={`/q/${match.params.questionnaireId}`} />;
   }
 
@@ -118,7 +112,7 @@ const PublishPage = ({ match, history }) => {
           </AlignedColumn>
           <Separator />
           <AlignedColumn>
-            <InformationPanel>
+            <InformationPanel maxWidth="50%">
               No further changes can be made to the questionnaire after it has
               been submitted for approval
             </InformationPanel>

--- a/eq-author/src/App/review/ReviewPage.test.js
+++ b/eq-author/src/App/review/ReviewPage.test.js
@@ -4,11 +4,26 @@ import ReviewPage from "./ReviewPage";
 import { MeContext } from "App/MeContext";
 import actSilenceWarning from "tests/utils/actSilenceWarning";
 import reviewQuestionnaireMutation from "./reviewQuestionnaire.graphql";
-import { AWAITING_APPROVAL, PUBLISHED } from "constants/publishStatus";
+import {
+  AWAITING_APPROVAL,
+  UPDATES_REQUIRED,
+  PUBLISHED,
+} from "constants/publishStatus";
 import QuestionnaireContext from "components/QuestionnaireContext";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
 
-describe("Publish page", () => {
+//eslint-disable-next-line react/prop-types
+jest.mock("components/RichTextEditor", () => ({ onUpdate }) => {
+  const handleInputChange = event =>
+    onUpdate({
+      value: event.target.value,
+    });
+  return (
+    <input data-test="reject-comment-input" onChange={handleInputChange} />
+  );
+});
+
+describe("Review page", () => {
   let user, mocks, queryWasCalled, questionnaire;
   actSilenceWarning();
 
@@ -26,85 +41,179 @@ describe("Publish page", () => {
       }
     );
 
-  beforeEach(() => {
-    questionnaire = {
-      id: "Q1",
-      publishStatus: AWAITING_APPROVAL,
-      displayName: "Test questionnaire",
-      totalErrorCount: 0,
-      createdBy: {
-        id: "1",
-        name: "Morty",
-        email: "what@ever.com",
-      },
-      editors: [],
-    };
-    user = {
-      id: "123",
-      displayName: "Awesome Tester",
-      email: "test@jest.com",
-      picture: "",
-      admin: true,
-    };
-    queryWasCalled = false;
-    mocks = [
-      {
-        request: {
-          query: reviewQuestionnaireMutation,
-          variables: {
-            input: {
-              questionnaireId: questionnaire.id,
-              reviewAction: "Approved",
-            },
-          },
+  describe("Approve", () => {
+    beforeEach(() => {
+      questionnaire = {
+        id: "Q1",
+        publishStatus: AWAITING_APPROVAL,
+        displayName: "Test questionnaire",
+        totalErrorCount: 0,
+        createdBy: {
+          id: "1",
+          name: "Morty",
+          email: "what@ever.com",
         },
-        result: () => {
-          queryWasCalled = true;
-          return {
-            data: {
-              reviewQuestionnaire: {
-                id: "987-546-232",
-                publishStatus: PUBLISHED,
-                __typename: "Object",
+        editors: [],
+      };
+      user = {
+        id: "123",
+        displayName: "Awesome Tester",
+        email: "test@jest.com",
+        picture: "",
+        admin: true,
+      };
+      queryWasCalled = false;
+      mocks = [
+        {
+          request: {
+            query: reviewQuestionnaireMutation,
+            variables: {
+              input: {
+                questionnaireId: questionnaire.id,
+                reviewAction: "Approved",
               },
             },
-          };
-        },
-      },
-      {
-        request: {
-          query: publishStatusSubscription,
-          variables: { id: questionnaire.id },
-        },
-        result: () => ({
-          data: {
-            publishStatusUpdated: {
-              id: questionnaire.id,
-              publishStatus: "Unpublished",
-              __typename: "Questionnaire",
-            },
           },
-        }),
-      },
-    ];
+          result: () => {
+            queryWasCalled = true;
+            return {
+              data: {
+                reviewQuestionnaire: {
+                  id: "987-546-232",
+                  publishStatus: PUBLISHED,
+                  __typename: "Object",
+                },
+              },
+            };
+          },
+        },
+        {
+          request: {
+            query: publishStatusSubscription,
+            variables: { id: questionnaire.id },
+          },
+          result: () => ({
+            data: {
+              publishStatusUpdated: {
+                id: questionnaire.id,
+                publishStatus: "Unpublished",
+                __typename: "Questionnaire",
+              },
+            },
+          }),
+        },
+      ];
+    });
+
+    it("should fire a mutation to review the questionnaire when the 'Approve' button is pressed", async () => {
+      const { getByTestId } = renderReviewPage();
+      fireEvent.click(getByTestId("approve-review-btn"));
+      await flushPromises();
+      expect(queryWasCalled).toBeTruthy();
+    });
+    it("should redirect to homepage when questionnaire is approved", async () => {
+      const { getByTestId, history } = renderReviewPage();
+      fireEvent.click(getByTestId("approve-review-btn"));
+      await flushPromises();
+      expect(history.location.pathname).toBe(`/`);
+    });
+    it("should redirect to questionnaire when it is not awaiting approval", async () => {
+      questionnaire.publishStatus = "Unpublished";
+      const { history } = renderReviewPage();
+      await flushPromises();
+      expect(history.location.pathname).toBe(`/q/${questionnaire.id}`);
+    });
   });
 
-  it("should fire a mutation to review the questionnaire when the 'Approve' button is pressed", async () => {
-    const { getByTestId } = renderReviewPage();
-    fireEvent.click(getByTestId("approve-review-btn"));
-    await flushPromises();
-    expect(queryWasCalled).toBeTruthy();
-  });
-  it("should redirect to homepage when questionnaire is approved", async () => {
-    const { getByTestId, history } = renderReviewPage();
-    fireEvent.click(getByTestId("approve-review-btn"));
-    await flushPromises();
-    expect(history.location.pathname).toBe(`/`);
-  });
-  it("should redirect to questionnaire when it is not awaiting approval", async () => {
-    questionnaire.publishStatus = "Unpublished";
-    const { history } = renderReviewPage();
-    await flushPromises();
-    expect(history.location.pathname).toBe(`/q/${questionnaire.id}`);
+  describe("Reject", () => {
+    beforeEach(() => {
+      questionnaire = {
+        id: "Q1",
+        publishStatus: AWAITING_APPROVAL,
+        displayName: "Shantay you stay",
+        totalErrorCount: 0,
+        createdBy: {
+          id: "1968",
+          name: "Michelle Visage",
+          email: "SlayGurl@outlook.com",
+        },
+        editors: [],
+      };
+      user = {
+        id: "1989",
+        displayName: "Sir Reginald Hargreeves",
+        email: "reggieH@umb.rell.a.ac.uk",
+        picture:
+          "https://i.pinimg.com/originals/ce/1b/3f/ce1b3f549c222d301991846ccdc25696.jpg",
+        admin: true,
+      };
+      queryWasCalled = false;
+      mocks = [
+        {
+          request: {
+            query: reviewQuestionnaireMutation,
+            variables: {
+              input: {
+                questionnaireId: questionnaire.id,
+                reviewAction: "Rejected",
+                reviewComment: "You need to add a question about lip-syncing",
+              },
+            },
+          },
+          result: () => {
+            queryWasCalled = true;
+            return {
+              data: {
+                reviewQuestionnaire: {
+                  id: "987-546-232",
+                  publishStatus: UPDATES_REQUIRED,
+                  __typename: "Object",
+                },
+              },
+            };
+          },
+        },
+        {
+          request: {
+            query: publishStatusSubscription,
+            variables: { id: questionnaire.id },
+          },
+          result: () => ({
+            data: {
+              publishStatusUpdated: {
+                id: questionnaire.id,
+                publishStatus: "Unpublished",
+                __typename: "Questionnaire",
+              },
+            },
+          }),
+        },
+      ];
+    });
+    it("should render the 'Reject' button disabled if a reject comment has not been entered", () => {
+      const { getByTestId } = renderReviewPage(mocks);
+      const btn = getByTestId("reject-review-btn");
+      expect(btn.disabled).toBeTruthy();
+    });
+    it("should render the 'Reject' button enabled if a reject comment has been entered", () => {
+      const { getByTestId } = renderReviewPage(mocks);
+      const input = getByTestId("reject-comment-input");
+      fireEvent.change(input, {
+        target: { value: "You need to add a question about lip-syncing" },
+      });
+      const btn = getByTestId("reject-review-btn");
+      expect(btn.disabled).toBeFalsy();
+    });
+    it("should fire a mutation when the 'Reject' button is pressed", async () => {
+      const { getByTestId } = renderReviewPage(mocks);
+      const input = getByTestId("reject-comment-input");
+      fireEvent.change(input, {
+        target: { value: "You need to add a question about lip-syncing" },
+      });
+      const btn = getByTestId("reject-review-btn");
+      fireEvent.click(btn);
+      await flushPromises();
+      expect(queryWasCalled).toBeTruthy();
+    });
   });
 });

--- a/eq-author/src/components/BaseLayout/App/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/BaseLayout/App/__snapshots__/index.test.js.snap
@@ -19,6 +19,7 @@ exports[`components/AppContainer should render 1`] = `
         "lightGrey": "#d6d8da",
         "lightMediumGrey": "#E4E8EB",
         "lighterGrey": "#f5f5f5",
+        "negative": "#D0021B",
         "orange": "#FDBD56",
         "paleBlue": "#f0f1f9",
         "positive": "#0f8243",

--- a/eq-author/src/components/Panel/index.js
+++ b/eq-author/src/components/Panel/index.js
@@ -6,19 +6,22 @@ const Panel = styled.div`
   border-radius: ${radius};
   background-color: ${colors.white};
   border: 1px solid ${colors.bordersLight};
+  max-width: ${props => props.maxWidth};
+`;
+
+const InformationPanel = styled(Panel)`
+  background-color: ${colors.paleBlue};
+  border: 0;
+  border-radius: 0;
+  border-left: 0.5em solid ${colors.darkerBlue};
+  padding: 1em;
+  margin: 1em 0;
 `;
 
 Panel.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export const CenteredPanel = styled(Panel)`
-  padding: 2em 2.5em;
-  display: flex;
-  flex: 1 1 100%;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
+export { Panel, InformationPanel };
 
 export default Panel;

--- a/eq-author/src/components/buttons/Button/index.js
+++ b/eq-author/src/components/buttons/Button/index.js
@@ -68,6 +68,20 @@ export const positiveButton = css`
   }
 `;
 
+export const negativeButton = css`
+  --color-text: ${colors.white};
+  --color-bg: ${colors.negative};
+
+  position: relative;
+  border: none;
+
+  &:hover {
+    --color-text: ${colors.white};
+    --color-bg: ${darken(0.1, colors.negative)};
+    border-color: var(--color-bg);
+  }
+`;
+
 export const mediumButton = css`
   padding: 0.4em 0.8em;
 `;
@@ -117,6 +131,7 @@ const Button = styled.button`
   ${props => props.variant === "tertiary" && tertiaryButton};
   ${props => props.variant === "tertiary-light" && tertiaryLightButton};
   ${props => props.variant === "positive" && positiveButton};
+  ${props => props.variant === "negative" && negativeButton};
   ${props => props.medium && mediumButton};
   ${props => props.small && smallButton};
 `;

--- a/eq-author/src/components/buttons/Button/propTypes.js
+++ b/eq-author/src/components/buttons/Button/propTypes.js
@@ -6,6 +6,7 @@ export const propTypes = {
     "tertiary",
     "tertiary-light",
     "positive",
+    "negative",
   ]),
   small: PropTypes.bool,
   medium: PropTypes.bool,

--- a/eq-author/src/constants/publishStatus.js
+++ b/eq-author/src/constants/publishStatus.js
@@ -1,3 +1,4 @@
 export const UNPUBLISHED = "Unpublished";
 export const AWAITING_APPROVAL = "AwaitingApproval";
 export const PUBLISHED = "Published";
+export const UPDATES_REQUIRED = "UpdatesRequired";

--- a/eq-author/src/constants/theme.js
+++ b/eq-author/src/constants/theme.js
@@ -21,6 +21,7 @@ colors.primary = colors.blue;
 colors.secondary = colors.blue;
 colors.tertiary = colors.orange;
 colors.positive = colors.green;
+colors.negative = colors.red;
 colors.text = colors.black;
 colors.textLight = colors.darkGrey;
 colors.borders = colors.grey;


### PR DESCRIPTION
### What is the context of this PR?

This PR adds the ability for an admin to reject a questionnaire.

### How to review 

1. Ensure all of the tests pass
2. Ensure that the code words; 
a. Make a new, valid, survey;
b. Submit it for approval;
c. Go to the review page;
d. The 'reject' button *should* be disabled until you enter a reject comment
e. If you reject the questionnaire, the status on the home page should be set to 'Updates requested' and the dot should be red;
f. After rejecting the questionnaire, the History page should have updated to show the new publish status and reject comment
3. Ensure the code employs good practices, looks clean, etc.
4. Suggest any changes and improvements, additional tests or point out missing features

Trello card: https://trello.com/c/9oiQkzn3
