### PR TITLE
Fixed incorrect label texst

### DIFF
--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -140,6 +140,7 @@ class Question {
 
   buildMutuallyExclusiveAnswers(mutuallyExclusive) {
     Object.assign(mutuallyExclusive.properties, { required: false });
+    delete mutuallyExclusive.label;
     const mutuallyExclusiveAnswer = new Answer({
       ...mutuallyExclusive,
       id: `${mutuallyExclusive.id}-exclusive`,

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -530,6 +530,7 @@ describe("Question", () => {
         {
           type: "Checkbox",
           id: "1",
+          label: "test",
           properties: { required: true },
           options: [
             {
@@ -600,6 +601,11 @@ describe("Question", () => {
     it("should have a mandatory property", () => {
       const question = new Question(createQuestionJSON({ answers }));
       expect(question).toHaveProperty("mandatory");
+    });
+
+    it("should not inherit the label property", () => {
+      const question = new Question(createQuestionJSON({ answers }));
+      expect(question).not.toHaveProperty("label");
     });
 
     it("should set mandatory on exclusive child answers to false", () => {


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with exclusive options showing the wrong text when provided a label.

### How to review 
Tests pass and if you publish a checkbox answer with a 
exclusive option and a answer label the exclusive option should still be labelled with "OR"