### PR TITLE
Upgraded Draft-js-plugin-editor version

### DIFF
--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -92,7 +92,7 @@
     "draft-convert": "latest",
     "draft-js": "latest",
     "draft-js-block-breakout-plugin": "latest",
-    "draft-js-plugins-editor": "latest",
+    "draft-js-plugins-editor": "^3.0.0",
     "draft-js-raw-content-state": "latest",
     "draftjs-filters": "^2.2.4",
     "firebase": "latest",

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -3910,11 +3910,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decorate-component-with-props@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/decorate-component-with-props/-/decorate-component-with-props-1.1.0.tgz#b496c814c6a2aba0cf2ad26e44cbedb8ead42f15"
-  integrity sha512-tTYQojixN64yK3/WBODMfvss/zbmyUx9HQXhzSxZiSiofeekVeRyyuToy9BCiTMrVEIKWxTcla2t3y5qdaUF7Q==
-
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -4245,16 +4240,13 @@ draft-js-block-breakout-plugin@latest:
   dependencies:
     immutable "~3.7.4"
 
-draft-js-plugins-editor@latest:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/draft-js-plugins-editor/-/draft-js-plugins-editor-2.1.1.tgz#7c9aedd696737c6ddf45d47c978bd764ef33f688"
-  integrity sha512-fKGe71irNvFHJ5L/lUrh+3vPkBNq0de6x+cgiZUJ9zQERc5KPBtGXIFiarLFVHyrRTCPq+K6xmgfFSAERaFHPw==
+draft-js-plugins-editor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/draft-js-plugins-editor/-/draft-js-plugins-editor-3.0.0.tgz#196d1e065e2c29faebaab4ec081b734fdef294a2"
+  integrity sha512-bFEL0FUIPg9VK3KSeBZ3D+uMqQEVe4Cv7++LWCMASRH02jy6x2f87NRxSZLzTQES5+oL6Qg+OEUlaTn409145A==
   dependencies:
-    decorate-component-with-props "^1.0.2"
-    find-with-regex "^1.1.3"
     immutable "~3.7.4"
     prop-types "^15.5.8"
-    union-class-names "^1.0.0"
 
 draft-js-raw-content-state@latest:
   version "1.2.7"
@@ -5223,11 +5215,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-with-regex@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
-  integrity sha512-zkEVQ1H3PIQL/19ADKt1lCQU4QGM3OneiderUcFgn5EgTm/TnoUh7HxPAwP8w/vXxWSLC6KtpbDQpypJ5+majw==
 
 firebase@latest:
   version "5.11.1"
@@ -12678,11 +12665,6 @@ unified@^8.0.0:
     is-plain-obj "^2.0.0"
     trough "^1.0.0"
     vfile "^4.0.0"
-
-union-class-names@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/union-class-names/-/union-class-names-1.0.0.tgz#9259608adacc39094a2b0cfe16c78e6200617847"
-  integrity sha1-kllgitrMOQlKKwz+FseOYgBheEc=
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
There is a version mis-match between draft-js and draft-js-plugin-editor.
draft-js 0.11.0 has a peer dependancy on editor plugin 3.0.0 (currently 2.1.1)
This mis-match is possibly causing our i is not a function error in sentry.

