### PR TITLE
Add refetch and correct error conditions

### DIFF
--- a/eq-author-api/src/validation/customKeywords/linkedDecimalValidation.js
+++ b/eq-author-api/src/validation/customKeywords/linkedDecimalValidation.js
@@ -1,4 +1,4 @@
-const { get, isNull } = require("lodash");
+const { get } = require("lodash");
 const getEntityKeyValue = require("../../../utils/getEntityByKeyValue");
 
 module.exports = function(ajv) {
@@ -39,9 +39,10 @@ module.exports = function(ajv) {
             referencedAnswer,
             "properties.decimals"
           );
+
           if (
-            !isNull(referencedDecimals) &&
-            !isNull(parentData.decimals) &&
+            referencedDecimals !== (null || undefined) &&
+            parentData.decimals !== (null || undefined) &&
             parentData.decimals !== referencedDecimals
           ) {
             isValid.errors = [

--- a/eq-author/src/App/page/Design/Validation/withToggleValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withToggleValidationRule.js
@@ -22,6 +22,7 @@ export const mapMutateToProps = ({ mutate }) => ({
   onToggleValidationRule: input =>
     mutate({
       variables: { input: filter(inputFilter, input) },
+      refetchQueries: ["GetPage"],
     }),
 });
 

--- a/eq-author/src/App/page/Design/Validation/withToggleValidationRule.test.js
+++ b/eq-author/src/App/page/Design/Validation/withToggleValidationRule.test.js
@@ -25,6 +25,7 @@ describe("withToggleValidationRule", () => {
     props.onToggleValidationRule(validationRule);
     expect(mutate).toHaveBeenCalledWith({
       variables: { input: validationRule },
+      refetchQueries: ["GetPage"],
     });
   });
 });

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
@@ -94,6 +94,7 @@ export const mapMutateToProps = ({ mutate }) => ({
   onUpdateValidationRule: input =>
     mutate({
       variables: { input: filter(INPUT_FRAGMENT, input) },
+      refetchQueries: ["GetPage"],
     }),
 });
 

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
@@ -30,6 +30,7 @@ describe("withUpdateValidationRule", () => {
           },
         },
       },
+      refetchQueries: ["GetPage"],
     });
   });
 });


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?

Make the decimal error message appear straight away instead of waiting for a refresh.

This was done by adding a graphql query refetch on answer update and correcting the conditions for adding the decimal error message to the error validation array.

It was just printing if it wasn't `null` but wasn't checking for `undefined`. 
It also was firing if the values were just not equal

This works but I'm wary of adding the refetch in case it bogs Author down with network requests.

### How to review 
- Create a questionnaire
- Add two question pages
- First page add a **Number/Currency/Unit/Percentage** answer and set the decimal value to **2** 
- Second page add a **Number/Currency/Unit/Percentage** answer and set the **minimum** value to the Previous answer
    - **Answer type must match**
- ~~Validation error under the decimal box reads - "Enter a decimal that is the same as the associated question page."~~
- Validation error should appear before pressing done on the validation modal

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
