### PR TITLE
Upgrade react-router and react-router-dom to v5.1.2

### DIFF
--- a/eq-author/src/App/MeContext.js
+++ b/eq-author/src/App/MeContext.js
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useEffect, useContext } from "react";
 import PropType from "prop-types";
 import { Query, withApollo } from "react-apollo";
-import { withRouter } from "react-router";
+import { withRouter } from "react-router-dom";
 import gql from "graphql-tag";
 import { get, flowRight } from "lodash";
 import auth from "components/Auth";

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavigationHeader.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavigationHeader.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { withRouter } from "react-router";
+import { withRouter } from "react-router-dom";
 import gql from "graphql-tag";
 
 import CustomPropTypes from "custom-prop-types";

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import { colors } from "constants/theme";
 import { flowRight } from "lodash";
-import { withRouter } from "react-router";
+import { withRouter } from "react-router-dom";
 import gql from "graphql-tag";
 
 import ScrollPane from "components/ScrollPane";

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -3,9 +3,8 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import gql from "graphql-tag";
 import { Query, Subscription } from "react-apollo";
-import { Switch } from "react-router-dom";
+import { Switch, Route, Redirect } from "react-router-dom";
 import { Titled } from "react-titled";
-import { Route, Redirect } from "react-router";
 import { get, find, flatMap, flowRight } from "lodash";
 
 import { Grid, Column } from "components/Grid";

--- a/eq-author/src/App/index.js
+++ b/eq-author/src/App/index.js
@@ -3,8 +3,7 @@
 import React from "react";
 import CustomPropTypes from "custom-prop-types";
 import { AppContainer } from "react-hot-loader";
-import { Switch } from "react-router-dom";
-import { Route, Router } from "react-router";
+import { Switch, Route, Router } from "react-router-dom";
 import { ApolloProvider } from "react-apollo";
 import { Provider } from "react-redux";
 

--- a/eq-author/src/App/page/Routing/index.js
+++ b/eq-author/src/App/page/Routing/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
-import { Redirect } from "react-router";
+import { Redirect } from "react-router-dom";
 
 import { get } from "lodash";
 import PropTypes from "prop-types";

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { withRouter, Redirect } from "react-router";
+import { withRouter, Redirect } from "react-router-dom";
 import CustomPropTypes from "custom-prop-types";
 import { useMutation } from "@apollo/react-hooks";
 import { map, isEmpty, some } from "lodash";

--- a/eq-author/src/App/review/ReviewPage.js
+++ b/eq-author/src/App/review/ReviewPage.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { withRouter, Redirect } from "react-router";
+import { withRouter, Redirect } from "react-router-dom";
 import { useMutation } from "@apollo/react-hooks";
 import CustomPropTypes from "custom-prop-types";
 

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import PropTypes from "prop-types";
 
-import { Router, Route } from "react-router";
+import { Router, Route } from "react-router-dom";
 import { createMemoryHistory } from "history";
 import TestProvider from "tests/utils/TestProvider";
 import { buildSectionPath } from "utils/UrlUtils";

--- a/eq-author/src/components/CommentsPanel/index.js
+++ b/eq-author/src/components/CommentsPanel/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { withRouter } from "react-router";
+import { withRouter } from "react-router-dom";
 import { get } from "lodash";
 import moment from "moment";
 import { useQuery, useMutation } from "@apollo/react-hooks";

--- a/eq-author/src/components/PrivateRoute/index.js
+++ b/eq-author/src/components/PrivateRoute/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import { Route, Redirect } from "react-router";
+import { Route, Redirect } from "react-router-dom";
 
 import Loading from "components/Loading";
 import Layout from "components/Layout";

--- a/eq-author/src/components/RedirectRoute/index.js
+++ b/eq-author/src/components/RedirectRoute/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Route, Redirect } from "react-router";
+import { Route, Redirect } from "react-router-dom";
 import { generatePath } from "utils/UrlUtils";
 
 // react-router will eventually support something akin to this.

--- a/eq-author/src/components/UserProfile/index.js
+++ b/eq-author/src/components/UserProfile/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { flowRight } from "lodash";
 import { withApollo } from "react-apollo";
-import { withRouter } from "react-router";
+import { withRouter } from "react-router-dom";
 
 import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -9848,15 +9848,15 @@ react-redux@^5.0.7:
     react-lifecycles-compat "^3.0.0"
 
 react-router-dom@latest:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.1.tgz#ee66f4a5d18b6089c361958e443489d6bab714be"
-  integrity sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
+  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
   dependencies:
     "@babel/runtime" "^7.1.2"
     history "^4.9.0"
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
-    react-router "5.0.1"
+    react-router "5.1.2"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
@@ -9870,10 +9870,10 @@ react-router-test-context@latest:
   resolved "https://registry.yarnpkg.com/react-router-test-context/-/react-router-test-context-0.1.0.tgz#3a8f52078fc171f4c966c05cefb6dff3de399713"
   integrity sha1-Oo9SB4/BcfTJZsBc77bf8945lxM=
 
-react-router@5.0.1, react-router@latest:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"
-  integrity sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==
+react-router@5.1.2, react-router@latest:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"
+  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
   dependencies:
     "@babel/runtime" "^7.1.2"
     history "^4.9.0"


### PR DESCRIPTION
### What is the context of this PR?
Upgrades both `react-router` and `react-router-dom` to v5.1.2. 

This update includes hooks! Yay! https://reacttraining.com/blog/react-router-v5-1/

I also changed the imports, as `react-router` gets those imports from `react-router-dom`, it makes more sense to keep it consistent and get the imports from `react-router-dom` instead.

### How to review 
Test that routing still works as expected.
