### PR TITLE
Various text has been corrected

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -17,7 +17,6 @@ import { buildQuestionnairePath } from "utils/UrlUtils";
 
 import { colors } from "constants/theme";
 import { WRITE } from "constants/questionnaire-permissions";
-import { AWAITING_APPROVAL } from "constants/publishStatus";
 
 import FormattedDate from "./FormattedDate";
 
@@ -243,6 +242,13 @@ export class Row extends React.Component {
 
     const ColoredStatusDot = () => <StatusDot publishStatus={publishStatus} />;
 
+    const translations = {
+      Published: "Published",
+      Unpublished: "Unpublished",
+      AwaitingApproval: "Awaiting approval",
+      UpdatesRequired: "Updates required",
+    };
+
     return (
       <>
         <FadeTransition {...rest} exit={this.state.transitionOut}>
@@ -278,9 +284,7 @@ export class Row extends React.Component {
             </TD>
             <TD>
               <TableIconText icon={ColoredStatusDot}>
-                {publishStatus === AWAITING_APPROVAL
-                  ? "Awaiting approval"
-                  : publishStatus}
+                {translations[publishStatus] || publishStatus}
               </TableIconText>
             </TD>
             <TD>{createdBy.displayName}</TD>

--- a/eq-author/src/App/review/ReviewPage.js
+++ b/eq-author/src/App/review/ReviewPage.js
@@ -75,7 +75,7 @@ const ReviewPage = ({ match, history }) => {
         <Separator />
         <InformationPanel>
           Provide a comment if you are rejecting. Your comment will be displayed
-          to the questionnaire editors in the History page.
+          on the History page.
         </InformationPanel>
         <RichTextEditor
           id={`reject-reason-textarea`}


### PR DESCRIPTION
### What is the context of this PR?
Bethan found issues with the original Reject Content PR:

> I just checked this and noticed that the text for "Status" once the survey has been rejected should be "Updates required" not "UpdatesRequired"

> I also noticed the info box above the reason for rejecting should be "Provide a comment if you are rejecting. Your comment will be displayed on the History page" and not the text displayed in the info box.

### How to review 
Ensure tests pass and that above issue has been fixed

Also, ensure that the functionality described in this Trello ticket is met: https://trello.com/c/uc2jLjXh/1312-add-a-note-when-approving-or-rejecting-a-survey
