### PR TITLE
Fix missing border lines and overflow of alias input text

### DIFF
--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -118,14 +118,14 @@ exports[`Option should render a checkbox 1`] = `
 
 .c7 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   font-weight: inherit;
   resize: none;
   overflow: hidden;
@@ -678,11 +678,11 @@ exports[`Option should render a checkbox 1`] = `
                                                 "isStatic": false,
                                                 "lastClassName": "c7",
                                                 "rules": Array [
-                                                  "font-size:1em;border:1px solid ",
+                                                  "font-size:1em;border:thin solid ",
                                                   "#999999",
                                                   ";padding:0.5em;color:",
                                                   "#333333",
-                                                  ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:1px solid transparent;&:hover{border-color:",
+                                                  ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:thin solid transparent;&:hover{border-color:",
                                                   "#3B7A9E",
                                                   ";outline-color:",
                                                   "#3B7A9E",
@@ -976,11 +976,11 @@ exports[`Option should render a checkbox 1`] = `
                                           "isStatic": false,
                                           "lastClassName": "c7",
                                           "rules": Array [
-                                            "font-size:1em;border:1px solid ",
+                                            "font-size:1em;border:thin solid ",
                                             "#999999",
                                             ";padding:0.5em;color:",
                                             "#333333",
-                                            ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:1px solid transparent;&:hover{border-color:",
+                                            ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:thin solid transparent;&:hover{border-color:",
                                             "#3B7A9E",
                                             ";outline-color:",
                                             "#3B7A9E",

--- a/eq-author/src/App/page/Design/answers/dummy/TextArea/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/dummy/TextArea/__snapshots__/index.test.js.snap
@@ -4,14 +4,14 @@ exports[`components/Answers/Dummy/TextArea shoulder render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   border-color: #d6d8da;
   padding: 1.2em 1.2em 1.2em 2em;
   position: relative;

--- a/eq-author/src/App/page/Design/answers/dummy/TextInput/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/dummy/TextInput/__snapshots__/index.test.js.snap
@@ -4,14 +4,14 @@ exports[`components/Answers/Dummy/TextInput shoulder render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   border: none;
   background: transparent url(placeholder.svg) no-repeat;
   background-size: 100% 100%;

--- a/eq-author/src/components/AliasEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/AliasEditor/__snapshots__/index.test.js.snap
@@ -2,15 +2,15 @@
 
 exports[`AliasEditor should render 1`] = `
 <AliasEditor__Wrapper>
-  <AliasEditor__StyledWrappingInput
+  <AliasEditor__InputBox
+    autoComplete="off"
     data-test="alias"
     id="alias"
-    maxLength={255}
-    maxRows={1}
     name="alias"
-    onBlur={[MockFunction]}
-    onChange={[MockFunction]}
+    onBlur={[Function]}
+    onChange={[Function]}
     placeholder="Shortcode"
+    type="text"
     value="FooBar"
   />
   <CharacterCounter

--- a/eq-author/src/components/AliasEditor/index.js
+++ b/eq-author/src/components/AliasEditor/index.js
@@ -1,31 +1,38 @@
 import React from "react";
 import styled from "styled-components";
 import CharacterCounter from "components/CharacterCounter";
-import WrappingInput from "components/Forms/WrappingInput";
 import PropTypes from "prop-types";
 
+import { sharedStyles } from "components/Forms/css";
+import { colors } from "constants/theme";
+
 export const Wrapper = styled.div`
-  position: relative;
+  ${sharedStyles};
+  height: 2.3em;
+  display: flex;
   max-width: 22em;
-  flex: 1 1 auto;
 `;
 
-const StyledWrappingInput = styled(WrappingInput)`
-  white-space: nowrap;
+const InputBox = styled.input`
+  width: 100%;
+  outline: none;
+  border: none;
+  font-size: 1em;
+  color: ${colors.black};
 `;
 
 const AliasEditor = ({ onChange, onUpdate, alias }) => (
   <Wrapper>
-    <StyledWrappingInput
+    <InputBox
       id="alias"
+      type="text"
       data-test="alias"
+      autoComplete="off"
       name="alias"
       placeholder="Shortcode"
-      onChange={onChange}
-      onBlur={onUpdate}
-      value={alias}
-      maxLength={255}
-      maxRows={1}
+      onChange={e => onChange(e.target)}
+      onBlur={e => onUpdate(e.target)}
+      value={alias || ""}
     />
     <CharacterCounter value={alias} limit={24} />
   </Wrapper>

--- a/eq-author/src/components/CharacterCounter/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/CharacterCounter/__snapshots__/index.test.js.snap
@@ -4,12 +4,8 @@ exports[`CharacterCounter should handle null value 1`] = `
 <DocumentFragment>
   .c0 {
   color: #d6d8da;
-  position: absolute;
-  top: 1px;
-  bottom: 1px;
-  right: 1px;
-  padding: 0.5em;
-  background: white;
+  padding: 0 0.3em;
+  background: none;
 }
 
 <span
@@ -24,12 +20,8 @@ exports[`CharacterCounter should render 1`] = `
 <DocumentFragment>
   .c0 {
   color: #d6d8da;
-  position: absolute;
-  top: 1px;
-  bottom: 1px;
-  right: 1px;
-  padding: 0.5em;
-  background: white;
+  padding: 0 0.3em;
+  background: none;
 }
 
 <span

--- a/eq-author/src/components/CharacterCounter/index.js
+++ b/eq-author/src/components/CharacterCounter/index.js
@@ -8,12 +8,8 @@ const getLength = value => (value ? value.length : 0);
 export const Counter = styled.span`
   color: ${props =>
     props.limit - getLength(props.value) < 0 ? colors.red : colors.lightGrey};
-  position: absolute;
-  top: 1px;
-  bottom: 1px;
-  right: 1px;
-  padding: 0.5em;
-  background: white;
+  padding: 0 0.3em;
+  background: none;
 `;
 
 const CharacterCounter = ({ value, limit }) => {

--- a/eq-author/src/components/Forms/Input/__snapshots__/Input.test.js.snap
+++ b/eq-author/src/components/Forms/Input/__snapshots__/Input.test.js.snap
@@ -3,14 +3,14 @@
 exports[`components/Forms/Input Text should render correctly 1`] = `
 .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
 }
 
 .c0:hover {
@@ -80,11 +80,11 @@ exports[`components/Forms/Input Text should render correctly 1`] = `
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "font-size:1em;border:1px solid ",
+                "font-size:1em;border:thin solid ",
                 "#999999",
                 ";padding:0.5em;color:",
                 "#333333",
-                ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:1px solid transparent;&:hover{border-color:",
+                ";display:block;width:100%;transition:outline-color 100ms ease-in,border-color 100ms ease-in;outline:thin solid transparent;&:hover{border-color:",
                 "#3B7A9E",
                 ";outline-color:",
                 "#3B7A9E",

--- a/eq-author/src/components/Forms/TextArea/__snapshots__/TextArea.test.js.snap
+++ b/eq-author/src/components/Forms/TextArea/__snapshots__/TextArea.test.js.snap
@@ -4,14 +4,14 @@ exports[`components/Forms/TextArea should render correctly 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   resize: none;
 }
 

--- a/eq-author/src/components/Forms/css.js
+++ b/eq-author/src/components/Forms/css.js
@@ -23,13 +23,13 @@ const invalidStyle = css`
 
 export const sharedStyles = css`
   font-size: 1em;
-  border: 1px solid ${colors.borders};
+  border: thin solid ${colors.borders};
   padding: 0.5em;
   color: ${colors.black};
   display: block;
   width: 100%;
   transition: outline-color 100ms ease-in, border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
 
   &:hover {
     border-color: ${colors.blue};

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -4,14 +4,14 @@ exports[`ToggleSwitch should render 1`] = `
 <DocumentFragment>
   .c1 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   display: inline-block;
   width: 1.1em;
   height: 1.1em;
@@ -169,14 +169,14 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
 <DocumentFragment>
   .c1 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   display: inline-block;
   width: 1.1em;
   height: 1.1em;

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableInput.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableInput.test.js.snap
@@ -4,14 +4,14 @@ exports[`TableInput should render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
 }
 
 .c0:hover {

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableInputDate.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableInputDate.test.js.snap
@@ -4,14 +4,14 @@ exports[`TableInputDate should render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
 }
 
 .c0:hover {

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableSelect.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableSelect.test.js.snap
@@ -4,14 +4,14 @@ exports[`TableSelect should render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
   display: inline-block;
   padding: 0.5em 2em 0.5em 0.75em;
   background: white url('icon-select.svg') no-repeat right center;

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableTypeaheadInput.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableTypeaheadInput.test.js.snap
@@ -4,14 +4,14 @@ exports[`TableTypeaheadInput should render 1`] = `
 <DocumentFragment>
   .c0 {
   font-size: 1em;
-  border: 1px solid #999999;
+  border: thin solid #999999;
   padding: 0.5em;
   color: #333333;
   display: block;
   width: 100%;
   -webkit-transition: outline-color 100ms ease-in,border-color 100ms ease-in;
   transition: outline-color 100ms ease-in,border-color 100ms ease-in;
-  outline: 1px solid transparent;
+  outline: thin solid transparent;
 }
 
 .c0:hover {


### PR DESCRIPTION
### What is the context of this PR?
Fix issue with part of border lines disappearing when reducing zoom on chrome. This typically happened at zoom 90%. This was fixed by changing border size to `thin` instead of `1px`. Setting it to `1px` was forcing Chrome to do subpixel calculation, which had some strange side effects.

Also fixed the input box to only cover the visible area. Previously it would overflow behind the character count.

### How to review 
* Check that the border lines stay the same when zooming in and out.
* Check that entering shortcode on calc summary page, question page and section still works.
* Check that shortcode text doesnt overlap with character counter.