### PR TITLE
Add validation error for previous decimal answers

### DIFF
--- a/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/index.js
+++ b/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/index.js
@@ -131,7 +131,7 @@ export const UnwrappedGroupedAnswerProperties = ({
           </InlineField>
           {hasDecimalInconsistency && (
             <ValidationWarning icon={ValidationErrorIcon}>
-              Decimal number does not match the linked page
+              Enter a decimal that is the same as the associated question page.
             </ValidationWarning>
           )}
           {answerType === UNIT && (


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?

Updated the validation error for Decimals when using min/max on the previous answer
| Before  | After |
| ------------- | ------------- |
| <img width="310" alt="Screenshot 2020-04-02 at 08 55 53" src="https://user-images.githubusercontent.com/22731314/78270607-e5ba7880-74bf-11ea-94f5-41d9f2c21f6a.png"> | <img width="310" alt="Screenshot 2020-04-02 at 08 56 14" src="https://user-images.githubusercontent.com/22731314/78270632-ed7a1d00-74bf-11ea-8139-b49277eba2af.png">|



### How to review 
- Create a questionnaire
- Add two question pages
- First page add a **Number/Currency/Unit/Percentage** answer and set the decimal value to **2** 
- Second page add a **Number/Currency/Unit/Percentage** answer and set the **minimum** value to the Previous answer
    - **Answer type must match**
- Validation error under the decimal box reads - "Enter a decimal that is the same as the associated question page."

**Note:** If validation appears in the section navigation and not on the page. Switch to another section and back and the error message should appear.

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
