### PR TITLE
added migration for textarea max length

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -12,6 +12,7 @@ const migrations = [
   require("./addPublishStatusToQuestionnaire"),
   require("./addHistoryToQuestionnaire"),
   require("./addTypeToHistoryEvent"),
+  require("./updateDefaultTextAreaLength"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateDefaultTextAreaLength.js
+++ b/eq-author-api/migrations/updateDefaultTextAreaLength.js
@@ -1,0 +1,14 @@
+//This is an auto-generated file.  Do NOT modify the method signature.
+
+module.exports = function updateDefaultTextAreaLength(questionnaire) {
+  questionnaire.sections.forEach(section => {
+    section.pages.forEach(page => {
+      page.answers.forEach(answer => {
+        if (answer.type === "TextArea" && !answer.properties.maxLength) {
+          answer.properties.maxLength = "2000";
+        }
+      });
+    });
+  });
+  return questionnaire;
+};

--- a/eq-author-api/migrations/updateDefaultTextAreaLength.test.js
+++ b/eq-author-api/migrations/updateDefaultTextAreaLength.test.js
@@ -1,0 +1,76 @@
+const { cloneDeep } = require("lodash");
+const updateDefaultTextAreaLength = require("./updateDefaultTextAreaLength.js");
+
+const mockMaxlengthMissing = {
+  sections: [
+    {
+      pages: [
+        {
+          answers: [
+            {
+              type: "TextArea",
+              properties: {
+                required: false,
+              },
+            },
+            {
+              type: "Text",
+              properties: {
+                required: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const mockMaxlengthIncluded = {
+  sections: [
+    {
+      pages: [
+        {
+          answers: [
+            {
+              type: "TextArea",
+              properties: {
+                required: false,
+                maxLength: "100",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("updateDefaultTextAreaLength", () => {
+  // This test must remain for your migration to always work
+  it("should be deterministic", () => {
+    const questionnaire = mockMaxlengthMissing;
+    expect(updateDefaultTextAreaLength(cloneDeep(questionnaire))).toEqual(
+      updateDefaultTextAreaLength(cloneDeep(questionnaire))
+    );
+  });
+
+  it("should add a default max length if missing for textarea answers only", () => {
+    const questionnaire = mockMaxlengthMissing;
+    const result = updateDefaultTextAreaLength(cloneDeep(questionnaire));
+    expect(result.sections[0].pages[0].answers[0].properties.maxLength).toEqual(
+      "2000"
+    );
+    expect(
+      result.sections[0].pages[0].answers[1].properties.maxLength
+    ).toBeUndefined();
+  });
+
+  it("should not add a default max length for text area if it is already there ", () => {
+    const questionnaire = mockMaxlengthIncluded;
+    const result = updateDefaultTextAreaLength(cloneDeep(questionnaire));
+    expect(result.sections[0].pages[0].answers[0].properties.maxLength).toEqual(
+      "100"
+    );
+  });
+});


### PR DESCRIPTION
I've created a migration to add the default max_length when missing when opening older surveys.

To Test -
- visual review
- unit test run 'yarn test migrations'

Once deployed we can modify a survey in staging and check that it updates correctly.