### PR TITLE
Cors now uses empty state where no whitelist is given

### DIFF
--- a/eq-author-api/server.js
+++ b/eq-author-api/server.js
@@ -41,23 +41,23 @@ const createApp = () => {
     ];
   }
 
-  let whitelist = [];
-
   if (process.env.CORS_WHITELIST) {
-    whitelist = process.env.CORS_WHITELIST.split(",");
+    const whitelist = process.env.CORS_WHITELIST.split(",");
+
+    const corsOptions = {
+      origin: function(origin, callback) {
+        if (whitelist.indexOf(origin) !== -1 || !origin) {
+          callback(null, true);
+        } else {
+          callback(new Error("Not allowed by CORS"));
+        }
+      },
+    };
+
+    app.use(cors(corsOptions));
+  } else {
+    app.use(cors());
   }
-
-  const corsOptions = {
-    origin: function(origin, callback) {
-      if (whitelist.indexOf(origin) !== -1 || !origin) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-  };
-
-  app.use(cors(corsOptions));
 
   app.use(
     "/graphql",


### PR DESCRIPTION
My earlier change breaks AWS because I was not allowing cors the chance to check if the domain the request came from is the same as the one it is hosted on, a.k.a server-to-server requests.

This change enables `cors()` to the empty state if we don't give it a whitelist, which works because AWS doesn't need one as it's all on the same domain. Where, GCP does as we are hosting the api on a different domain to the frontend. 