### PR TITLE
Added exclusion of std label if optional label is used

### DIFF
--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -28,9 +28,6 @@ exports[`MultipleChoiceAnswer exclusive options should render exclusive 1`] = `
   type="Checkbox"
 >
   <MultipleChoiceAnswer__AnswerWrapper>
-    <MultipleChoiceAnswer__AnswerHelper>
-      Select all that apply
-    </MultipleChoiceAnswer__AnswerHelper>
     <TransitionGroup
       childFactory={[Function]}
       component={
@@ -38,7 +35,7 @@ exports[`MultipleChoiceAnswer exclusive options should render exclusive 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
             "isStatic": false,
             "rules": Array [
               "margin:0 0 1em;",
@@ -47,7 +44,7 @@ exports[`MultipleChoiceAnswer exclusive options should render exclusive 1`] = `
           "displayName": "MultipleChoiceAnswer__Options",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
           "target": "div",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -231,7 +228,7 @@ exports[`MultipleChoiceAnswer other option and answer should render other 1`] = 
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
             "isStatic": false,
             "rules": Array [
               "margin:0 0 1em;",
@@ -240,7 +237,7 @@ exports[`MultipleChoiceAnswer other option and answer should render other 1`] = 
           "displayName": "MultipleChoiceAnswer__Options",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
           "target": "div",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -361,7 +358,7 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+            "componentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
             "isStatic": false,
             "rules": Array [
               "margin:0 0 1em;",
@@ -370,7 +367,7 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
           "displayName": "MultipleChoiceAnswer__Options",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-3",
+          "styledComponentId": "MultipleChoiceAnswer__Options-sc-199jynm-2",
           "target": "div",
           "toString": [Function],
           "warnTooManyClasses": [Function],

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
@@ -26,13 +26,6 @@ const AnswerWrapper = styled.div`
   width: 85%;
 `;
 
-const AnswerHelper = styled.div`
-  margin-bottom: 0.5em;
-  font-size: 0.9em;
-  font-weight: 600;
-  color: ${colors.text};
-`;
-
 const ExclusiveOr = styled.div`
   padding-bottom: 1em;
   font-size: 1em;
@@ -137,9 +130,6 @@ export class UnwrappedMultipleChoiceAnswer extends Component {
         type={answer.type}
       >
         <AnswerWrapper>
-          {answer.type === CHECKBOX && (
-            <AnswerHelper>Select all that apply</AnswerHelper>
-          )}
           <TransitionGroup
             component={Options}
             data-test="multiple-choice-options"

--- a/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
+++ b/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
@@ -144,7 +144,7 @@ const MultipleChoiceAnswer = ({ answer }) => {
   return (
     <Field>
       <Legend>{answer.label}</Legend>
-      {answer.type === CHECKBOX && (
+      {answer.type === CHECKBOX && !answer.label && (
         <SelectAll>Select all that apply:</SelectAll>
       )}
       {answer.options.map((option, index) => (

--- a/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -194,9 +194,6 @@ exports[`MultipleChoiceAnswer should render checkboxes 1`] = `
   <MultipleChoiceAnswer__Legend>
     Foo
   </MultipleChoiceAnswer__Legend>
-  <MultipleChoiceAnswer__SelectAll>
-    Select all that apply:
-  </MultipleChoiceAnswer__SelectAll>
   <Option
     key="1"
     option={
@@ -214,9 +211,6 @@ exports[`MultipleChoiceAnswer should render mutually exclusive when it has one 1
   <MultipleChoiceAnswer__Legend>
     Foo
   </MultipleChoiceAnswer__Legend>
-  <MultipleChoiceAnswer__SelectAll>
-    Select all that apply:
-  </MultipleChoiceAnswer__SelectAll>
   <Option
     key="1"
     option={


### PR DESCRIPTION
### What is the context of this PR?
Have included exclusion for std label "Select all that apply" if an optional label has an entry.  This exclusion is used for both the author preview and AnswerHelper label on main page.

### How to review 
Create survey with a question and a mutually checkbox answer.
Leave the optional label for the first checkbox empty
The "Select all that apply" helper text should be visible above the first checkbox and this label is used in the preview tab in Author.
Go back to survey and add an optional label
The helper text should clear and the option label should only be used on the preview tab.
