### PR TITLE
1183 validating on earliest and latest date range

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -29,7 +29,7 @@ const {
 
 const { DURATION_LOOKUP } = require("../../constants/durationTypes");
 
-const { DATE, DATE_RANGE } = require("../../constants/answerTypes");
+const { DATE } = require("../../constants/answerTypes");
 
 const pubsub = require("../../db/pubSub");
 const { getName } = require("../../utils/getName");
@@ -373,7 +373,6 @@ const Resolvers = {
     }),
     updateAnswer: createMutation((root, { input }, ctx) => {
       const answers = getAnswers(ctx);
-      console.log("\n\nanswers - - - -", answers);
       const additionalAnswers = flatMap(answers, answer =>
         answer.options
           ? flatMap(answer.options, option => option.additionalAnswer)
@@ -383,24 +382,13 @@ const Resolvers = {
       const answer = find(concat(answers, additionalAnswers), { id: input.id });
 
       merge(answer, input);
-      console.log("\n\nBASE.js answer in mutation - - - - - - ", answer);
+
       if (answer.type === DATE && !input.label && input.properties.format) {
         answer.validation.earliestDate.offset.unit =
           DURATION_LOOKUP[input.properties.format];
         answer.validation.latestDate.offset.unit =
           DURATION_LOOKUP[input.properties.format];
       }
-      if (
-        answer.type === DATE_RANGE &&
-        !input.label &&
-        input.properties.format
-      ) {
-        answer.validation.earliestDate.offset.unit =
-          DURATION_LOOKUP[input.properties.format];
-        answer.validation.latestDate.offset.unit =
-          DURATION_LOOKUP[input.properties.format];
-      }
-
       return answer;
     }),
     updateAnswersOfType: createMutation(
@@ -535,7 +523,6 @@ const Resolvers = {
     }),
     toggleValidationRule: createMutation((_, args, ctx) => {
       const validation = getValidationById(ctx, args.input.id);
-      console.log("\n\n Base.js - toggleValidationRule", validation);
 
       validation.enabled = args.input.enabled;
       const newValidation = Object.assign({}, validation);
@@ -546,9 +533,6 @@ const Resolvers = {
     }),
     updateValidationRule: createMutation((_, args, ctx) => {
       const validation = getValidationById(ctx, args.input.id);
-      // console.log("\n\nctx = = = = ", ctx);
-      // console.log("\n\nargs.input", args.input);
-      console.log("\n\n Base.js - updateValidationRule", validation);
 
       const { validationType } = validation;
       merge(validation, args.input[`${validationType}Input`]);
@@ -1077,25 +1061,12 @@ const Resolvers = {
   },
 
   DateValidation: {
-    earliestDate: answer => {
-      console.log(
-        "\n\nBASE.js - DateValidation - answer.validation.earliestDate",
-        answer.validation.earliestDate
-      );
-      return answer.validation.earliestDate;
-    },
-    // earliestDate: answer => answer.validation.earliestDate,
+    earliestDate: answer => answer.validation.earliestDate,
     latestDate: answer => answer.validation.latestDate,
   },
 
   DateRangeValidation: {
-    earliestDate: answer => {
-      console.log(
-        "\n\nBASE.js - DateRangeValidation - answer.validation.earliestDate",
-        answer.validation.earliestDate
-      );
-      return answer.validation.earliestDate;
-    },
+    earliestDate: answer => answer.validation.earliestDate,
     latestDate: answer => answer.validation.latestDate,
     minDuration: answer => answer.validation.minDuration,
     maxDuration: answer => answer.validation.maxDuration,
@@ -1150,20 +1121,12 @@ const Resolvers = {
       getAvailablePreviousAnswersForValidation(ctx, id),
     availableMetadata: ({ id }, args, ctx) =>
       getAvailableMetadataForValidation(ctx, id),
-    validationErrorInfo: ({ id }, args, ctx) => {
-      console.log(
-        "\n\nEarliestDateValidationRule - ctx.validationErrorInfo[VALIDATION]",
-        ctx.validationErrorInfo[VALIDATION][id]
-      );
-
-      return (
-        ctx.validationErrorInfo[VALIDATION][id] || {
-          id: id,
-          errors: [],
-          totalCount: 0,
-        }
-      );
-    },
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[VALIDATION][id] || {
+        id: id,
+        errors: [],
+        totalCount: 0,
+      },
   },
 
   LatestDateValidationRule: {
@@ -1181,56 +1144,32 @@ const Resolvers = {
       getAvailablePreviousAnswersForValidation(ctx, id),
     availableMetadata: ({ id }, args, ctx) =>
       getAvailableMetadataForValidation(ctx, id),
-    validationErrorInfo: ({ id }, args, ctx) => {
-      console.log(
-        "\n\nLatestDateValidationRule - ctx.validationErrorInfo[VALIDATION]",
-        ctx.validationErrorInfo[VALIDATION][id]
-      );
-
-      return (
-        ctx.validationErrorInfo[VALIDATION][id] || {
-          id: id,
-          errors: [],
-          totalCount: 0,
-        }
-      );
-    },
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[VALIDATION][id] || {
+        id: id,
+        errors: [],
+        totalCount: 0,
+      },
   },
 
   MinDurationValidationRule: {
     duration: ({ duration }) => duration,
-    validationErrorInfo: ({ id }, args, ctx) => {
-      console.log(
-        "\nMinDurationValidationRule - ctx.validationErrorInfo[VALIDATION][id]",
-        ctx.validationErrorInfo[VALIDATION][id]
-      );
-
-      return (
-        ctx.validationErrorInfo[VALIDATION][id] || {
-          id: id,
-          errors: [],
-          totalCount: 0,
-        }
-      );
-    },
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[VALIDATION][id] || {
+        id: id,
+        errors: [],
+        totalCount: 0,
+      },
   },
 
   MaxDurationValidationRule: {
     duration: ({ duration }) => duration,
-    validationErrorInfo: ({ id }, args, ctx) => {
-      console.log(
-        "\n\nMaxDurationValidationRule - ctx.validationErrorInfo[VALIDATION][id]",
-        ctx.validationErrorInfo[VALIDATION][id]
-      );
-
-      return (
-        ctx.validationErrorInfo[VALIDATION][id] || {
-          id: id,
-          errors: [],
-          totalCount: 0,
-        }
-      );
-    },
+    validationErrorInfo: ({ id }, args, ctx) =>
+      ctx.validationErrorInfo[VALIDATION][id] || {
+        id: id,
+        errors: [],
+        totalCount: 0,
+      },
   },
 
   TotalValidationRule: {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1153,22 +1153,10 @@ const Resolvers = {
 
   MinDurationValidationRule: {
     duration: ({ duration }) => duration,
-    validationErrorInfo: ({ id }, args, ctx) =>
-      ctx.validationErrorInfo[VALIDATION][id] || {
-        id: id,
-        errors: [],
-        totalCount: 0,
-      },
   },
 
   MaxDurationValidationRule: {
     duration: ({ duration }) => duration,
-    validationErrorInfo: ({ id }, args, ctx) =>
-      ctx.validationErrorInfo[VALIDATION][id] || {
-        id: id,
-        errors: [],
-        totalCount: 0,
-      },
   },
 
   TotalValidationRule: {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1038,8 +1038,6 @@ const Resolvers = {
           return "DateValidation";
         case "dateRange":
           return "DateRangeValidation";
-        // return "DateValidation";
-
         default:
           throw new TypeError(
             `Validation is not supported on '${answer.type}' answers`
@@ -1201,10 +1199,38 @@ const Resolvers = {
 
   MinDurationValidationRule: {
     duration: ({ duration }) => duration,
+    validationErrorInfo: ({ id }, args, ctx) => {
+      console.log(
+        "\nMinDurationValidationRule - ctx.validationErrorInfo[VALIDATION][id]",
+        ctx.validationErrorInfo[VALIDATION][id]
+      );
+
+      return (
+        ctx.validationErrorInfo[VALIDATION][id] || {
+          id: id,
+          errors: [],
+          totalCount: 0,
+        }
+      );
+    },
   },
 
   MaxDurationValidationRule: {
     duration: ({ duration }) => duration,
+    validationErrorInfo: ({ id }, args, ctx) => {
+      console.log(
+        "\n\nMaxDurationValidationRule - ctx.validationErrorInfo[VALIDATION][id]",
+        ctx.validationErrorInfo[VALIDATION][id]
+      );
+
+      return (
+        ctx.validationErrorInfo[VALIDATION][id] || {
+          id: id,
+          errors: [],
+          totalCount: 0,
+        }
+      );
+    },
   },
 
   TotalValidationRule: {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1014,7 +1014,6 @@ const Resolvers = {
   ValidationType: {
     __resolveType: answer => {
       const validationEntity = getValidationEntity(answer.type);
-      // console.log("validationEntity - - -= ", validationEntity);
       switch (validationEntity) {
         case "number":
           return "NumberValidation";

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -64,6 +64,11 @@ const getValidationById = (ctx, id) => {
       return validation;
     })
   );
+  console.log(
+    "\n\n UTILS - getValidationById - answers[0].validation",
+    answers[0].validation
+  );
+
   const pageValidations = compact(
     flatMap(getPages(ctx), page => page.totalValidation)
   );

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -64,10 +64,6 @@ const getValidationById = (ctx, id) => {
       return validation;
     })
   );
-  console.log(
-    "\n\n UTILS - getValidationById - answers[0].validation",
-    answers[0].validation
-  );
 
   const pageValidations = compact(
     flatMap(getPages(ctx), page => page.totalValidation)

--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -48,7 +48,12 @@ describe("validation", () => {
       {
         pages: [
           {
-            answers: [{ type: DATE }, { type: CURRENCY }, { type: UNIT }],
+            answers: [
+              { type: DATE },
+              { type: CURRENCY },
+              { type: UNIT },
+              { type: DATE_RANGE },
+            ],
           },
         ],
       },
@@ -337,7 +342,7 @@ describe("validation", () => {
     });
 
     describe("schema validation", () => {
-      it("Date - should return validation error when latest date is before earliest date", async () => {
+      it("should return validation error when latest date is before earliest date", async () => {
         const answer = await createAnswer(ctx, {
           questionPageId: page.id,
           type: DATE,
@@ -655,9 +660,51 @@ describe("validation", () => {
           value: 0,
           unit: "Days",
         },
-        relativePosition: "Before",
+        relativePosition: "After",
       };
     });
+
+    // describe("schema validation", () => {
+    //   it.only("should return validation error when latest date is before earliest date", async () => {
+    //     const answer = await createAnswer(ctx, {
+    //       questionPageId: page.id,
+    //       type: "DateRange",
+    //     });
+    //     const validation = await queryValidation(ctx, answer.id);
+    //     await toggleValidation(ctx, {
+    //       id: validation.earliestDate.id,
+    //       enabled: true,
+    //     });
+    //     await toggleValidation(ctx, {
+    //       id: validation.latestDate.id,
+    //       enabled: true,
+    //     });
+    //     await updateValidation(ctx, {
+    //       id: validation.earliestDate.id,
+    //       earliestDateInput: {
+    //         ...params,
+    //         relativePosition: "Before",
+    //         custom: "2016-01-20",
+    //       },
+    //     });
+    //     await updateValidation(ctx, {
+    //       id: validation.latestDate.id,
+    //       latestDateInput: {
+    //         ...params,
+    //         custom: "2016-01-25",
+    //       },
+    //     });
+
+    //     const result = await queryValidation(ctx, answer.id);
+
+    //     expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
+    //       { errorCode: ERR_EARLIEST_AFTER_LATEST },
+    //     ]);
+    //     expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
+    //       { errorCode: ERR_EARLIEST_AFTER_LATEST },
+    //     ]);
+    //   });
+    // });
 
     it("should default earliest and latest date to CUSTOM entityType", async () => {
       const answer = await createAnswer(ctx, {
@@ -669,44 +716,6 @@ describe("validation", () => {
       expect(validation.earliestDate.entityType).toEqual(CUSTOM);
       expect(validation.latestDate.entityType).toEqual(CUSTOM);
     });
-
-    // it("should return validation error when latest date is before earliest date", async () => {
-    //   const answer = await createAnswer(ctx, {
-    //     questionPageId: page.id,
-    //     type: DATE_RANGE,
-    //   });
-    //   const validation = await queryValidation(ctx, answer.id);
-    //   await toggleValidation(ctx, {
-    //     id: validation.earliestDate.id,
-    //     enabled: true,
-    //   });
-    //   await toggleValidation(ctx, {
-    //     id: validation.latestDate.id,
-    //     enabled: true,
-    //   });
-    //   await updateValidation(ctx, {
-    //     id: validation.earliestDate.id,
-    //     earliestDateInput: {
-    //       ...params,
-    //       custom: "2017-01-06",
-    //     },
-    //   });
-    //   await updateValidation(ctx, {
-    //     id: validation.latestDate.id,
-    //     latestDateInput: {
-    //       ...params,
-    //       custom: "2017-01-05",
-    //     },
-    //   });
-    //   const result = await queryValidation(ctx, answer.id);
-
-    //   expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
-    //     { errorCode: ERR_EARLIEST_AFTER_LATEST },
-    //   ]);
-    //   expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
-    //     { errorCode: ERR_EARLIEST_AFTER_LATEST },
-    //   ]);
-    // });
 
     it("should create earliest validation for DateRange answers", async () => {
       const answer = await createAnswer(ctx, {

--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -374,44 +374,6 @@ describe("validation", () => {
           { errorCode: ERR_EARLIEST_AFTER_LATEST },
         ]);
       });
-
-      it("Date Range - should return validation error when latest date is before earliest date", async () => {
-        const answer = await createAnswer(ctx, {
-          questionPageId: page.id,
-          type: DATE_RANGE,
-        });
-        const validation = await queryValidation(ctx, answer.id);
-        await toggleValidation(ctx, {
-          id: validation.earliestDate.id,
-          enabled: true,
-        });
-        await toggleValidation(ctx, {
-          id: validation.latestDate.id,
-          enabled: true,
-        });
-        await updateValidation(ctx, {
-          id: validation.earliestDate.id,
-          earliestDateInput: {
-            ...params,
-            custom: "2017-01-06",
-          },
-        });
-        await updateValidation(ctx, {
-          id: validation.latestDate.id,
-          latestDateInput: {
-            ...params,
-            custom: "2017-01-05",
-          },
-        });
-        const result = await queryValidation(ctx, answer.id);
-
-        expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
-          { errorCode: ERR_EARLIEST_AFTER_LATEST },
-        ]);
-        expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
-          { errorCode: ERR_EARLIEST_AFTER_LATEST },
-        ]);
-      });
     });
 
     it("should default earliest and latest date to NOW entityType", async () => {
@@ -690,10 +652,10 @@ describe("validation", () => {
       params = {
         entityType: CUSTOM,
         offset: {
-          value: 8,
-          unit: "Months",
+          value: 0,
+          unit: "Days",
         },
-        relativePosition: "After",
+        relativePosition: "Before",
       };
     });
 
@@ -707,6 +669,44 @@ describe("validation", () => {
       expect(validation.earliestDate.entityType).toEqual(CUSTOM);
       expect(validation.latestDate.entityType).toEqual(CUSTOM);
     });
+
+    // it("should return validation error when latest date is before earliest date", async () => {
+    //   const answer = await createAnswer(ctx, {
+    //     questionPageId: page.id,
+    //     type: DATE_RANGE,
+    //   });
+    //   const validation = await queryValidation(ctx, answer.id);
+    //   await toggleValidation(ctx, {
+    //     id: validation.earliestDate.id,
+    //     enabled: true,
+    //   });
+    //   await toggleValidation(ctx, {
+    //     id: validation.latestDate.id,
+    //     enabled: true,
+    //   });
+    //   await updateValidation(ctx, {
+    //     id: validation.earliestDate.id,
+    //     earliestDateInput: {
+    //       ...params,
+    //       custom: "2017-01-06",
+    //     },
+    //   });
+    //   await updateValidation(ctx, {
+    //     id: validation.latestDate.id,
+    //     latestDateInput: {
+    //       ...params,
+    //       custom: "2017-01-05",
+    //     },
+    //   });
+    //   const result = await queryValidation(ctx, answer.id);
+
+    //   expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
+    //     { errorCode: ERR_EARLIEST_AFTER_LATEST },
+    //   ]);
+    //   expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
+    //     { errorCode: ERR_EARLIEST_AFTER_LATEST },
+    //   ]);
+    // });
 
     it("should create earliest validation for DateRange answers", async () => {
       const answer = await createAnswer(ctx, {

--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -337,13 +337,50 @@ describe("validation", () => {
     });
 
     describe("schema validation", () => {
-      it("should return validation error when latest date is before earliest date", async () => {
+      it("Date - should return validation error when latest date is before earliest date", async () => {
         const answer = await createAnswer(ctx, {
           questionPageId: page.id,
           type: DATE,
         });
         const validation = await queryValidation(ctx, answer.id);
+        await toggleValidation(ctx, {
+          id: validation.earliestDate.id,
+          enabled: true,
+        });
+        await toggleValidation(ctx, {
+          id: validation.latestDate.id,
+          enabled: true,
+        });
+        await updateValidation(ctx, {
+          id: validation.earliestDate.id,
+          earliestDateInput: {
+            ...params,
+            custom: "2017-01-06",
+          },
+        });
+        await updateValidation(ctx, {
+          id: validation.latestDate.id,
+          latestDateInput: {
+            ...params,
+            custom: "2017-01-05",
+          },
+        });
+        const result = await queryValidation(ctx, answer.id);
 
+        expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
+          { errorCode: ERR_EARLIEST_AFTER_LATEST },
+        ]);
+        expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
+          { errorCode: ERR_EARLIEST_AFTER_LATEST },
+        ]);
+      });
+
+      it("Date Range - should return validation error when latest date is before earliest date", async () => {
+        const answer = await createAnswer(ctx, {
+          questionPageId: page.id,
+          type: DATE_RANGE,
+        });
+        const validation = await queryValidation(ctx, answer.id);
         await toggleValidation(ctx, {
           id: validation.earliestDate.id,
           enabled: true,
@@ -671,7 +708,7 @@ describe("validation", () => {
       expect(validation.latestDate.entityType).toEqual(CUSTOM);
     });
 
-    it("should create earliest validation for DateRange answers", async () => {
+    it.only("should create earliest validation for DateRange answers", async () => {
       const answer = await createAnswer(ctx, {
         questionPageId: page.id,
         type: DATE_RANGE,

--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -708,7 +708,7 @@ describe("validation", () => {
       expect(validation.latestDate.entityType).toEqual(CUSTOM);
     });
 
-    it.only("should create earliest validation for DateRange answers", async () => {
+    it("should create earliest validation for DateRange answers", async () => {
       const answer = await createAnswer(ctx, {
         questionPageId: page.id,
         type: DATE_RANGE,

--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -664,48 +664,6 @@ describe("validation", () => {
       };
     });
 
-    // describe("schema validation", () => {
-    //   it.only("should return validation error when latest date is before earliest date", async () => {
-    //     const answer = await createAnswer(ctx, {
-    //       questionPageId: page.id,
-    //       type: "DateRange",
-    //     });
-    //     const validation = await queryValidation(ctx, answer.id);
-    //     await toggleValidation(ctx, {
-    //       id: validation.earliestDate.id,
-    //       enabled: true,
-    //     });
-    //     await toggleValidation(ctx, {
-    //       id: validation.latestDate.id,
-    //       enabled: true,
-    //     });
-    //     await updateValidation(ctx, {
-    //       id: validation.earliestDate.id,
-    //       earliestDateInput: {
-    //         ...params,
-    //         relativePosition: "Before",
-    //         custom: "2016-01-20",
-    //       },
-    //     });
-    //     await updateValidation(ctx, {
-    //       id: validation.latestDate.id,
-    //       latestDateInput: {
-    //         ...params,
-    //         custom: "2016-01-25",
-    //       },
-    //     });
-
-    //     const result = await queryValidation(ctx, answer.id);
-
-    //     expect(result.earliestDate.validationErrorInfo.errors).toMatchObject([
-    //       { errorCode: ERR_EARLIEST_AFTER_LATEST },
-    //     ]);
-    //     expect(result.latestDate.validationErrorInfo.errors).toMatchObject([
-    //       { errorCode: ERR_EARLIEST_AFTER_LATEST },
-    //     ]);
-    //   });
-    // });
-
     it("should default earliest and latest date to CUSTOM entityType", async () => {
       const answer = await createAnswer(ctx, {
         questionPageId: page.id,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -367,6 +367,7 @@ type MinDurationValidationRule implements ValidationRule {
   id: ID!
   enabled: Boolean!
   duration: Duration!
+  validationErrorInfo: ValidationErrorInfo
 }
 
 type MaxDurationValidationRule implements ValidationRule {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -374,6 +374,7 @@ type MaxDurationValidationRule implements ValidationRule {
   id: ID!
   enabled: Boolean!
   duration: Duration!
+  validationErrorInfo: ValidationErrorInfo
 }
 
 type Duration {

--- a/eq-author-api/src/validation/customKeywords/index.js
+++ b/eq-author-api/src/validation/customKeywords/index.js
@@ -5,5 +5,6 @@ module.exports = ajv => {
   require("./calculatedSummaryUnitConsistency")(ajv);
   require("./linkedDecimalValidation")(ajv);
   require("./validateLatestAfterEarliest")(ajv);
+  require("./validateDuration")(ajv);
   require("./textLengthInRange")(ajv);
 };

--- a/eq-author-api/src/validation/customKeywords/validateDuration.js
+++ b/eq-author-api/src/validation/customKeywords/validateDuration.js
@@ -1,4 +1,3 @@
-// const moment = require("moment");
 const {
   ERR_EARLIEST_AFTER_LATEST,
 } = require("../../../constants/validationErrorCodes");

--- a/eq-author-api/src/validation/customKeywords/validateDuration.js
+++ b/eq-author-api/src/validation/customKeywords/validateDuration.js
@@ -6,38 +6,11 @@ const {
 module.exports = function(ajv) {
   ajv.addKeyword("validateDuration", {
     $data: true,
-    validate: function isValid(
-      otherFields,
-      entityData,
-      fieldValue,
-      dataPath
-      // parentData
-    ) {
+    validate: function isValid(otherFields, entityData, fieldValue, dataPath) {
       isValid.errors = [];
 
-      // const translationMatrix = {
-      //   Before: data =>
-      //     moment(data.custom)
-      //       .subtract(data.offset.value, data.offset.unit)
-      //       .unix(),
-      //   After: data =>
-      //     moment(data.custom)
-      //       .add(data.offset.value, data.offset.unit)
-      //       .unix(),
-      // };
+      const valid = true;
 
-      // const a = translationMatrix[otherFields.relativePosition](otherFields);
-      // const b = translationMatrix[parentData.relativePosition](parentData);
-      // console.log("\n\na = = = = ", a);
-      // console.log("\n\nb = = = = ", b);
-
-      const isLatest = dataPath.split("/").includes("maxDuration");
-      // console.log('\n\ndataPath.split("/")', dataPath.split("/"));
-      // console.log("\n\ndataPath - - - ", dataPath);
-      console.log("\n\nisLatest - - - ", isLatest);
-      console.log("WERE HERHEJERJEJREJE KER EKR ERKEREKR EKR Ekkkkk!!!!!!");
-      // const valid = isLatest ? a < b : a > b;
-      const valid = false;
       if (!valid) {
         isValid.errors = [
           {

--- a/eq-author-api/src/validation/customKeywords/validateDuration.js
+++ b/eq-author-api/src/validation/customKeywords/validateDuration.js
@@ -1,0 +1,57 @@
+// const moment = require("moment");
+const {
+  ERR_EARLIEST_AFTER_LATEST,
+} = require("../../../constants/validationErrorCodes");
+
+module.exports = function(ajv) {
+  ajv.addKeyword("validateDuration", {
+    $data: true,
+    validate: function isValid(
+      otherFields,
+      entityData,
+      fieldValue,
+      dataPath
+      // parentData
+    ) {
+      isValid.errors = [];
+
+      // const translationMatrix = {
+      //   Before: data =>
+      //     moment(data.custom)
+      //       .subtract(data.offset.value, data.offset.unit)
+      //       .unix(),
+      //   After: data =>
+      //     moment(data.custom)
+      //       .add(data.offset.value, data.offset.unit)
+      //       .unix(),
+      // };
+
+      // const a = translationMatrix[otherFields.relativePosition](otherFields);
+      // const b = translationMatrix[parentData.relativePosition](parentData);
+      // console.log("\n\na = = = = ", a);
+      // console.log("\n\nb = = = = ", b);
+
+      const isLatest = dataPath.split("/").includes("maxDuration");
+      // console.log('\n\ndataPath.split("/")', dataPath.split("/"));
+      // console.log("\n\ndataPath - - - ", dataPath);
+      console.log("\n\nisLatest - - - ", isLatest);
+      console.log("WERE HERHEJERJEJREJE KER EKR ERKEREKR EKR Ekkkkk!!!!!!");
+      // const valid = isLatest ? a < b : a > b;
+      const valid = false;
+      if (!valid) {
+        isValid.errors = [
+          {
+            keyword: "errorMessage",
+            dataPath,
+            message: ERR_EARLIEST_AFTER_LATEST,
+            params: {},
+          },
+        ];
+
+        return false;
+      }
+
+      return true;
+    },
+  });
+};

--- a/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
+++ b/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
@@ -28,10 +28,17 @@ module.exports = function(ajv) {
 
       const a = translationMatrix[otherFields.relativePosition](otherFields);
       const b = translationMatrix[parentData.relativePosition](parentData);
+      // console.log("\n\na = = = = ", a);
+      // console.log("\n\nb = = = = ", b);
 
       const isLatest = dataPath.split("/").includes("latestDate");
 
+      // console.log("\n\ndataPath - - - ", dataPath);
+      // console.log("\n\nisLatest - - - ", isLatest);
+
       const valid = isLatest ? a < b : a > b;
+
+      // console.log("\n\nvalid ? = = = = ", valid);
 
       if (!valid) {
         isValid.errors = [

--- a/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
+++ b/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
@@ -28,17 +28,17 @@ module.exports = function(ajv) {
 
       const a = translationMatrix[otherFields.relativePosition](otherFields);
       const b = translationMatrix[parentData.relativePosition](parentData);
+
       // console.log("\n\na = = = = ", a);
       // console.log("\n\nb = = = = ", b);
 
       const isLatest = dataPath.split("/").includes("latestDate");
 
+      // console.log('\n\ndataPath.split("/")', dataPath.split("/"));
       // console.log("\n\ndataPath - - - ", dataPath);
       // console.log("\n\nisLatest - - - ", isLatest);
 
       const valid = isLatest ? a < b : a > b;
-
-      // console.log("\n\nvalid ? = = = = ", valid);
 
       if (!valid) {
         isValid.errors = [

--- a/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
+++ b/eq-author-api/src/validation/customKeywords/validateLatestAfterEarliest.js
@@ -29,14 +29,7 @@ module.exports = function(ajv) {
       const a = translationMatrix[otherFields.relativePosition](otherFields);
       const b = translationMatrix[parentData.relativePosition](parentData);
 
-      // console.log("\n\na = = = = ", a);
-      // console.log("\n\nb = = = = ", b);
-
       const isLatest = dataPath.split("/").includes("latestDate");
-
-      // console.log('\n\ndataPath.split("/")', dataPath.split("/"));
-      // console.log("\n\ndataPath - - - ", dataPath);
-      // console.log("\n\nisLatest - - - ", isLatest);
 
       const valid = isLatest ? a < b : a > b;
 

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -25,6 +25,10 @@ require("ajv-keywords")(ajv, "select");
 
 const validate = ajv.addSchema(schemas.slice(1)).compile(schemas[0]);
 
+// console.log("\n\najv - - - - - - - - - - - - - ", ajv);
+// console.log("\n\nvalidate = = = ", validate);
+// console.log("\n\nschemas - - - ", schemas[1].definitions);
+
 const convertObjectType = objectType => {
   switch (objectType) {
     case "additionalAnswer":
@@ -82,6 +86,8 @@ module.exports = questionnaire => {
     );
     object.totalCount = totalErrors;
 
+    // console.log("\n\nobject------------", object);
+
     return object;
   };
 
@@ -103,6 +109,8 @@ module.exports = questionnaire => {
   const errorMessages = validate.errors.filter(
     err => err.keyword === "errorMessage"
   );
+  // console.log("\n\nvalidate.errors - - ", validate.errors);
+  // console.log("\n\nerrorMessages", errorMessages);
 
   const transformedMessages = uniqBy(errorMessages, "dataPath")
     .map(error => {
@@ -177,6 +185,8 @@ module.exports = questionnaire => {
             ...errorInfo,
           };
         }
+        // console.log("\n\nstructure - - - - ", structure);
+
         return structure;
       },
       {
@@ -190,5 +200,6 @@ module.exports = questionnaire => {
         totalCount: errorMessages.length,
       }
     );
+
   return removeDuplicateCounts(transformedMessages);
 };

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -109,8 +109,7 @@ module.exports = questionnaire => {
   const errorMessages = validate.errors.filter(
     err => err.keyword === "errorMessage"
   );
-  console.log("\n\nvalidate.errors - - ", validate.errors);
-  console.log("\n\nerrorMessages", errorMessages);
+  // console.log("\n\nerrorMessages", errorMessages);
 
   const transformedMessages = uniqBy(errorMessages, "dataPath")
     .map(error => {

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -25,10 +25,6 @@ require("ajv-keywords")(ajv, "select");
 
 const validate = ajv.addSchema(schemas.slice(1)).compile(schemas[0]);
 
-// console.log("\n\najv - - - - - - - - - - - - - ", ajv);
-// console.log("\n\nvalidate = = = ", validate);
-// console.log("\n\nschemas - - - ", schemas[1].definitions);
-
 const convertObjectType = objectType => {
   switch (objectType) {
     case "additionalAnswer":
@@ -86,8 +82,6 @@ module.exports = questionnaire => {
     );
     object.totalCount = totalErrors;
 
-    // console.log("\n\nobject------------", object);
-
     return object;
   };
 
@@ -109,7 +103,6 @@ module.exports = questionnaire => {
   const errorMessages = validate.errors.filter(
     err => err.keyword === "errorMessage"
   );
-  // console.log("\n\nerrorMessages", errorMessages);
 
   const transformedMessages = uniqBy(errorMessages, "dataPath")
     .map(error => {
@@ -184,7 +177,6 @@ module.exports = questionnaire => {
             ...errorInfo,
           };
         }
-        // console.log("\n\nstructure - - - - ", structure);
 
         return structure;
       },

--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -109,8 +109,8 @@ module.exports = questionnaire => {
   const errorMessages = validate.errors.filter(
     err => err.keyword === "errorMessage"
   );
-  // console.log("\n\nvalidate.errors - - ", validate.errors);
-  // console.log("\n\nerrorMessages", errorMessages);
+  console.log("\n\nvalidate.errors - - ", validate.errors);
+  console.log("\n\nerrorMessages", errorMessages);
 
   const transformedMessages = uniqBy(errorMessages, "dataPath")
     .map(error => {

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -5,6 +5,7 @@ const {
   UNIT,
   PERCENTAGE,
   DATE,
+  DATE_RANGE,
 } = require("../../constants/answerTypes");
 
 const {

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -343,9 +343,10 @@ describe("schema validation", () => {
       });
     });
 
-    describe("date answers", () => {
-      it("Date - should validate that latest date is always after earlier date", () => {
-        const answer = {
+    describe("all date answers", () => {
+      let answer;
+      beforeEach(() => {
+        answer = {
           id: "a1",
           type: "Date",
           label: "some answer",
@@ -379,7 +380,7 @@ describe("schema validation", () => {
           },
         };
 
-        const questionnaire = {
+        questionnaire = {
           id: "q1",
           sections: [
             {
@@ -393,162 +394,106 @@ describe("schema validation", () => {
             },
           ],
         };
-        const pageErrors = validation(questionnaire);
-
-        expect(
-          pageErrors.validation[answer.validation.earliestDate.id].errors
-        ).toHaveLength(1);
-        expect(pageErrors.totalCount).toBe(1);
       });
-
-      it("Date - should not validate if one of the two is disabled", () => {
-        ["earliestDate", "latestDate", "none"].forEach(entity => {
-          const answer = {
-            id: "a1",
-            type: DATE,
-            label: "some answer",
-            validation: {
-              earliestDate: {
-                id: "123",
-                enabled: entity === "earliestDate",
-                custom: "2019-06-23",
-                inclusive: true,
-                entityType: "Custom",
-                previousAnswer: null,
-              },
-              latestDate: {
-                id: "321",
-                enabled: entity === "latestDate",
-                custom: "2019-06-23",
-                inclusive: true,
-                entityType: "Custom",
-                previousAnswer: null,
-              },
-            },
-          };
-
-          const questionnaire = {
-            id: "q1",
-            sections: [
-              {
-                id: "s1",
-                pages: [
-                  {
-                    id: "p1",
-                    answers: [answer],
-                  },
-                ],
-              },
-            ],
-          };
+      describe("date only answers", () => {
+        it("should validate that latest date is always after earlier date", () => {
           const pageErrors = validation(questionnaire);
 
-          expect(pageErrors.validation).toMatchObject({});
-          expect(pageErrors.totalCount).toBe(0);
+          expect(
+            pageErrors.validation[answer.validation.earliestDate.id].errors
+          ).toHaveLength(1);
+          expect(
+            pageErrors.validation[answer.validation.earliestDate.id].errors[0]
+              .errorCode
+          ).toEqual("ERR_EARLIEST_AFTER_LATEST");
+          expect(pageErrors.totalCount).toBe(1);
+        });
+
+        it("should not validate if one of the two is disabled", () => {
+          ["earliestDate", "latestDate", "none"].forEach(entity => {
+            const answer = {
+              id: "a1",
+              type: DATE,
+              label: "some answer",
+              validation: {
+                earliestDate: {
+                  id: "123",
+                  enabled: entity === "earliestDate",
+                  custom: "2019-06-23",
+                  inclusive: true,
+                  entityType: "Custom",
+                  previousAnswer: null,
+                },
+                latestDate: {
+                  id: "321",
+                  enabled: entity === "latestDate",
+                  custom: "2019-06-23",
+                  inclusive: true,
+                  entityType: "Custom",
+                  previousAnswer: null,
+                },
+              },
+            };
+
+            questionnaire.sections[0].pages[0].answers = [answer];
+
+            const pageErrors = validation(questionnaire);
+
+            expect(pageErrors.validation).toMatchObject({});
+            expect(pageErrors.totalCount).toBe(0);
+          });
         });
       });
 
-      it("Date Range - should validate that latest date is always after earlier date", () => {
-        const answer = {
-          id: "a1",
-          type: DATE_RANGE,
-          label: "some answer",
-          validation: {
-            earliestDate: {
-              id: "123",
-              enabled: true,
-              custom: "2019-08-12",
-              inclusive: true,
-              entityType: "Custom",
-              previousAnswer: null,
-              offset: {
-                value: 1,
-                unit: "Years",
-              },
-              relativePosition: "After",
-            },
-            latestDate: {
-              id: "321",
-              enabled: true,
-              custom: "2019-08-11",
-              inclusive: true,
-              entityType: "Custom",
-              previousAnswer: null,
-              offset: {
-                value: 3,
-                unit: "Days",
-              },
-              relativePosition: "Before",
-            },
-          },
-        };
+      describe("date range answers", () => {
+        it("Date Range - should validate that latest date is always after earlier date", () => {
+          questionnaire.sections[0].pages[0].answers = [answer];
 
-        const questionnaire = {
-          id: "q1",
-          sections: [
-            {
-              id: "s1",
-              pages: [
-                {
-                  id: "p1",
-                  answers: [answer],
-                },
-              ],
-            },
-          ],
-        };
-        const pageErrors = validation(questionnaire);
-
-        expect(
-          pageErrors.validation[answer.validation.earliestDate.id].errors
-        ).toHaveLength(1);
-        expect(pageErrors.totalCount).toBe(1);
-      });
-
-      it("Date Range - should not validate if one of the two is disabled", () => {
-        ["earliestDate", "latestDate", "none"].forEach(entity => {
-          const answer = {
-            id: "a1",
-            type: DATE,
-            label: "some answer",
-            validation: {
-              earliestDate: {
-                id: "123",
-                enabled: entity === "earliestDate",
-                custom: "2019-06-23",
-                inclusive: true,
-                entityType: "Custom",
-                previousAnswer: null,
-              },
-              latestDate: {
-                id: "321",
-                enabled: entity === "latestDate",
-                custom: "2019-06-23",
-                inclusive: true,
-                entityType: "Custom",
-                previousAnswer: null,
-              },
-            },
-          };
-
-          const questionnaire = {
-            id: "q1",
-            sections: [
-              {
-                id: "s1",
-                pages: [
-                  {
-                    id: "p1",
-                    answers: [answer],
-                  },
-                ],
-              },
-            ],
-          };
           const pageErrors = validation(questionnaire);
 
-          expect(pageErrors.validation).toMatchObject({});
-          expect(pageErrors.totalCount).toBe(0);
+          expect(
+            pageErrors.validation[answer.validation.earliestDate.id].errors
+          ).toHaveLength(1);
+          expect(
+            pageErrors.validation[answer.validation.earliestDate.id].errors[0]
+              .errorCode
+          ).toEqual("ERR_EARLIEST_AFTER_LATEST");
+          expect(pageErrors.totalCount).toBe(1);
+        });
+
+        it("Date Range - should not validate if one of the two is disabled", () => {
+          ["earliestDate", "latestDate", "none"].forEach(entity => {
+            const answer = {
+              id: "a1",
+              type: DATE_RANGE,
+              label: "some answer",
+              validation: {
+                earliestDate: {
+                  id: "123",
+                  enabled: entity === "earliestDate",
+                  custom: "2019-06-23",
+                  inclusive: true,
+                  entityType: "Custom",
+                  previousAnswer: null,
+                },
+                latestDate: {
+                  id: "321",
+                  enabled: entity === "latestDate",
+                  custom: "2019-06-23",
+                  inclusive: true,
+                  entityType: "Custom",
+                  previousAnswer: null,
+                },
+              },
+            };
+
+            questionnaire.sections[0].pages[0].answers = [answer];
+
+            const pageErrors = validation(questionnaire);
+
+            expect(pageErrors.validation).toMatchObject({});
+            expect(pageErrors.totalCount).toBe(0);
+          });
         });
       });
     });

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -5,7 +5,7 @@ const {
   UNIT,
   PERCENTAGE,
   DATE,
-  DATE_RANGE,
+  // DATE_RANGE,
 } = require("../../constants/answerTypes");
 
 const {

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -5,7 +5,7 @@ const {
   UNIT,
   PERCENTAGE,
   DATE,
-  // DATE_RANGE,
+  DATE_RANGE,
 } = require("../../constants/answerTypes");
 
 const {
@@ -344,7 +344,7 @@ describe("schema validation", () => {
     });
 
     describe("date answers", () => {
-      it("should validate that latest date is always after earlier date", () => {
+      it("Date - should validate that latest date is always after earlier date", () => {
         const answer = {
           id: "a1",
           type: "Date",
@@ -401,7 +401,111 @@ describe("schema validation", () => {
         expect(pageErrors.totalCount).toBe(1);
       });
 
-      it("should not validate if one of the two is disabled", () => {
+      it("Date - should not validate if one of the two is disabled", () => {
+        ["earliestDate", "latestDate", "none"].forEach(entity => {
+          const answer = {
+            id: "a1",
+            type: DATE,
+            label: "some answer",
+            validation: {
+              earliestDate: {
+                id: "123",
+                enabled: entity === "earliestDate",
+                custom: "2019-06-23",
+                inclusive: true,
+                entityType: "Custom",
+                previousAnswer: null,
+              },
+              latestDate: {
+                id: "321",
+                enabled: entity === "latestDate",
+                custom: "2019-06-23",
+                inclusive: true,
+                entityType: "Custom",
+                previousAnswer: null,
+              },
+            },
+          };
+
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                pages: [
+                  {
+                    id: "p1",
+                    answers: [answer],
+                  },
+                ],
+              },
+            ],
+          };
+          const pageErrors = validation(questionnaire);
+
+          expect(pageErrors.validation).toMatchObject({});
+          expect(pageErrors.totalCount).toBe(0);
+        });
+      });
+
+      it("Date Range - should validate that latest date is always after earlier date", () => {
+        const answer = {
+          id: "a1",
+          type: DATE_RANGE,
+          label: "some answer",
+          validation: {
+            earliestDate: {
+              id: "123",
+              enabled: true,
+              custom: "2019-08-12",
+              inclusive: true,
+              entityType: "Custom",
+              previousAnswer: null,
+              offset: {
+                value: 1,
+                unit: "Years",
+              },
+              relativePosition: "After",
+            },
+            latestDate: {
+              id: "321",
+              enabled: true,
+              custom: "2019-08-11",
+              inclusive: true,
+              entityType: "Custom",
+              previousAnswer: null,
+              offset: {
+                value: 3,
+                unit: "Days",
+              },
+              relativePosition: "Before",
+            },
+          },
+        };
+
+        const questionnaire = {
+          id: "q1",
+          sections: [
+            {
+              id: "s1",
+              pages: [
+                {
+                  id: "p1",
+                  answers: [answer],
+                },
+              ],
+            },
+          ],
+        };
+        const pageErrors = validation(questionnaire);
+
+        expect(
+          pageErrors.validation[answer.validation.earliestDate.id].errors
+        ).toHaveLength(1);
+        expect(pageErrors.totalCount).toBe(1);
+      });
+
+      it("Date Range - should not validate if one of the two is disabled", () => {
         ["earliestDate", "latestDate", "none"].forEach(entity => {
           const answer = {
             id: "a1",

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -332,6 +332,28 @@
                       }
                     }
                   }
+                },
+                {
+                  "properties": {
+                    "minDuration": {
+                      "properties": {
+                        "enabled": {
+                          "const": true
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "maxDuration": {
+                      "properties": {
+                        "enabled": {
+                          "const": true
+                        }
+                      }
+                    }
+                  }
                 }
               ]
             },
@@ -356,6 +378,26 @@
                       }
                     }
                   }
+                },
+                "minDuration": {
+                  "type": "object",
+                  "properties": {
+                    "custom": {
+                      "validateDuration": {
+                        "$data": "2/maxDuration"
+                      }
+                    }
+                  }
+                },
+                "maxDuration": {
+                  "type": "object",
+                  "properties": {
+                    "custom": {
+                      "validateDuration": {
+                        "$data": "2/minDuration"
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -366,6 +408,73 @@
         }
       }
     },
+
+    "dateAnswerWithDuration": {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": ["DateRange"]
+          }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "validation": {
+            "if": {
+              "allOf": [
+                {
+                  "properties": {
+                    "minDuration": {
+                      "properties": {
+                        "enabled": {
+                          "const": true
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "maxDuration": {
+                      "properties": {
+                        "enabled": {
+                          "const": true
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "then": {
+              "properties": {
+                "minDuration": {
+                  "type": "object",
+                  "properties": {
+                    "validateDuration": {
+                      "$data": "2/maxDuration"
+                    }
+                  }
+                },
+                "maxDuration": {
+                  "type": "object",
+                  "properties": {
+                    "validateDuration": {
+                      "$data": "2/minDuration"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "$ref": "entities.json#/definitions/properties"
+          }
+        }
+      }
+    },
+
     "properties": {
       "type": "object",
       "properties": {

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -337,9 +337,8 @@
                   "properties": {
                     "minDuration": {
                       "properties": {
-                        "enabled": {
-                          "const": true
-                        }
+                        "enabled": { "const": true },
+                        "entityType": { "const": "Custom" }
                       }
                     }
                   }
@@ -348,9 +347,8 @@
                   "properties": {
                     "maxDuration": {
                       "properties": {
-                        "enabled": {
-                          "const": true
-                        }
+                        "enabled": { "const": true },
+                        "entityType": { "const": "Custom" }
                       }
                     }
                   }
@@ -396,72 +394,6 @@
                       "validateDuration": {
                         "$data": "2/minDuration"
                       }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "properties": {
-            "$ref": "entities.json#/definitions/properties"
-          }
-        }
-      }
-    },
-
-    "dateAnswerWithDuration": {
-      "if": {
-        "properties": {
-          "type": {
-            "enum": ["DateRange"]
-          }
-        }
-      },
-      "then": {
-        "type": "object",
-        "properties": {
-          "validation": {
-            "if": {
-              "allOf": [
-                {
-                  "properties": {
-                    "minDuration": {
-                      "properties": {
-                        "enabled": {
-                          "const": true
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "maxDuration": {
-                      "properties": {
-                        "enabled": {
-                          "const": true
-                        }
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            "then": {
-              "properties": {
-                "minDuration": {
-                  "type": "object",
-                  "properties": {
-                    "validateDuration": {
-                      "$data": "2/maxDuration"
-                    }
-                  }
-                },
-                "maxDuration": {
-                  "type": "object",
-                  "properties": {
-                    "validateDuration": {
-                      "$data": "2/minDuration"
                     }
                   }
                 }

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -402,26 +402,6 @@
                       }
                     }
                   }
-                },
-                {
-                  "properties": {
-                    "minDuration": {
-                      "properties": {
-                        "enabled": { "const": true },
-                        "entityType": { "const": "Custom" }
-                      }
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "maxDuration": {
-                      "properties": {
-                        "enabled": { "const": true },
-                        "entityType": { "const": "Custom" }
-                      }
-                    }
-                  }
                 }
               ]
             },
@@ -443,26 +423,6 @@
                     "custom": {
                       "validateLatestAfterEarliest": {
                         "$data": "2/earliestDate"
-                      }
-                    }
-                  }
-                },
-                "minDuration": {
-                  "type": "object",
-                  "properties": {
-                    "custom": {
-                      "validateDuration": {
-                        "$data": "2/maxDuration"
-                      }
-                    }
-                  }
-                },
-                "maxDuration": {
-                  "type": "object",
-                  "properties": {
-                    "custom": {
-                      "validateDuration": {
-                        "$data": "2/minDuration"
                       }
                     }
                   }

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -306,7 +306,7 @@
       "if": {
         "properties": {
           "type": {
-            "enum": ["Date", "DateRange"]
+            "enum": ["Date"]
           }
         }
       },
@@ -373,7 +373,7 @@
       "if": {
         "properties": {
           "type": {
-            "enum": ["Date", "DateRange"]
+            "enum": ["DateRange"]
           }
         }
       },

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -162,6 +162,9 @@
         },
         {
           "$ref": "entities.json#/definitions/dateAnswer"
+        },
+        {
+          "$ref": "entities.json#/definitions/dateRangeAnswer"
         }
       ]
     },
@@ -332,6 +335,73 @@
                       }
                     }
                   }
+                }
+              ]
+            },
+            "then": {
+              "properties": {
+                "earliestDate": {
+                  "type": "object",
+                  "properties": {
+                    "custom": {
+                      "validateLatestAfterEarliest": {
+                        "$data": "2/latestDate"
+                      }
+                    }
+                  }
+                },
+                "latestDate": {
+                  "type": "object",
+                  "properties": {
+                    "custom": {
+                      "validateLatestAfterEarliest": {
+                        "$data": "2/earliestDate"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "$ref": "entities.json#/definitions/properties"
+          }
+        }
+      }
+    },
+    "dateRangeAnswer": {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": ["Date", "DateRange"]
+          }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "validation": {
+            "if": {
+              "allOf": [
+                {
+                  "properties": {
+                    "earliestDate": {
+                      "properties": {
+                        "enabled": { "const": true },
+                        "entityType": { "const": "Custom" }
+                      }
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "latestDate": {
+                      "properties": {
+                        "enabled": { "const": true },
+                        "entityType": { "const": "Custom" }
+                      }
+                    }
+                  }
                 },
                 {
                   "properties": {
@@ -406,7 +476,6 @@
         }
       }
     },
-
     "properties": {
       "type": "object",
       "properties": {

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -303,7 +303,7 @@
       "if": {
         "properties": {
           "type": {
-            "enum": ["Date"]
+            "enum": ["Date", "DateRange"]
           }
         }
       },

--- a/eq-author-api/tests/utils/contextBuilder/validation/updateValidation.js
+++ b/eq-author-api/tests/utils/contextBuilder/validation/updateValidation.js
@@ -1,7 +1,7 @@
 const executeQuery = require("../../executeQuery");
 
 const updateValidationMutation = `
-  mutation ToggleValidationRule($input: UpdateValidationRuleInput!) {
+  mutation updateValidationRule($input: UpdateValidationRuleInput!) {
     updateValidationRule(input: $input) {
       id
       ...on MinValueValidationRule {

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -47,12 +47,12 @@ const defaultValidationEntityTypes = ({ type }) => ({
   latestDate: {
     entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
   },
-  // minDuration: {
-  //   entityType: CUSTOM,
-  // },
-  // maxDuration: {
-  //   entityType: CUSTOM,
-  // },
+  minDuration: {
+    entityType: CUSTOM,
+  },
+  maxDuration: {
+    entityType: CUSTOM,
+  },
 });
 
 Object.assign(module.exports, {

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -47,12 +47,12 @@ const defaultValidationEntityTypes = ({ type }) => ({
   latestDate: {
     entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
   },
-  minDuration: {
-    entityType: CUSTOM,
-  },
-  maxDuration: {
-    entityType: CUSTOM,
-  },
+  // minDuration: {
+  //   entityType: CUSTOM,
+  // },
+  // maxDuration: {
+  //   entityType: CUSTOM,
+  // },
 });
 
 Object.assign(module.exports, {

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -42,10 +42,10 @@ const defaultValidationEntityTypes = ({ type }) => ({
     entityType: CUSTOM,
   },
   earliestDate: {
-    entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
+    entityType: type === DATE ? NOW : CUSTOM,
   },
   latestDate: {
-    entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
+    entityType: type === DATE ? NOW : CUSTOM,
   },
   minDuration: {
     entityType: CUSTOM,

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -42,10 +42,10 @@ const defaultValidationEntityTypes = ({ type }) => ({
     entityType: CUSTOM,
   },
   earliestDate: {
-    entityType: type === DATE ? NOW : CUSTOM,
+    entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
   },
   latestDate: {
-    entityType: type === DATE ? NOW : CUSTOM,
+    entityType: type === DATE || type === DATE_RANGE ? NOW : CUSTOM,
   },
   minDuration: {
     entityType: CUSTOM,

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -1568,6 +1568,218 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
                                                             },
                                                           },
                                                         },
+                                                        Object {
+                                                          "directives": Array [],
+                                                          "kind": "InlineFragment",
+                                                          "selectionSet": Object {
+                                                            "kind": "SelectionSet",
+                                                            "selections": Array [
+                                                              Object {
+                                                                "alias": undefined,
+                                                                "arguments": Array [],
+                                                                "directives": Array [],
+                                                                "kind": "Field",
+                                                                "name": Object {
+                                                                  "kind": "Name",
+                                                                  "value": "earliestDate",
+                                                                },
+                                                                "selectionSet": Object {
+                                                                  "kind": "SelectionSet",
+                                                                  "selections": Array [
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "id",
+                                                                      },
+                                                                      "selectionSet": undefined,
+                                                                    },
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "validationErrorInfo",
+                                                                      },
+                                                                      "selectionSet": Object {
+                                                                        "kind": "SelectionSet",
+                                                                        "selections": Array [
+                                                                          Object {
+                                                                            "directives": Array [],
+                                                                            "kind": "FragmentSpread",
+                                                                            "name": Object {
+                                                                              "kind": "Name",
+                                                                              "value": "ValidationErrorInfo",
+                                                                            },
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                    },
+                                                                  ],
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "alias": undefined,
+                                                                "arguments": Array [],
+                                                                "directives": Array [],
+                                                                "kind": "Field",
+                                                                "name": Object {
+                                                                  "kind": "Name",
+                                                                  "value": "latestDate",
+                                                                },
+                                                                "selectionSet": Object {
+                                                                  "kind": "SelectionSet",
+                                                                  "selections": Array [
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "id",
+                                                                      },
+                                                                      "selectionSet": undefined,
+                                                                    },
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "validationErrorInfo",
+                                                                      },
+                                                                      "selectionSet": Object {
+                                                                        "kind": "SelectionSet",
+                                                                        "selections": Array [
+                                                                          Object {
+                                                                            "directives": Array [],
+                                                                            "kind": "FragmentSpread",
+                                                                            "name": Object {
+                                                                              "kind": "Name",
+                                                                              "value": "ValidationErrorInfo",
+                                                                            },
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                    },
+                                                                  ],
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "alias": undefined,
+                                                                "arguments": Array [],
+                                                                "directives": Array [],
+                                                                "kind": "Field",
+                                                                "name": Object {
+                                                                  "kind": "Name",
+                                                                  "value": "minDuration",
+                                                                },
+                                                                "selectionSet": Object {
+                                                                  "kind": "SelectionSet",
+                                                                  "selections": Array [
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "id",
+                                                                      },
+                                                                      "selectionSet": undefined,
+                                                                    },
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "validationErrorInfo",
+                                                                      },
+                                                                      "selectionSet": Object {
+                                                                        "kind": "SelectionSet",
+                                                                        "selections": Array [
+                                                                          Object {
+                                                                            "directives": Array [],
+                                                                            "kind": "FragmentSpread",
+                                                                            "name": Object {
+                                                                              "kind": "Name",
+                                                                              "value": "ValidationErrorInfo",
+                                                                            },
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                    },
+                                                                  ],
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "alias": undefined,
+                                                                "arguments": Array [],
+                                                                "directives": Array [],
+                                                                "kind": "Field",
+                                                                "name": Object {
+                                                                  "kind": "Name",
+                                                                  "value": "maxDuration",
+                                                                },
+                                                                "selectionSet": Object {
+                                                                  "kind": "SelectionSet",
+                                                                  "selections": Array [
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "id",
+                                                                      },
+                                                                      "selectionSet": undefined,
+                                                                    },
+                                                                    Object {
+                                                                      "alias": undefined,
+                                                                      "arguments": Array [],
+                                                                      "directives": Array [],
+                                                                      "kind": "Field",
+                                                                      "name": Object {
+                                                                        "kind": "Name",
+                                                                        "value": "validationErrorInfo",
+                                                                      },
+                                                                      "selectionSet": Object {
+                                                                        "kind": "SelectionSet",
+                                                                        "selections": Array [
+                                                                          Object {
+                                                                            "directives": Array [],
+                                                                            "kind": "FragmentSpread",
+                                                                            "name": Object {
+                                                                              "kind": "Name",
+                                                                              "value": "ValidationErrorInfo",
+                                                                            },
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                    },
+                                                                  ],
+                                                                },
+                                                              },
+                                                            ],
+                                                          },
+                                                          "typeCondition": Object {
+                                                            "kind": "NamedType",
+                                                            "name": Object {
+                                                              "kind": "Name",
+                                                              "value": "DateRangeValidation",
+                                                            },
+                                                          },
+                                                        },
                                                       ],
                                                     },
                                                   },
@@ -1761,7 +1973,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withValidations sh
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1656,
+        "end": 2507,
         "start": 0,
       },
     }

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -353,6 +353,20 @@ export const VALIDATION_QUERY = gql`
                       }
                     }
                   }
+                  ... on DateRangeValidation {
+                    earliestDate {
+                      id
+                      validationErrorInfo {
+                        ...ValidationErrorInfo
+                      }
+                    }
+                    latestDate {
+                      id
+                      validationErrorInfo {
+                        ...ValidationErrorInfo
+                      }
+                    }
+                  }
                 }
               }
               ... on MultipleChoiceAnswer {

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -366,6 +366,18 @@ export const VALIDATION_QUERY = gql`
                         ...ValidationErrorInfo
                       }
                     }
+                    # minDuration {
+                    #   id
+                    #   validationErrorInfo {
+                    #     ...ValidationErrorInfo
+                    #   }
+                    # }
+                    # maxDuration {
+                    #   id
+                    #   validationErrorInfo {
+                    #     ...ValidationErrorInfo
+                    #   }
+                    # }
                   }
                 }
               }

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -366,18 +366,18 @@ export const VALIDATION_QUERY = gql`
                         ...ValidationErrorInfo
                       }
                     }
-                    # minDuration {
-                    #   id
-                    #   validationErrorInfo {
-                    #     ...ValidationErrorInfo
-                    #   }
-                    # }
-                    # maxDuration {
-                    #   id
-                    #   validationErrorInfo {
-                    #     ...ValidationErrorInfo
-                    #   }
-                    # }
+                    minDuration {
+                      id
+                      validationErrorInfo {
+                        ...ValidationErrorInfo
+                      }
+                    }
+                    maxDuration {
+                      id
+                      validationErrorInfo {
+                        ...ValidationErrorInfo
+                      }
+                    }
                   }
                 }
               }

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.js
@@ -173,7 +173,6 @@ class AnswerValidation extends React.PureComponent {
   );
 
   render() {
-    // ------ Here, we know answer (this.props) already has NO validation Errors for DATE_RANGE - when it should ---------
     const { answer } = this.props;
     const validValidationTypes = validations[answer.type] || [];
     if (validValidationTypes.length === 0) {
@@ -181,10 +180,6 @@ class AnswerValidation extends React.PureComponent {
     }
 
     const validationErrors = [];
-
-    console.log("answer = = = = = ", answer);
-    // console.log("validations = = = ", validations);
-    // console.log("validValidationTypes - - - - ", validValidationTypes);
 
     return (
       <ValidationContext.Provider value={{ answer }}>
@@ -208,15 +203,11 @@ class AnswerValidation extends React.PureComponent {
           });
         })}
 
-        {console.log("validationErrors", validationErrors)}
-
         {validationErrors.length > 0 && (
           <PropertiesError icon={WarningIcon}>
-            {/* //------------------------needs looking at---------------- */}
             {answer.type === "Date" || answer.type === "DateRange"
               ? "Enter an earliest date that is before latest date"
               : "Enter a max value that is greater than min value"}
-            {/* //-------------------------------------------------------- */}
           </PropertiesError>
         )}
         <ModalWithNav

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.js
@@ -173,6 +173,7 @@ class AnswerValidation extends React.PureComponent {
   );
 
   render() {
+    // ------ Here, we know answer (this.props) already has NO validation Errors for DATE_RANGE - when it should ---------
     const { answer } = this.props;
     const validValidationTypes = validations[answer.type] || [];
     if (validValidationTypes.length === 0) {
@@ -180,6 +181,10 @@ class AnswerValidation extends React.PureComponent {
     }
 
     const validationErrors = [];
+
+    console.log("answer = = = = = ", answer);
+    // console.log("validations = = = ", validations);
+    // console.log("validValidationTypes - - - - ", validValidationTypes);
 
     return (
       <ValidationContext.Provider value={{ answer }}>
@@ -203,11 +208,15 @@ class AnswerValidation extends React.PureComponent {
           });
         })}
 
+        {console.log("validationErrors", validationErrors)}
+
         {validationErrors.length > 0 && (
           <PropertiesError icon={WarningIcon}>
-            {answer.type === "Date"
+            {/* //------------------------needs looking at---------------- */}
+            {answer.type === "Date" || answer.type === "DateRange"
               ? "Enter an earliest date that is before latest date"
               : "Enter a max value that is greater than min value"}
+            {/* //-------------------------------------------------------- */}
           </PropertiesError>
         )}
         <ModalWithNav

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
@@ -8,6 +8,7 @@ import {
   PERCENTAGE,
   UNIT,
   DATE,
+  DATE_RANGE,
 } from "constants/answer-types";
 import { CENTIMETRES } from "constants/unit-types";
 
@@ -232,11 +233,47 @@ describe("AnswerValidation", () => {
       ).toBeTruthy();
     });
 
-    it("should render an error message when earliest date is after latest date", () => {
+    it("Date Validation - should render an error message when earliest date is after latest date", () => {
       props = {
         answer: {
           id: "2",
           type: DATE,
+          validation: {
+            earliestDate: {
+              enabled: false,
+              validationErrorInfo: { errors: [] },
+            },
+            latestDate: {
+              enabled: false,
+              validationErrorInfo: { errors: [] },
+            },
+          },
+        },
+      };
+      const error = [
+        {
+          errorCode: "ERR_EARLIEST_AFTER_LATEST",
+          field: "custom",
+          id: "latestDate-2-b79f-4766-ba7a-3c3718bb9f26-custom",
+          type: "validation",
+          __typename: "ValidationError",
+        },
+      ];
+      props.answer.validation.earliestDate.validationErrorInfo.errors = error;
+      props.answer.validation.latestDate.validationErrorInfo.errors = error;
+
+      const { getByText } = rtlRender(<AnswerValidation {...props} />);
+
+      expect(
+        getByText("Enter an earliest date that is before latest date")
+      ).toBeTruthy();
+    });
+
+    it("DateRange validation - should render an error message when earliest date is after latest date", () => {
+      props = {
+        answer: {
+          id: "2",
+          type: DATE_RANGE,
           validation: {
             earliestDate: {
               enabled: false,

--- a/eq-author/src/App/page/Design/Validation/DateValidation.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation.js
@@ -121,7 +121,7 @@ export class UnwrappedDateValidation extends React.Component {
       onUpdate,
       onChangeUpdate,
     } = this.props;
-
+    console.log("this.props", this.props);
     const availableUnits = getUnits({ format, type });
 
     const validationPills = {

--- a/eq-author/src/App/page/Design/Validation/DateValidation.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation.js
@@ -121,7 +121,6 @@ export class UnwrappedDateValidation extends React.Component {
       onUpdate,
       onChangeUpdate,
     } = this.props;
-    console.log("this.props", this.props);
     const availableUnits = getUnits({ format, type });
 
     const validationPills = {

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -136,14 +136,14 @@ StatelessBasicAnswer.fragments = {
             enabled
             ...LatestDateValidationRule
           }
-          # minDuration {
-          #   enabled
-          #   ...MinDurationValidationRule
-          # }
-          # maxDuration {
-          #   enabled
-          #   ...MaxDurationValidationRule
-          # }
+          minDuration {
+            enabled
+            ...MinDurationValidationRule
+          }
+          maxDuration {
+            enabled
+            ...MaxDurationValidationRule
+          }
         }
       }
       validationErrorInfo {
@@ -155,6 +155,8 @@ StatelessBasicAnswer.fragments = {
     ${EarliestDateValidationRule}
     ${LatestDateValidationRule}
     ${ValidationErrorInfoFragment}
+    ${MinDurationValidationRule}
+    ${MaxDurationValidationRule}
   `,
 };
 

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -12,6 +12,8 @@ import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.
 import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import LatestDateValidationRule from "graphql/fragments/latest-date-validation-rule.graphql";
 import ValidationErrorInfoFragment from "graphql/fragments/validationErrorInfo.graphql";
+import MinDurationValidationRule from "graphql/fragments/min-duration-validation-rule.graphql";
+import MaxDurationValidationRule from "graphql/fragments/max-duration-validation-rule.graphql";
 
 import gql from "graphql-tag";
 
@@ -124,6 +126,24 @@ StatelessBasicAnswer.fragments = {
             enabled
             ...LatestDateValidationRule
           }
+        }
+        ... on DateRangeValidation {
+          earliestDate {
+            enabled
+            ...EarliestDateValidationRule
+          }
+          latestDate {
+            enabled
+            ...LatestDateValidationRule
+          }
+          # minDuration {
+          #   enabled
+          #   ...MinDurationValidationRule
+          # }
+          # maxDuration {
+          #   enabled
+          #   ...MaxDurationValidationRule
+          # }
         }
       }
       validationErrorInfo {

--- a/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/index.js
+++ b/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { flowRight, merge } from "lodash";
 import CustomPropTypes from "custom-prop-types";
 
-import { DATE } from "constants/answer-types";
+import { DATE, DATE_RANGE } from "constants/answer-types";
 import { DAYS, MONTHS, YEARS } from "constants/durations";
 
 import withUpdateAnswer from "App/page/Design/answers/withUpdateAnswer";
@@ -34,6 +34,7 @@ export class UnwrappedAnswerProperties extends React.Component {
       validation,
       type,
     } = this.props.answer;
+
     const properties = merge({}, currentProperties, {
       [propName]: value,
     });
@@ -44,6 +45,11 @@ export class UnwrappedAnswerProperties extends React.Component {
     });
 
     if (type === DATE && propName === "format") {
+      validation.earliestDate.offset.unit = durationsMap[value];
+      validation.latestDate.offset.unit = durationsMap[value];
+    }
+
+    if (type === DATE_RANGE && propName === "format") {
       validation.earliestDate.offset.unit = durationsMap[value];
       validation.latestDate.offset.unit = durationsMap[value];
     }

--- a/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/index.js
+++ b/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/index.js
@@ -44,12 +44,7 @@ export class UnwrappedAnswerProperties extends React.Component {
       properties,
     });
 
-    if (type === DATE && propName === "format") {
-      validation.earliestDate.offset.unit = durationsMap[value];
-      validation.latestDate.offset.unit = durationsMap[value];
-    }
-
-    if (type === DATE_RANGE && propName === "format") {
+    if ((type === DATE || type === DATE_RANGE) && propName === "format") {
       validation.earliestDate.offset.unit = durationsMap[value];
       validation.latestDate.offset.unit = durationsMap[value];
     }

--- a/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/max-duration-validation-rule.graphql
@@ -1,7 +1,17 @@
 fragment MaxDurationValidationRule on MaxDurationValidationRule {
+  id
+  duration {
+    value
+    unit
+  }
+  validationErrorInfo {
     id
-    duration {
-        value
-        unit
+    errors {
+      id
+      type
+      field
+      errorCode
     }
+    totalCount
+  }
 }

--- a/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
@@ -4,4 +4,14 @@ fragment MinDurationValidationRule on MinDurationValidationRule {
     value
     unit
   }
+  # validationErrorInfo {
+  #   id
+  #   errors {
+  #     id
+  #     type
+  #     field
+  #     errorCode
+  #   }
+  #   totalCount
+  # }
 }

--- a/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
+++ b/eq-author/src/graphql/fragments/min-duration-validation-rule.graphql
@@ -4,14 +4,14 @@ fragment MinDurationValidationRule on MinDurationValidationRule {
     value
     unit
   }
-  # validationErrorInfo {
-  #   id
-  #   errors {
-  #     id
-  #     type
-  #     field
-  #     errorCode
-  #   }
-  #   totalCount
-  # }
+  validationErrorInfo {
+    id
+    errors {
+      id
+      type
+      field
+      errorCode
+    }
+    totalCount
+  }
 }

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -5,7 +5,6 @@ const {
   CURRENCY,
   PERCENTAGE,
   DATE,
-  // DATE_RANGE,
   UNIT,
   DURATION,
   TEXTAREA,

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -54,7 +54,7 @@ class Answer {
         const { minValue, maxValue } = answer.validation;
         this.buildNumberValidation(minValue, "min_value");
         this.buildNumberValidation(maxValue, "max_value");
-      } else if (answer.type === DATE) {
+      } else if (answer.type === DATE || answer.type === DATE_RANGE) {
         const { earliestDate, latestDate } = answer.validation;
         this.minimum = Answer.buildDateValidation(earliestDate);
         this.maximum = Answer.buildDateValidation(latestDate);
@@ -73,7 +73,7 @@ class Answer {
       this.currency = "GBP";
     }
 
-    if (answer.type === DATE) {
+    if (answer.type === DATE || answer.type === DATE_RANGE) {
       const format = get(answer, "properties.format");
 
       if (format === "yyyy") {

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -5,6 +5,7 @@ const {
   CURRENCY,
   PERCENTAGE,
   DATE,
+  DATE_RANGE,
   UNIT,
   DURATION,
   TEXTAREA,

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -5,6 +5,7 @@ const {
   CURRENCY,
   PERCENTAGE,
   DATE,
+  DATE_RANGE,
   UNIT,
   DURATION,
   TEXTAREA,
@@ -55,6 +56,10 @@ class Answer {
         this.buildNumberValidation(minValue, "min_value");
         this.buildNumberValidation(maxValue, "max_value");
       } else if (answer.type === DATE) {
+        const { earliestDate, latestDate } = answer.validation;
+        this.minimum = Answer.buildDateValidation(earliestDate);
+        this.maximum = Answer.buildDateValidation(latestDate);
+      } else if (answer.type === DATE_RANGE) {
         const { earliestDate, latestDate } = answer.validation;
         this.minimum = Answer.buildDateValidation(earliestDate);
         this.maximum = Answer.buildDateValidation(latestDate);

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -59,11 +59,12 @@ class Answer {
         const { earliestDate, latestDate } = answer.validation;
         this.minimum = Answer.buildDateValidation(earliestDate);
         this.maximum = Answer.buildDateValidation(latestDate);
-      } else if (answer.type === DATE_RANGE) {
-        const { earliestDate, latestDate } = answer.validation;
-        this.minimum = Answer.buildDateValidation(earliestDate);
-        this.maximum = Answer.buildDateValidation(latestDate);
       }
+      // else if (answer.type === DATE_RANGE) {
+      //   const { earliestDate, latestDate } = answer.validation;
+      //   this.minimum = Answer.buildDateValidation(earliestDate);
+      //   this.maximum = Answer.buildDateValidation(latestDate);
+      // }
     }
 
     if (has(answer, "properties.decimals")) {

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -60,16 +60,6 @@ class Answer {
         this.minimum = Answer.buildDateValidation(earliestDate);
         this.maximum = Answer.buildDateValidation(latestDate);
       }
-      // else if (answer.type === DATE_RANGE) {
-      //   const { earliestDate, latestDate } = answer.validation;
-      //   this.minimum = Answer.buildDateValidation(earliestDate);
-      //   this.maximum = Answer.buildDateValidation(latestDate);
-      //   console.log(
-      //     "this.minimum, this.maximum-----",
-      //     this.minimum,
-      //     this.maximum
-      //   );
-      // }
     }
 
     if (has(answer, "properties.decimals")) {

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -64,6 +64,11 @@ class Answer {
       //   const { earliestDate, latestDate } = answer.validation;
       //   this.minimum = Answer.buildDateValidation(earliestDate);
       //   this.maximum = Answer.buildDateValidation(latestDate);
+      //   console.log(
+      //     "this.minimum, this.maximum-----",
+      //     this.minimum,
+      //     this.maximum
+      //   );
       // }
     }
 

--- a/eq-publisher/src/eq_schema/Answer.js
+++ b/eq-publisher/src/eq_schema/Answer.js
@@ -5,7 +5,7 @@ const {
   CURRENCY,
   PERCENTAGE,
   DATE,
-  DATE_RANGE,
+  // DATE_RANGE,
   UNIT,
   DURATION,
   TEXTAREA,


### PR DESCRIPTION
### What is the context of this PR?

Previously, When adding a date range answer - there was no validation occurring on date ranges and earliest /latest dates.
this PR is to fix validation on these

### How to review 

1. Create a new questionnaire and add a new question with 'Date Range' answer
2. Add an Earliest Date that is AFTER a Latest Date - you should get a validation message.
3. Add a Latest Date that is BEFORE an Earliest Date - you should get a validation message.
4. Correct these dates and the validation message should be gone!

5. Play around with 'Earliest Date is' XX days/months or years BEFORE  on 'Earliest Date.
this should trigger a validation message if that then makes the earliest date AFTER the latest date.

6. Do the same (ViseVersa) for 'Latest Date After' field.

EG - Earliest Date is 2nd Jan 2020 and latest date is 1st Jan 2020 - INVALID MSG
add 2 days or more to the 'Earliest date is before' field and validation message should clear.

EG - Earliest Date is 2nd Jan 2020 and latest date is 1st Jan 2020 - INVALID MSG
add 2 days or more to the 'Latest Date is After' field and validation message should clear.

There is currently NO validation on Duration Fields as that is part of another ticket!!
also - duration fields should NOT affect the validation on date range (currently) at all.

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
