### PR TITLE
Increase margin to make space for error message

### DIFF
--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/Option.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/Option.js
@@ -34,7 +34,7 @@ export const Flex = styled.div`
 `;
 
 export const OptionField = styled(Field)`
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
 `;
 
 export const StyledOption = styled.div`

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -310,7 +310,7 @@ exports[`Option should render a checkbox 1`] = `
 }
 
 .c3 {
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
 }
 
 .c0 {
@@ -477,7 +477,7 @@ exports[`Option should render a checkbox 1`] = `
                           "isStatic": false,
                           "lastClassName": "c3",
                           "rules": Array [
-                            "margin-bottom:1em;",
+                            "margin-bottom:1.5em;",
                           ],
                         },
                         "displayName": "Option__OptionField",
@@ -783,7 +783,7 @@ exports[`Option should render a checkbox 1`] = `
                     "isStatic": false,
                     "lastClassName": "c3",
                     "rules": Array [
-                      "margin-bottom:1em;",
+                      "margin-bottom:1.5em;",
                     ],
                   },
                   "displayName": "Option__OptionField",

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
@@ -23,7 +23,7 @@ import withMoveOption from "../withMoveOption";
 
 const AnswerWrapper = styled.div`
   margin: 2em 0 0;
-  width: 75%;
+  width: 85%;
 `;
 
 const AnswerHelper = styled.div`

--- a/eq-author/src/App/questionConfirmation/Design/Editor.js
+++ b/eq-author/src/App/questionConfirmation/Design/Editor.js
@@ -17,7 +17,7 @@ const Wrapper = styled.div`
 `;
 
 const OptionsWrapper = styled.div`
-  width: calc(75% - 6em);
+  width: calc(85% - 1em);
   margin-top: 3em;
 `;
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes the inline error message so it no longer overlaps with other content.

Design changes confirmed with Joe :)

### How to review 
1. To see the issue, reduce the screen size to about 1200x500.
2. Checkout this branch and check if fix works.
3. Should work for checkboxes answers, radio answers and confirmation questions.
