### PR TITLE
removed saving indicator from read-only surveys

### DIFF
--- a/eq-author/src/components/EditorLayout/Header/SavingIndicator/SavingIndicator.test.js
+++ b/eq-author/src/components/EditorLayout/Header/SavingIndicator/SavingIndicator.test.js
@@ -69,4 +69,17 @@ describe("SavingIndicator", () => {
     wrapper.setProps({ isSaving: true });
     expect(findIndicator(wrapper).exists()).toBe(false);
   });
+
+  it("should not show if user doesn't have permission", () => {
+    const wrapper = shallow(
+      <UnconnectedSavingIndicator
+        isSaving={false}
+        hasError={false}
+        isUnauthorized
+      />
+    );
+
+    wrapper.setProps({ isSaving: true });
+    expect(findIndicator(wrapper).exists()).toBe(false);
+  });
 });

--- a/eq-author/src/components/EditorLayout/Header/SavingIndicator/index.js
+++ b/eq-author/src/components/EditorLayout/Header/SavingIndicator/index.js
@@ -31,6 +31,7 @@ export class UnconnectedSavingIndicator extends React.Component {
   static propTypes = {
     isSaving: PropTypes.bool.isRequired,
     hasError: PropTypes.bool.isRequired,
+    isUnauthorized: PropTypes.bool,
     minDisplayTime: PropTypes.number,
   };
 
@@ -80,8 +81,9 @@ export class UnconnectedSavingIndicator extends React.Component {
 
   render() {
     const isVisible =
-      !this.props.hasError && (this.props.isSaving || this.state.timerRunning);
-
+      !this.props.hasError &&
+      !this.props.isUnauthorized &&
+      (this.props.isSaving || this.state.timerRunning);
     return (
       <TransitionGroup>
         {isVisible ? this.renderIndicator() : null}

--- a/eq-author/src/components/EditorLayout/Header/index.js
+++ b/eq-author/src/components/EditorLayout/Header/index.js
@@ -77,6 +77,7 @@ export const UnconnectedHeader = props => {
     variables: { id: match.params.questionnaireId },
   });
   const publishStatus = get(questionnaire, "publishStatus");
+  const permission = get(questionnaire, "permission");
 
   const previewUrl = `${config.REACT_APP_LAUNCH_URL}/${
     (questionnaire || {}).id
@@ -164,7 +165,7 @@ export const UnconnectedHeader = props => {
         <PageTitle>{title}</PageTitle>
         {children}
         <SavingContainer>
-          <SavingIndicator />
+          <SavingIndicator isUnauthorized={permission !== "Write"} />
         </SavingContainer>
       </StyledHeader>
       {questionnaire && (


### PR DESCRIPTION
### What is the context of this PR?
The saving indicator was being displayed when a user didn't have permission on a survey the PR prevents it from showing.

### How to review 
Access a survey you don't have permission on and try to edit it, the saving indicator should not appear, however should appear on surveys you do have access on.
