### PR TITLE
Remove saved search state

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
@@ -106,7 +106,6 @@ const Header = ({
 Header.propTypes = {
   onCreateQuestionnaire: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
-  searchTerm: PropTypes.string.isRequired,
   onToggleFilter: PropTypes.func.isRequired,
   isFiltered: PropTypes.bool.isRequired,
 };

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/Header/index.js
@@ -57,7 +57,6 @@ const SearchInput = styled(Input).attrs({
 const Header = ({
   onCreateQuestionnaire,
   onSearchChange,
-  searchTerm,
   onToggleFilter,
   isFiltered,
 }) => {
@@ -79,7 +78,7 @@ const Header = ({
           </VisuallyHidden>
           <SearchInput
             id="search"
-            defaultValue={searchTerm}
+            defaultValue={""}
             onChange={onSearchChangeDebounced}
           />
         </Search>

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.js
@@ -99,7 +99,6 @@ const QuestionnairesView = ({
       <Header
         onCreateQuestionnaire={onCreateQuestionnaire}
         onSearchChange={onSearchChange}
-        searchTerm={state.searchTerm}
         isFiltered={state.isFiltered}
         onToggleFilter={onToggleFilter}
       />

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
@@ -737,7 +737,7 @@ describe("QuestionnairesView", () => {
         expect(queryByText("Short 2")).toBeTruthy();
       });
 
-      it("should save the search term", () => {
+      it("should not save the search term", () => {
         const { getByLabelText, queryByText, unmount } = render(
           <QuestionnairesView {...props} />
         );
@@ -760,7 +760,7 @@ describe("QuestionnairesView", () => {
           <QuestionnairesView {...props} />
         );
 
-        expect(secondQueryByText("Questionnaire 2 Title")).toBeFalsy();
+        expect(secondQueryByText("Questionnaire 2 Title")).toBeTruthy();
         expect(secondQueryByText("Questionnaire 1 Title")).toBeTruthy();
       });
 

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
@@ -68,7 +68,7 @@ const buildState = state => {
 };
 
 export const buildInitialState = questionnaires => state =>
-  buildState({ ...state, apiQuestionnaires: questionnaires });
+  buildState({ ...state, searchTerm: "", apiQuestionnaires: questionnaires });
 
 export const ACTIONS = {
   CHANGE_PAGE: "CHANGE_PAGE",


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?
Search terms were being saved in local storage so that it was saved on refresh. 

The list of questionnaires was filtered based on this. Making it possible for all the questionnaires to be 'missing' due to saved search terms.

### How to review 
- Load Author
- Create two questionnaires with different names
- Search for questionnaire one
- Refresh the browser
- Questionnaire list should be populated with both questionnaires again
- Can repeat for the other questionnaire to double-check

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
