### PR TITLE
Added ability to publish multiple themes

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - NODE_ENV=development
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
       - PUBLISHER_URL=http://localhost:9000/publish/
-      - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit/
+      - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api
       - JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -1099,7 +1099,7 @@ type Subscription {
 input PublishQuestionnaireInput {
   questionnaireId: ID!
   surveyId: String!
-  formType: String!
+  formTypes: JSON!
 }
 
 enum ReviewAction {

--- a/eq-author-api/tests/utils/contextBuilder/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/index.js
@@ -188,7 +188,7 @@ const buildContext = async (questionnaireConfig, userConfig = {}) => {
       {
         questionnaireId: questionnaire.id,
         surveyId: "123",
-        formType: "456",
+        formTypes: { ONS: "456" },
       },
       ctx
     );

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/publishQuestionnaire.js
@@ -10,13 +10,13 @@ mutation triggerPublish($input: PublishQuestionnaireInput!) {
 `;
 
 const publishQuestionnaire = async (
-  { questionnaireId, surveyId, formType },
+  { questionnaireId, surveyId, formTypes },
   ctx
 ) => {
   const result = await executeQuery(
     publishQuestionnaireMutation,
     {
-      input: { questionnaireId, surveyId, formType },
+      input: { questionnaireId, surveyId, formTypes },
     },
     ctx
   );


### PR DESCRIPTION
### What is the context of this PR?
This PR allows you to publish multiple surveys to the register with different themes. Will require the latest survey register changes, that can be found at: https://github.com/ONSdigital/eq-survey-register/pull/5

### How to review 
Test the new publish page works as expected and when you publish the appropriate number of surveys show up in the register.
