### PR TITLE
Fix scrollpane ghosting text issue

### DIFF
--- a/eq-author/src/components/ScrollPane/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/ScrollPane/__snapshots__/index.test.js.snap
@@ -9,7 +9,6 @@ exports[`ScrollPane should render 1`] = `
   -webkit-background-clip: text;
   -webkit-transition: background-color 0.2s;
   transition: background-color 0.2s;
-  background-color: rgba(0,0,0,0.18);
 }
 
 .c0::-webkit-scrollbar-thumb {

--- a/eq-author/src/components/ScrollPane/index.js
+++ b/eq-author/src/components/ScrollPane/index.js
@@ -6,7 +6,6 @@ import { darken } from "polished";
 export const ScrollPaneCSS = css`
   -webkit-background-clip: text;
   transition: background-color 0.2s;
-  background-color: rgba(0, 0, 0, 0.18);
 
   ::-webkit-scrollbar-thumb {
     border-radius: 0;


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with text ghosting when using scrollpane.

### How to review 
Check that nothing has changed except for ghosting is now gone. You can test this on the history page by adding multiple notes till the page starts scrolling.
