### PR TITLE
Replaced removing all checkbox labels with just removing the second

### DIFF
--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -84,6 +84,7 @@ class Question {
       this.type = "MutuallyExclusive";
       this.mandatory = get("properties.required", mutuallyExclusive);
       this.answers = this.buildMutuallyExclusiveAnswers(mutuallyExclusive);
+      delete this.answers[1].label;
     } else if (question.totalValidation && question.totalValidation.enabled) {
       this.type = "Calculated";
       this.answers = this.buildAnswers(question.answers);
@@ -140,7 +141,6 @@ class Question {
 
   buildMutuallyExclusiveAnswers(mutuallyExclusive) {
     Object.assign(mutuallyExclusive.properties, { required: false });
-    delete mutuallyExclusive.label;
     const mutuallyExclusiveAnswer = new Answer({
       ...mutuallyExclusive,
       id: `${mutuallyExclusive.id}-exclusive`,


### PR DESCRIPTION
### Mutually exclusive optional label not showing in runner
When creating mutually exclusive checkboxes al the labels were removed which allowed runner to set an Or for the final checkbox but it meant the first checkbox group was also stripped of the label so runner used the Std one.  The blanket delete was removed and a delete for the 2nd label in the array - this potentially will have issues if other answer types precede the checkboxes.

### How to review 
Create a survey with mutually exclusive checkboxes leaving optional label blank.
Preview the survey in runner and observe the std label of "Select all that apply" is used.
Add an optional label for the checkboxes
Preview survey
Observe the new label is use.
