### PR TITLE
Enable publish for editors and owners

### DIFF
--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -6,7 +6,6 @@ import CustomPropTypes from "custom-prop-types";
 import { useMutation } from "@apollo/react-hooks";
 import { map, isEmpty, some } from "lodash";
 
-import { useMe } from "App/MeContext";
 import { useQuestionnaire } from "components/QuestionnaireContext";
 
 import { colors } from "constants/theme";
@@ -94,7 +93,6 @@ const PublishPage = ({ match, history }) => {
   const questionnaireId = match.params.questionnaireId;
   const [surveyId, setSurveyId] = useState("");
   const [formTypes, setFormTypes] = useState({});
-  const { me } = useMe();
   const { questionnaire } = useQuestionnaire();
 
   const [triggerPublish] = useMutation(triggerPublishMutation);
@@ -113,10 +111,17 @@ const PublishPage = ({ match, history }) => {
   };
 
   const publishStatus = questionnaire && questionnaire.publishStatus;
+
+  const canPublish = () => {
+    if (!questionnaire) {
+      return true;
+    }
+    return questionnaire.permission === "Write";
+  };
   if (
-    !me.admin ||
     publishStatus === AWAITING_APPROVAL ||
-    publishStatus === PUBLISHED
+    publishStatus === PUBLISHED ||
+    !canPublish()
   ) {
     return <Redirect to={`/q/${match.params.questionnaireId}`} />;
   }

--- a/eq-author/src/App/publish/PublishPage.test.js
+++ b/eq-author/src/App/publish/PublishPage.test.js
@@ -20,8 +20,8 @@ describe("Publish page", () => {
         </QuestionnaireContext.Provider>
       </MeContext.Provider>,
       {
-        route: `/q/${questionnaire.id}/page/2`,
-        urlParamMatcher: "/q/:questionnaireId/page/:pageId",
+        route: `/q/${questionnaire.id}/publish`,
+        urlParamMatcher: "/q/:questionnaireId",
         mocks,
       }
     );
@@ -43,7 +43,8 @@ describe("Publish page", () => {
         name: "Morty",
         email: "what@ever.com",
       },
-      editors: [],
+      editors: [{ id: "2", name: "Rick", email: "rick@mail.com" }],
+      permission: "Write",
     };
     user = {
       id: "123",
@@ -133,10 +134,23 @@ describe("Publish page", () => {
     expect(history.location.pathname).toBe("/");
   });
 
-  it("should redirect to questionnaire when it is not Unpublished", async () => {
+  it("should redirect to questionnaire when it is not Unpublished", () => {
     questionnaire.publishStatus = AWAITING_APPROVAL;
     const { history } = renderPublishPage();
-    await flushPromises();
     expect(history.location.pathname).toBe(`/q/${questionnaire.id}`);
+  });
+
+  it("should not redirect to questionnaire when user is owner", () => {
+    questionnaire.publishStatus = UNPUBLISHED;
+    user = { ...user, id: "1", admin: false };
+    const { history } = renderPublishPage();
+    expect(history.location.pathname).toBe(`/q/${questionnaire.id}/publish`);
+  });
+
+  it("should not redirect to questionnaire when user is editor", () => {
+    questionnaire.publishStatus = UNPUBLISHED;
+    user = { ...user, id: "2", admin: false };
+    const { history } = renderPublishPage();
+    expect(history.location.pathname).toBe(`/q/${questionnaire.id}/publish`);
   });
 });

--- a/eq-author/src/components/EditorLayout/Header/index.js
+++ b/eq-author/src/components/EditorLayout/Header/index.js
@@ -98,15 +98,19 @@ export const UnconnectedHeader = props => {
         </RouteButton>
       );
     }
+
     if (publishStatus === AWAITING_APPROVAL && !me.admin) {
       return null;
     }
+
+    const canPublish = questionnaire.permission === "Write";
     return (
       <RouteButton
         variant="tertiary-light"
         to={buildPublishPath(match.params)}
         small
         disabled={
+          !canPublish ||
           questionnaire.totalErrorCount > 0 ||
           title === "Publish" ||
           publishStatus === PUBLISHED
@@ -148,7 +152,7 @@ export const UnconnectedHeader = props => {
                 >
                   <IconText icon={viewIcon}>View survey</IconText>
                 </LinkButton>
-                {me.admin && renderPublishReviewButton()}
+                {renderPublishReviewButton()}
                 <Button
                   variant="tertiary-light"
                   onClick={() => setSharingModalOpen(true)}

--- a/eq-author/src/components/EditorLayout/Header/index.test.js
+++ b/eq-author/src/components/EditorLayout/Header/index.test.js
@@ -201,6 +201,33 @@ describe("Header", () => {
       });
       expect(queryWasCalled).toBeTruthy();
     });
+
+    it("should enable publish button for owner of questionnaire", () => {
+      questionnaire.publishStatus = UNPUBLISHED;
+      user = { ...user, id: "1", admin: false };
+      const { getByTestId } = renderWithContext(<Header {...props} />);
+
+      const publishSurveyButton = getByTestId("btn-publish");
+      expect(publishSurveyButton).toBeTruthy();
+    });
+
+    it("should enable publish button for editor of questionnaire", () => {
+      questionnaire.publishStatus = UNPUBLISHED;
+      user = { ...user, id: "2", admin: false };
+      const { getByTestId } = renderWithContext(<Header {...props} />);
+
+      const publishSurveyButton = getByTestId("btn-publish");
+      expect(publishSurveyButton).toBeTruthy();
+    });
+
+    it("should not display publish button when awaiting approval", () => {
+      questionnaire.publishStatus = AWAITING_APPROVAL;
+      user = { ...user, id: "1", admin: false };
+      const { queryByTestId } = renderWithContext(<Header {...props} />);
+
+      const publishSurveyButton = queryByTestId("btn-publish");
+      expect(publishSurveyButton).toBeFalsy();
+    });
   });
 
   describe("review survey button", () => {
@@ -236,6 +263,14 @@ describe("Header", () => {
 
       fireEvent.click(reviewButton);
       expect(history.location.pathname).toMatch("/review");
+    });
+
+    it("should not show review button for non admins", () => {
+      questionnaire.publishStatus = AWAITING_APPROVAL;
+      user.admin = false;
+      const { queryByTestId } = renderWithContext(<Header {...props} />);
+      const reviewButton = queryByTestId("btn-review");
+      expect(reviewButton).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Enabled publish button for editors and owners of questionnaires.

### How to review 
Check that you can now publish a questionnaire as an owner and editor.