### PR TITLE
Change logo link to a instead of react-router

### DIFF
--- a/eq-author/src/components/Logo/index.js
+++ b/eq-author/src/components/Logo/index.js
@@ -1,12 +1,11 @@
 import React from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 
 import { colors } from "constants/theme";
 
 import logo from "./logo.svg";
 
-export const Logo = styled(Link)`
+export const Logo = styled.a`
   width: 6.5em;
   display: flex;
   align-items: center;
@@ -24,7 +23,7 @@ const LogoImg = styled.img`
 `;
 
 export default () => (
-  <Logo to="/" data-test="logo">
+  <Logo href="/" data-test="logo">
     <LogoImg src={logo} alt="Author" width={20} />
   </Logo>
 );


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?
Removed the `react-router` Link component for an anchor element.

The 'back to home' link present also uses an anchor element instead of a Link component which is the link that initially worked.
### How to review 
- Create a new questionnaire in local Author
- Remove part of the URL
- Hit enter
- Wait for React error stack to appear
- Close with **X** in the top right
- Click on the Author logo in the top left
- return to the homepage

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
