### PR TITLE
Fixed migration

### DIFF
--- a/eq-author-api/middleware/runQuestionnaireMigrations.js
+++ b/eq-author-api/middleware/runQuestionnaireMigrations.js
@@ -1,4 +1,8 @@
-const { saveQuestionnaire } = require("../utils/datastore");
+const {
+  saveQuestionnaire,
+  getQuestionnaireMetaById,
+} = require("../utils/datastore");
+const { merge } = require("lodash");
 
 module.exports = logger => ({ currentVersion, migrations }) => async (
   req,
@@ -16,6 +20,11 @@ module.exports = logger => ({ currentVersion, migrations }) => async (
   }
 
   try {
+    const questionnaireMeta = await getQuestionnaireMetaById(
+      req.questionnaire.id
+    );
+    merge(questionnaireMeta, { ...req.questionnaire });
+    req.questionnaire = questionnaireMeta;
     req.questionnaire = await migrations
       .slice(req.questionnaire.version)
       .reduce((questionnaire, migration) => {

--- a/eq-author-api/migrations/addTypeToHistoryEvent.js
+++ b/eq-author-api/migrations/addTypeToHistoryEvent.js
@@ -1,17 +1,10 @@
-const { getQuestionnaireMetaById, saveModel } = require("../utils/datastore");
-const { QuestionnaireModel } = require("../db/models/DynamoDB");
-
 module.exports = async function addTypeToHistoryEvent(questionnaire) {
-  const metadata = await getQuestionnaireMetaById(questionnaire.id);
-
-  metadata.history.map(item => {
+  questionnaire.history.map(item => {
     if (!item.type) {
       item.type = item.hasOwnProperty("bodyText") ? "note" : "system";
     }
     return item;
   });
-
-  await saveModel(new QuestionnaireModel(metadata));
 
   return questionnaire;
 };


### PR DESCRIPTION
### What is the context of this PR?
Lots of questionnaires were failing due to the addTypeToHistory migration making database calls within the migration and so was resolving out of order. This PR should fix this.

### How to review 
Get a questionnaire, modify the database to remove history and revert it to version 11, then try to access it, pre this PR that will fail, however on this branch it should succeed.
