### PR TITLE
Updated security for graphql

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
+      - GRAPHQL_USER_BYPASS=false
     entrypoint:
       - yarn
       - start:dev

--- a/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
+++ b/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
@@ -3,7 +3,7 @@ module.exports = async (req, res, next) => {
     next();
     return;
   }
-  
+
   if (!req.user || !req.user.isVerified) {
     res.status(401).send("Unauthorised user");
     return;

--- a/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
+++ b/eq-author-api/middleware/identification/rejectUnidentifiedUsers.js
@@ -1,11 +1,11 @@
 module.exports = async (req, res, next) => {
-  if (req.method === "GET") {
+  if (req.method === "GET" && process.env.GRAPHQL_USER_BYPASS === "true") {
     next();
     return;
   }
-
+  
   if (!req.user || !req.user.isVerified) {
-    res.status(401).send("User does not exist");
+    res.status(401).send("Unauthorised user");
     return;
   }
 

--- a/eq-author-api/middleware/identification/rejectUnidentifiedUsers.test.js
+++ b/eq-author-api/middleware/identification/rejectUnidentifiedUsers.test.js
@@ -18,9 +18,4 @@ describe("rejectUnidentifiedUsers", () => {
     rejectUnidentifiedUsers(req, res, next);
     expect(next).toHaveBeenCalled();
   });
-  it("should allow GET calls through", () => {
-    req.method = "GET";
-    rejectUnidentifiedUsers(req, res, next);
-    expect(next).toHaveBeenCalled();
-  });
 });

--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node app.js",
-    "start:dev": "ENABLE_OPENTRACING=true NODE_ENV=development nodemon --ignore 'data/ migrations/' --inspect=0.0.0.0:5858",
+    "start:dev": "ENABLE_OPENTRACING=true nodemon --ignore 'data/ migrations/' --inspect=0.0.0.0:5858",
     "lint": "eslint .",
     "test": "./scripts/test.sh",
     "test:breakingChanges": "node scripts/checkForBreakingChanges.js",


### PR DESCRIPTION
Currently any HTTP requests to the graphql endpoint that of the type GET are allowed without authorisation but all other HTTP requests are checked for an authorised user.
This change stops that behaviour but can be bypassed in local development to test graphql responses.

To test graphql endpoints set the GRAPHQL_USER_BYPASS env variable to true in the docker compose file or your env file. This will disable user authorisation for GET requests.

when testing the endpoint you can use either the graphql playground or get raw JSON.
For the graphql browser interface set NODE_ENV to 'development'.
To return raw JSON responses set NODE_ENV to something else like 'prod'
