### PR TITLE
API now controls db model outside of resolvers

### DIFF
--- a/eq-author-api/README.md
+++ b/eq-author-api/README.md
@@ -31,6 +31,7 @@ Changes to the application should hot reload via `nodemon`.
 | `RUNNER_SESSION_URL`    | Authentication URL for survey runner                                               | Yes      |
 | `PUBLISHER_URL`         | URL that produces valid survey runner JSON                                         | Yes      |
 | `FIREBASE_PROJECT_ID`   | The project ID for your Firebase project.                                          | Yes      |
+| `DATABASE`              | The name of the database to use; currently only supports 'dynamodb'                | Yes      |
 | `SECRETS_S3_BUCKET`     | Name of S3 bucket where secrets are stored                                         | No       |
 | `KEYS_FILE`             | Name of the keys file to use inside the bucket                                     | No       |
 | `AUTH_HEADER_KEY`       | Name of the header values that contains the Auth token                             | No       |

--- a/eq-author-api/db/datastore/datastore-dynamodb.js
+++ b/eq-author-api/db/datastore/datastore-dynamodb.js
@@ -9,9 +9,11 @@ const {
   justListFields,
   UserModel,
   CommentsModel,
-} = require("../db/models/DynamoDB");
+} = require("../models/DynamoDB");
 
-const { questionnaireCreationEvent } = require("./questionnaireEvents");
+const {
+  questionnaireCreationEvent,
+} = require("../../utils/questionnaireEvents");
 
 const omitTimestamps = questionnaire =>
   omit({ ...questionnaire }, ["updatedAt", "createdAt"]);
@@ -29,6 +31,10 @@ const saveModel = (model, options = {}) =>
       resolve(model);
     });
   });
+
+const saveMetadata = metadata => {
+  return saveModel(new QuestionnaireModel(metadata));
+};
 
 const createUser = user => {
   const { id, email, name, externalId, picture } = user;
@@ -299,4 +305,5 @@ module.exports = {
   getCommentsForQuestionnaire,
   saveComments,
   createComments,
+  saveMetadata,
 };

--- a/eq-author-api/db/datastore/datastore-dynamodb.test.js
+++ b/eq-author-api/db/datastore/datastore-dynamodb.test.js
@@ -63,14 +63,14 @@ describe("Datastore dynamo", () => {
 
     justListFields = jest.fn();
 
-    jest.doMock("../db/models/DynamoDB", () => ({
+    jest.doMock("../models/DynamoDB", () => ({
       dynamoose,
       QuestionnaireModel,
       QuestionnaireVersionsModel,
       justListFields,
     }));
 
-    saveQuestionnaire = require("./datastore").saveQuestionnaire;
+    saveQuestionnaire = require("./index").saveQuestionnaire;
   });
   afterEach(() => {
     jest.resetModules();

--- a/eq-author-api/db/datastore/index.js
+++ b/eq-author-api/db/datastore/index.js
@@ -1,0 +1,19 @@
+const DYNAMODB = "dynamodb";
+
+if (!process.env.DATABASE) {
+  throw new Error("Unset env var 'DATABASE'");
+}
+
+const databaseName = process.env.DATABASE;
+
+let datastore;
+
+if (databaseName === DYNAMODB) {
+  datastore = require("./datastore-dynamodb");
+}
+
+if (!datastore) {
+  throw new Error(`Unknown DATABASE env value: ${databaseName}`);
+}
+
+module.exports = datastore;

--- a/eq-author-api/db/datastore/index.test.js
+++ b/eq-author-api/db/datastore/index.test.js
@@ -1,0 +1,29 @@
+describe("Choosing which datastore to use", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  it("should error if the DATABASE env var is unset", () => {
+    delete process.env.DATABASE;
+
+    expect(process.env.DATABASE).toBeFalsy();
+    expect(() => require("./index")).toThrow();
+  });
+
+  it("should error if the value of env var DATABASE is not recognised", () => {
+    process.env.DATABASE = "this is not the env var you are looking for";
+    expect(process.env.DATABASE).toBeTruthy();
+    expect(process.env.DATABASE).toBe(
+      "this is not the env var you are looking for"
+    );
+    expect(() => require("./index")).toThrow();
+  });
+
+  it("should not error otherwise", () => {
+    expect(() => require("./index")).not.toThrow();
+    expect(typeof require("./index")).toBe("object");
+  });
+});

--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
+      - DATABASE=dynamodb
     entrypoint:
       - yarn
       - start:dev

--- a/eq-author-api/middleware/export.js
+++ b/eq-author-api/middleware/export.js
@@ -1,4 +1,4 @@
-const { getQuestionnaire } = require("../utils/datastore");
+const { getQuestionnaire } = require("../db/datastore");
 
 module.exports = async (req, res) => {
   const questionnaireId = req.params.questionnaireId;

--- a/eq-author-api/middleware/identification/getUserFromHeader.js
+++ b/eq-author-api/middleware/identification/getUserFromHeader.js
@@ -1,7 +1,7 @@
 const { isNil, isEmpty } = require("lodash/fp");
 const jwt = require("jsonwebtoken");
 
-const { getUserByExternalId } = require("../../utils/datastore");
+const { getUserByExternalId } = require("../../db/datastore");
 
 const verifyServiceRequest = require("./verifyServiceRequest");
 const verifyJwtToken = require("./verifyJwtToken");

--- a/eq-author-api/middleware/identification/index.test.js
+++ b/eq-author-api/middleware/identification/index.test.js
@@ -8,7 +8,7 @@ const keysFile = "./keys.test.yml";
 const keysYaml = yaml.safeLoad(fs.readFileSync(keysFile, "utf8"));
 const keysJson = JSON.parse(JSON.stringify(keysYaml));
 
-const { createUser } = require("../../utils/datastore");
+const { createUser } = require("../../db/datastore");
 
 jest.mock("./verifyJwtToken", () => {
   const jwt = require("jsonwebtoken");

--- a/eq-author-api/middleware/identification/upsertUser.js
+++ b/eq-author-api/middleware/identification/upsertUser.js
@@ -4,7 +4,7 @@ const {
   createUser,
   updateUser,
   getUserByExternalId,
-} = require("../../utils/datastore");
+} = require("../../db/datastore");
 
 const checkForUpdates = (user, existingUser) => {
   const pickRequiredFields = pick(["email", "name", "externalId", "picture"]);

--- a/eq-author-api/middleware/identification/upsertUser.test.js
+++ b/eq-author-api/middleware/identification/upsertUser.test.js
@@ -1,5 +1,5 @@
 const upsertUser = require("./upsertUser");
-const { getUserByExternalId, createUser } = require("../../utils/datastore");
+const { getUserByExternalId, createUser } = require("../../db/datastore");
 const defaultUser = require("../../tests/utils/mockUserPayload");
 
 const mockResponse = () => {

--- a/eq-author-api/middleware/import.js
+++ b/eq-author-api/middleware/import.js
@@ -1,5 +1,5 @@
 const uuid = require("uuid");
-const { createQuestionnaire } = require("../utils/datastore");
+const { createQuestionnaire } = require("../db/datastore");
 
 module.exports = async (req, res) => {
   const input = req.body;

--- a/eq-author-api/middleware/launch.js
+++ b/eq-author-api/middleware/launch.js
@@ -1,7 +1,7 @@
 const { generateToken } = require("../utils/jwtHelper");
 const { assign, isNil, isEmpty } = require("lodash");
 const { sanitiseMetadata } = require("../utils/sanitiseMetadata");
-const { getQuestionnaire } = require("../utils/datastore");
+const { getQuestionnaire } = require("../db/datastore");
 const { defaultTypeValueNames } = require("../utils/defaultMetadata");
 
 const buildClaims = metadata => {

--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -1,4 +1,4 @@
-const { getQuestionnaire } = require("../utils/datastore");
+const { getQuestionnaire } = require("../db/datastore");
 const { get } = require("lodash");
 
 module.exports = async (req, res, next) => {

--- a/eq-author-api/middleware/runQuestionnaireMigrations.js
+++ b/eq-author-api/middleware/runQuestionnaireMigrations.js
@@ -1,7 +1,7 @@
 const {
   saveQuestionnaire,
   getQuestionnaireMetaById,
-} = require("../utils/datastore");
+} = require("../db/datastore");
 const { merge } = require("lodash");
 
 module.exports = logger => ({ currentVersion, migrations }) => async (

--- a/eq-author-api/middleware/runQuestionnaireMigrations.test.js
+++ b/eq-author-api/middleware/runQuestionnaireMigrations.test.js
@@ -1,9 +1,9 @@
 const runQuestionnaireMigrations = require("./runQuestionnaireMigrations");
 const { buildContext } = require("../tests/utils/contextBuilder");
-require("../utils/datastore");
+require("../db/datastore");
 
-jest.mock("../utils/datastore", () => ({
-  ...require.requireActual("../utils/datastore"),
+jest.mock("../db/datastore", () => ({
+  ...require.requireActual("../db/datastore"),
   getQuestionnaireMetaById: jest.fn(() => ({
     createdAt: 1576579844508,
     createdBy: "a5570fd6-af3a-4192-8286-f66ac304ba39",

--- a/eq-author-api/migrations/updateCreatedByToUseUsers.test.js
+++ b/eq-author-api/migrations/updateCreatedByToUseUsers.test.js
@@ -4,7 +4,7 @@ const uuid = require("uuid");
 const updateCreatedByToUseUsers = require("./updateCreatedByToUseUsers.js");
 const { getUserByName, getUserByEmail } = updateCreatedByToUseUsers;
 
-const { createUser } = require("../utils/datastore");
+const { createUser } = require("../db/datastore");
 const { AUTHOR_TEAM_NAME } = require("../constants/authorTeamUser");
 
 describe("updateCreatedByToUseUsers", () => {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -81,18 +81,16 @@ const {
   createHistoryEvent,
   getQuestionnaireMetaById,
   createComments,
-  saveModel,
+  saveMetadata,
   saveComments,
   getCommentsForQuestionnaire,
-} = require("../../utils/datastore");
-
-const { QuestionnaireModel } = require("../../db/models/DynamoDB");
+} = require("../../db/datastore");
 
 const {
   createDefaultBusinessSurveyMetadata,
 } = require("../../utils/defaultMetadata");
 
-const { listQuestionnaires } = require("../../utils/datastore");
+const { listQuestionnaires } = require("../../db/datastore");
 
 const createQuestionnaireIntroduction = require("../../utils/createQuestionnaireIntroduction");
 
@@ -302,7 +300,7 @@ const Resolvers = {
 
       noteToUpdate.bodyText = input.bodyText;
 
-      await saveModel(new QuestionnaireModel(metadata));
+      await saveMetadata(metadata);
       return metadata.history;
     },
 
@@ -321,7 +319,7 @@ const Resolvers = {
 
       remove(metadata.history, item => item.id === noteToDelete.id);
 
-      await saveModel(new QuestionnaireModel(metadata));
+      await saveMetadata(metadata);
       return metadata.history;
     },
 

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -2,8 +2,8 @@ const pubsub = require("../../db/pubSub");
 const validateQuestionnaire = require("../../src/validation");
 const { enforceHasWritePermission } = require("./withPermissions");
 
-const { saveQuestionnaire } = require("../../utils/datastore");
-const { createHistoryEvent } = require("../../utils/datastore");
+const { saveQuestionnaire } = require("../../db/datastore");
+const { createHistoryEvent } = require("../../db/datastore");
 const { publishStatusEvent } = require("../../utils/questionnaireEvents");
 
 const {

--- a/eq-author-api/schema/tests/comments.test.js
+++ b/eq-author-api/schema/tests/comments.test.js
@@ -1,6 +1,6 @@
 const { buildContext } = require("../../tests/utils/contextBuilder");
 
-const { createQuestionnaire } = require("../../utils/datastore");
+const { createQuestionnaire } = require("../../db/datastore");
 
 const {
   deleteQuestionnaire,

--- a/eq-author-api/schema/tests/duplication.test.js
+++ b/eq-author-api/schema/tests/duplication.test.js
@@ -22,7 +22,7 @@ const {
   duplicatePage,
 } = require("../../tests/utils/contextBuilder/page");
 
-const { getQuestionnaire } = require("../../utils/datastore");
+const { getQuestionnaire } = require("../../db/datastore");
 
 describe("Duplication", () => {
   let ctx, questionnaire, section;

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -39,7 +39,7 @@ const {
 const { NUMBER } = require("../../constants/answerTypes");
 
 const defaultUser = require("../../tests/utils/mockUserPayload");
-const { createUser } = require("../../utils/datastore");
+const { createUser } = require("../../db/datastore");
 
 describe("questionnaire", () => {
   let ctx, questionnaire;

--- a/eq-author-api/scripts/bulkMigrateDataStore.js
+++ b/eq-author-api/scripts/bulkMigrateDataStore.js
@@ -5,7 +5,7 @@ const {
   getQuestionnaire,
   listQuestionnaires,
   saveQuestionnaire,
-} = require("../utils/datastore");
+} = require("../db/datastore");
 const { currentVersion, migrations } = require("../migrations");
 
 const bulkMigrateDataStore = async () => {

--- a/eq-author-api/scripts/import-json-to-dynamo.js
+++ b/eq-author-api/scripts/import-json-to-dynamo.js
@@ -2,7 +2,7 @@
 /* eslint-disable import/unambiguous,no-console */
 const fs = require("fs");
 const jsonPath = process.env.DATA_DIR;
-const { createQuestionnaire } = require("../utils/datastore");
+const { createQuestionnaire } = require("../db/datastore");
 
 if (!jsonPath) {
   throw new Error("Set DATA_DIR environment variable");

--- a/eq-author-api/scripts/import-users-to-table.js
+++ b/eq-author-api/scripts/import-users-to-table.js
@@ -2,7 +2,7 @@
 /* eslint-disable import/unambiguous,no-console */
 const fs = require("fs").promises;
 const jsonPath = process.env.DATA_DIR;
-const { createUser, getUserByExternalId } = require("../utils/datastore");
+const { createUser, getUserByExternalId } = require("../db/datastore");
 
 fs.readFile(jsonPath, "utf8").then(data => {
   const json = JSON.parse(data);

--- a/eq-author-api/scripts/test.sh
+++ b/eq-author-api/scripts/test.sh
@@ -48,4 +48,5 @@ FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID} \
 REDIS_DOMAIN_NAME=0.0.0.0 \
 REDIS_PORT=${REDIS_PORT} \
 SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit/ \
+DATABASE=dynamodb \
 yarn jest --runInBand --detectOpenHandles --forceExit "$@"

--- a/eq-author-api/server.js
+++ b/eq-author-api/server.js
@@ -137,7 +137,6 @@ const createApp = () => {
 
   logger.info(`🚀 Server ready at ${server.graphqlPath}`);
   logger.info(`🚀 Subscriptions ready at ${server.subscriptionsPath}`);
-
   return httpServer;
 };
 

--- a/eq-author-api/server.test.js
+++ b/eq-author-api/server.test.js
@@ -7,7 +7,7 @@ const { createSignedToken } = require("./tests/utils/createSignedToken");
 
 const { createApp } = require("./server");
 const { introspectionQuery } = require("graphql");
-const { createUser } = require("./utils/datastore");
+const { createUser } = require("./db/datastore");
 
 const tracer = require("./tracer");
 const apolloOpenTracing = require("apollo-opentracing");

--- a/eq-author-api/tests/utils/contextBuilder/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/index.js
@@ -2,7 +2,7 @@ const { SOCIAL } = require("../../../constants/questionnaireTypes");
 const { RADIO } = require("../../../constants/answerTypes");
 
 const { PUBLISHED, UNPUBLISHED } = require("../../../constants/publishStatus");
-const { createUser } = require("../../../utils/datastore");
+const { createUser } = require("../../../db/datastore");
 const {
   createQuestionnaire,
   publishQuestionnaire,

--- a/eq-author-api/tests/utils/executeQuery.js
+++ b/eq-author-api/tests/utils/executeQuery.js
@@ -3,7 +3,7 @@ const { graphql } = require("graphql");
 
 const graphqlTools = require("graphql-tools");
 
-const { getQuestionnaire } = require("../../utils/datastore");
+const { getQuestionnaire } = require("../../db/datastore");
 const validate = require("../../src/validation");
 
 const executableSchema = graphqlTools.makeExecutableSchema(schema);


### PR DESCRIPTION
### What is the context of this PR?
The database resolvers in the Author API need to be re-written to work with firestore. A configuration will need to be added to switch between which database is used.

### How to review 

I have removed all mentions of the database model from `base.js`, the resolvers, so that it is controled entierly from within `datastore.js`. The aformentioned file has been modified to allow switching between Firebase and Dynamodb via an environment variable, `DATABASE`.

Ensure the tests pass and usual Author behavior is unchanged.
