### PR TITLE
Modified parameters to meet dependency upgrade

### DIFF
--- a/eq-author/scripts/start.js
+++ b/eq-author/scripts/start.js
@@ -75,7 +75,13 @@ checkBrowsers(paths.appPath, isInteractive)
     const appName = require(paths.appPackageJson).name;
     const urls = prepareUrls(protocol, HOST, port);
     // Create a webpack compiler that is configured with custom messages.
-    const compiler = createCompiler(webpack, config, appName, urls, useYarn);
+    const compiler = createCompiler({
+      webpack,
+      config,
+      appName,
+      urls,
+      useYarn,
+    });
     // Load proxy config
     const proxySetting = require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(proxySetting, paths.appPublic);


### PR DESCRIPTION
The latest dependency upgrades changed what the `createCompiler` function expects to an object rather than multiple variables. Now, the `master` branch will not compile however this PR fixes that.