### PR TITLE
Fix smoke test by setting data-test correctly

### DIFF
--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -656,7 +656,7 @@ exports[`Option should render a checkbox 1`] = `
                                       <WrappingInput__TextArea
                                         aria-invalid="false"
                                         data-autofocus={true}
-                                        data-test="wrapping-input-textarea"
+                                        data-test="option-label"
                                         id="option-label-1"
                                         name="label"
                                         onBlur={[MockFunction]}
@@ -668,7 +668,7 @@ exports[`Option should render a checkbox 1`] = `
                                         <StyledComponent
                                           aria-invalid="false"
                                           data-autofocus={true}
-                                          data-test="wrapping-input-textarea"
+                                          data-test="option-label"
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -725,7 +725,7 @@ exports[`Option should render a checkbox 1`] = `
                                             aria-invalid="false"
                                             className="c7"
                                             data-autofocus={true}
-                                            data-test="wrapping-input-textarea"
+                                            data-test="option-label"
                                             id="option-label-1"
                                             inputRef={[Function]}
                                             name="label"
@@ -741,7 +741,7 @@ exports[`Option should render a checkbox 1`] = `
                                               aria-invalid="false"
                                               className="c7"
                                               data-autofocus={true}
-                                              data-test="wrapping-input-textarea"
+                                              data-test="option-label"
                                               id="option-label-1"
                                               name="label"
                                               onBlur={[MockFunction]}
@@ -956,7 +956,7 @@ exports[`Option should render a checkbox 1`] = `
                               >
                                 <WrappingInput__TextArea
                                   aria-invalid="false"
-                                  data-test="wrapping-input-textarea"
+                                  data-test="option-description"
                                   id="option-description-1"
                                   name="description"
                                   onBlur={[MockFunction]}
@@ -966,7 +966,7 @@ exports[`Option should render a checkbox 1`] = `
                                 >
                                   <StyledComponent
                                     aria-invalid="false"
-                                    data-test="wrapping-input-textarea"
+                                    data-test="option-description"
                                     forwardedComponent={
                                       Object {
                                         "$$typeof": Symbol(react.forward_ref),
@@ -1021,7 +1021,7 @@ exports[`Option should render a checkbox 1`] = `
                                     <TextareaAutosize
                                       aria-invalid="false"
                                       className="c7"
-                                      data-test="wrapping-input-textarea"
+                                      data-test="option-description"
                                       id="option-description-1"
                                       inputRef={[Function]}
                                       name="description"
@@ -1035,7 +1035,7 @@ exports[`Option should render a checkbox 1`] = `
                                       <textarea
                                         aria-invalid="false"
                                         className="c7"
-                                        data-test="wrapping-input-textarea"
+                                        data-test="option-description"
                                         id="option-description-1"
                                         name="description"
                                         onBlur={[MockFunction]}

--- a/eq-author/src/components/Forms/WrappingInput/index.js
+++ b/eq-author/src/components/Forms/WrappingInput/index.js
@@ -62,7 +62,6 @@ class WrappingInput extends React.Component {
           placeholder={placeholder}
           invalid={errorValidationMsg}
           aria-invalid={Boolean(errorValidationMsg).toString()}
-          data-test="wrapping-input-textarea"
         />
         {errorValidationMsg && <ErrorInline>{errorValidationMsg}</ErrorInline>}
       </StyleContext>

--- a/eq-author/src/components/Forms/WrappingInput/index.test.js
+++ b/eq-author/src/components/Forms/WrappingInput/index.test.js
@@ -16,6 +16,7 @@ describe("WrappingInput", () => {
         value="123"
         onChange={handleChange}
         onBlur={handleUpdate}
+        data-test="wrapping-input-textarea"
       />
     );
     expect(getByText("123")).toBeTruthy();
@@ -31,6 +32,7 @@ describe("WrappingInput", () => {
         value="123"
         onChange={handleChange}
         onBlur={handleUpdate}
+        data-test="wrapping-input-textarea"
       />
     );
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with data-test id being overwritten.

### How to review 
Pull down this branch and https://github.com/ONSdigital/eq-smoke-tests
Then run `BASE_URL=http://localhost:3000 yarn cypress:open` in `eq-smoke-tests` to see that smoke tests are now working.