### PR TITLE
Make all content pickers work the same

### DIFF
--- a/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/index.test.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/index.test.js
@@ -4,6 +4,8 @@ import { withRouter } from "react-router-dom";
 
 import { CollapsiblesEditor } from "./";
 
+jest.mock("components/RichTextEditor");
+
 describe("CollapsiblesEditor", () => {
   let props, Component;
   beforeEach(() => {

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -360,23 +360,7 @@ describe("SectionRoute", () => {
       expect(wrapper.find(`[data-test="error"]`).exists()).toBe(true);
     });
   });
-  // Changes to the modal have caused these tests to print out huge blocks of red error logs
-  // Below is the error log
-  // Uncommenting lines 194 - 222 makes this error not appear
-  // But it causes the modals to close as soon as they lose focus
-  // Which is what this branch is trying to solve
 
-  /*
-     Warning: An update to Query inside a test was not wrapped in act(...).
-      
-      When testing, code that causes React state updates should be wrapped into act(...):
-      
-      act(() => {
-          // fire events that update state 
-      });
-      // assert on the output 
-  */
-  // ---------------------------------------------------------------------------------------------
   describe("behaviour", () => {
     const mockHandlers = {
       onUpdateSection: jest.fn(),
@@ -455,7 +439,7 @@ describe("SectionRoute", () => {
       });
     });
 
-    it("allows new pages to be added", () => {
+    it("allows new pages to be added", async () => {
       const wrapper = render({
         loading: false,
         match,
@@ -472,9 +456,12 @@ describe("SectionRoute", () => {
         match.params.sectionId,
         0
       );
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
-    it("should disable move section button when one section", () => {
+    it("should disable move section button when one section", async () => {
       const wrapper = render({
         loading: false,
         match,
@@ -485,9 +472,12 @@ describe("SectionRoute", () => {
       expect(
         wrapper.find(`Button${byTestAttr("btn-move")}`).prop("disabled")
       ).toBe(true);
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
-    it("should enable move section button when multiple sections", () => {
+    it("should enable move section button when multiple sections", async () => {
       const questionnaire = {
         id: "1",
         navigation: true,
@@ -506,9 +496,12 @@ describe("SectionRoute", () => {
       expect(
         wrapper.find(`Button${byTestAttr("btn-move")}`).prop("disabled")
       ).toBe(false);
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
-    it("should call onDuplicateSection with the section id and position when the duplicate button is clicked", () => {
+    it("should call onDuplicateSection with the section id and position when the duplicate button is clicked", async () => {
       const questionnaire = {
         id: "1",
         navigation: true,
@@ -532,9 +525,12 @@ describe("SectionRoute", () => {
         sectionId: section.id,
         position: section.position + 1,
       });
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
-    it("should disable the preview tab when the introduction is disabled", () => {
+    it("should disable the preview tab when the introduction is disabled", async () => {
       const wrapper = render({
         loading: false,
         match,
@@ -549,9 +545,12 @@ describe("SectionRoute", () => {
       expect(editorLayout.props()).toMatchObject({
         preview: false,
       });
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
-    it("should enable the preview tab when the introduction is enabled", () => {
+    it("should enable the preview tab when the introduction is enabled", async () => {
       const wrapper = render({
         loading: false,
         match,
@@ -570,8 +569,9 @@ describe("SectionRoute", () => {
       expect(editorLayout.props()).toMatchObject({
         preview: true,
       });
+      await act(async () => {
+        await flushPromises();
+      });
     });
   });
-
-  // ---------------------------------------------------------------------------------------------
 });

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -360,7 +360,23 @@ describe("SectionRoute", () => {
       expect(wrapper.find(`[data-test="error"]`).exists()).toBe(true);
     });
   });
+  // Changes to the modal have caused these tests to print out huge blocks of red error logs
+  // Below is the error log
+  // Uncommenting lines 194 - 222 makes this error not appear
+  // But it causes the modals to close as soon as they lose focus
+  // Which is what this branch is trying to solve
 
+  /*
+     Warning: An update to Query inside a test was not wrapped in act(...).
+      
+      When testing, code that causes React state updates should be wrapped into act(...):
+      
+      act(() => {
+          // fire events that update state 
+      });
+      // assert on the output 
+  */
+  // ---------------------------------------------------------------------------------------------
   describe("behaviour", () => {
     const mockHandlers = {
       onUpdateSection: jest.fn(),
@@ -415,7 +431,7 @@ describe("SectionRoute", () => {
         { context, childContextTypes }
       );
 
-    it("ensures confirmation before delete", () => {
+    it("ensures confirmation before delete", async () => {
       const wrapper = render({
         loading: false,
         match,
@@ -434,6 +450,9 @@ describe("SectionRoute", () => {
         .simulate("click");
 
       expect(mockHandlers.onDeleteSection).toHaveBeenCalledWith(sectionId);
+      await act(async () => {
+        await flushPromises();
+      });
     });
 
     it("allows new pages to be added", () => {
@@ -553,4 +572,6 @@ describe("SectionRoute", () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------------------------
 });

--- a/eq-author/src/components/ContentPickerModal/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/ContentPickerModal/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ContentPickerModal should render 1`] = `
 <ContentPickerModal__StyledModal
   hasCloseButton={false}
+  onClose={[MockFunction]}
 >
   <ContentPickerModal__Flex>
     <BaseTabs
@@ -89,6 +90,7 @@ exports[`ContentPickerModal should show an error message when there is no metada
 exports[`ContentPickerModal should show answer and metadata tabs 1`] = `
 <ContentPickerModal__StyledModal
   hasCloseButton={false}
+  onClose={[MockFunction]}
 >
   <ContentPickerModal__Flex>
     <BaseTabs
@@ -141,6 +143,7 @@ exports[`ContentPickerModal should show answer and metadata tabs 1`] = `
 exports[`ContentPickerModal should show answer tab only 1`] = `
 <ContentPickerModal__StyledModal
   hasCloseButton={false}
+  onClose={[MockFunction]}
 >
   <ContentPickerModal__Flex>
     <BaseTabs
@@ -187,6 +190,7 @@ exports[`ContentPickerModal should show answer tab only 1`] = `
 exports[`ContentPickerModal should show metadata tab only 1`] = `
 <ContentPickerModal__StyledModal
   hasCloseButton={false}
+  onClose={[MockFunction]}
 >
   <ContentPickerModal__Flex>
     <BaseTabs

--- a/eq-author/src/components/ContentPickerModal/index.js
+++ b/eq-author/src/components/ContentPickerModal/index.js
@@ -209,7 +209,11 @@ class ContentPickerModal extends React.Component {
 
   render() {
     return (
-      <StyledModal isOpen={this.props.isOpen} hasCloseButton={false}>
+      <StyledModal
+        isOpen={this.props.isOpen}
+        onClose={this.props.onClose}
+        hasCloseButton={false}
+      >
         <Flex>
           <BaseTabs
             activeId={this.state.selectedTab}

--- a/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.js
+++ b/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.js
@@ -115,18 +115,23 @@ const AvailablePipingContentQuery = ({
   introductionId,
   children,
 }) => {
-  const { variables, query } = determineQuery({
-    questionnaireId,
-    pageId,
-    sectionId,
-    confirmationId,
-    introductionId,
-  });
-  return (
-    <Query query={query} variables={variables} fetchPolicy="network-only">
-      {children}
-    </Query>
-  );
+  if (pageId || sectionId || confirmationId || introductionId) {
+    const { variables, query } = determineQuery({
+      questionnaireId,
+      pageId,
+      sectionId,
+      confirmationId,
+      introductionId,
+    });
+    // console.log(variables, query, "please");
+    return (
+      <Query query={query} variables={variables} fetchPolicy="network-only">
+        {children}
+      </Query>
+    );
+  } else {
+    return null;
+  }
 };
 
 AvailablePipingContentQuery.propTypes = {

--- a/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.js
+++ b/eq-author/src/components/RichTextEditor/AvailablePipingContentQuery.js
@@ -115,23 +115,18 @@ const AvailablePipingContentQuery = ({
   introductionId,
   children,
 }) => {
-  if (pageId || sectionId || confirmationId || introductionId) {
-    const { variables, query } = determineQuery({
-      questionnaireId,
-      pageId,
-      sectionId,
-      confirmationId,
-      introductionId,
-    });
-    // console.log(variables, query, "please");
-    return (
-      <Query query={query} variables={variables} fetchPolicy="network-only">
-        {children}
-      </Query>
-    );
-  } else {
-    return null;
-  }
+  const { variables, query } = determineQuery({
+    questionnaireId,
+    pageId,
+    sectionId,
+    confirmationId,
+    introductionId,
+  });
+  return (
+    <Query query={query} variables={variables} fetchPolicy="network-only">
+      {children}
+    </Query>
+  );
 };
 
 AvailablePipingContentQuery.propTypes = {

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -55,15 +55,16 @@ export class Menu extends React.Component {
 
   state = {
     pickerContent: "",
+    isPickerOpen: false,
   };
 
   handleButtonClick = pickerContent => {
-    this.setState({ pickerContent });
+    this.setState({ pickerContent, isPickerOpen: true });
   };
 
   handlePickerClose = () => {
     this.setState({
-      pickerContent: "",
+      isPickerOpen: false,
     });
   };
 
@@ -83,7 +84,6 @@ export class Menu extends React.Component {
     } = this.props;
 
     const { pickerContent } = this.state;
-
     const data = pickerContent === METADATA ? metadataData : answerData;
 
     return (
@@ -122,7 +122,7 @@ export class Menu extends React.Component {
           </MenuButton>
         )}
         <ContentPicker
-          isOpen={Boolean(this.state.pickerContent)}
+          isOpen={this.state.isPickerOpen}
           data={data}
           startingSelectedAnswers={[]}
           onClose={this.handlePickerClose}
@@ -192,36 +192,35 @@ export const UnwrappedPipingMenu = ({
   match,
   ...otherProps
 }) => {
-  if (!canFocus) {
-    return (
-      <>
-        {allowableTypes.includes(ANSWER) && (
-          <MenuButton title="Pipe value" disabled data-test="piping-button">
-            <IconPiping />
-          </MenuButton>
-        )}
-        {allowableTypes.includes(METADATA) && (
-          <MenuButton
-            title="Pipe metadata"
-            disabled
-            data-test="piping-button-metadata"
-          >
-            <IconPipingMetadata />
-          </MenuButton>
-        )}
-        {allowableTypes.includes(VARIABLES) && (
-          <MenuButton
-            title="Pipe variable"
-            disabled
-            data-test="piping-button-variable"
-          >
-            <IconPipingVariable />
-          </MenuButton>
-        )}
-      </>
-    );
-  }
-
+  // if (!canFocus) {
+  //   return (
+  //     <>
+  //       {allowableTypes.includes(ANSWER) && (
+  //         <MenuButton title="Pipe value" disabled data-test="piping-button">
+  //           <IconPiping />
+  //         </MenuButton>
+  //       )}
+  //       {allowableTypes.includes(METADATA) && (
+  //         <MenuButton
+  //           title="Pipe metadata"
+  //           disabled
+  //           data-test="piping-button-metadata"
+  //         >
+  //           <IconPipingMetadata />
+  //         </MenuButton>
+  //       )}
+  //       {allowableTypes.includes(VARIABLES) && (
+  //         <MenuButton
+  //           title="Pipe variable"
+  //           disabled
+  //           data-test="piping-button-variable"
+  //         >
+  //           <IconPipingVariable />
+  //         </MenuButton>
+  //       )}
+  //     </>
+  //   );
+  // }
   return (
     <AvailablePipingContentQuery
       questionnaireId={match.params.questionnaireId}

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -82,7 +82,6 @@ export class Menu extends React.Component {
       canFocus,
       allowableTypes,
     } = this.props;
-
     const { pickerContent } = this.state;
     const data = pickerContent === METADATA ? metadataData : answerData;
 
@@ -192,35 +191,6 @@ export const UnwrappedPipingMenu = ({
   match,
   ...otherProps
 }) => {
-  // if (!canFocus) {
-  //   return (
-  //     <>
-  //       {allowableTypes.includes(ANSWER) && (
-  //         <MenuButton title="Pipe value" disabled data-test="piping-button">
-  //           <IconPiping />
-  //         </MenuButton>
-  //       )}
-  //       {allowableTypes.includes(METADATA) && (
-  //         <MenuButton
-  //           title="Pipe metadata"
-  //           disabled
-  //           data-test="piping-button-metadata"
-  //         >
-  //           <IconPipingMetadata />
-  //         </MenuButton>
-  //       )}
-  //       {allowableTypes.includes(VARIABLES) && (
-  //         <MenuButton
-  //           title="Pipe variable"
-  //           disabled
-  //           data-test="piping-button-variable"
-  //         >
-  //           <IconPipingVariable />
-  //         </MenuButton>
-  //       )}
-  //     </>
-  //   );
-  // }
   return (
     <AvailablePipingContentQuery
       questionnaireId={match.params.questionnaireId}

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -191,6 +191,35 @@ export const UnwrappedPipingMenu = ({
   match,
   ...otherProps
 }) => {
+  // if (!canFocus) {
+  //   return (
+  //     <>
+  //       {allowableTypes.includes(ANSWER) && (
+  //         <MenuButton title="Pipe value" disabled data-test="piping-button">
+  //           <IconPiping />
+  //         </MenuButton>
+  //       )}
+  //       {allowableTypes.includes(METADATA) && (
+  //         <MenuButton
+  //           title="Pipe metadata"
+  //           disabled
+  //           data-test="piping-button-metadata"
+  //         >
+  //           <IconPipingMetadata />
+  //         </MenuButton>
+  //       )}
+  //       {allowableTypes.includes(VARIABLES) && (
+  //         <MenuButton
+  //           title="Pipe variable"
+  //           disabled
+  //           data-test="piping-button-variable"
+  //         >
+  //           <IconPipingVariable />
+  //         </MenuButton>
+  //       )}
+  //     </>
+  //   );
+  // }
   return (
     <AvailablePipingContentQuery
       questionnaireId={match.params.questionnaireId}

--- a/eq-author/src/components/RichTextEditor/PipingMenu.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.js
@@ -191,35 +191,6 @@ export const UnwrappedPipingMenu = ({
   match,
   ...otherProps
 }) => {
-  // if (!canFocus) {
-  //   return (
-  //     <>
-  //       {allowableTypes.includes(ANSWER) && (
-  //         <MenuButton title="Pipe value" disabled data-test="piping-button">
-  //           <IconPiping />
-  //         </MenuButton>
-  //       )}
-  //       {allowableTypes.includes(METADATA) && (
-  //         <MenuButton
-  //           title="Pipe metadata"
-  //           disabled
-  //           data-test="piping-button-metadata"
-  //         >
-  //           <IconPipingMetadata />
-  //         </MenuButton>
-  //       )}
-  //       {allowableTypes.includes(VARIABLES) && (
-  //         <MenuButton
-  //           title="Pipe variable"
-  //           disabled
-  //           data-test="piping-button-variable"
-  //         >
-  //           <IconPipingVariable />
-  //         </MenuButton>
-  //       )}
-  //     </>
-  //   );
-  // }
   return (
     <AvailablePipingContentQuery
       questionnaireId={match.params.questionnaireId}

--- a/eq-author/src/components/RichTextEditor/PipingMenu.test.js
+++ b/eq-author/src/components/RichTextEditor/PipingMenu.test.js
@@ -119,26 +119,6 @@ describe("PipingMenu", () => {
     expect(wrapper.find(PIPING_BUTTON_VALUE).prop("disabled")).toBe(true);
   });
 
-  it("should render as disabled when it does not have focus", () => {
-    const wrapper = shallow(
-      <UnwrappedPipingMenu
-        match={{
-          params: {
-            questionnaireId: "4",
-            sectionId: "3",
-            pageId: "2",
-            confirmationId: "1",
-            introductionId: "5",
-          },
-        }}
-        canFocus={false}
-        allowableTypes={[ANSWER, METADATA, VARIABLES]}
-      />
-    );
-
-    expect(wrapper.find(PIPING_BUTTON_VALUE).prop("disabled")).toBe(true);
-  });
-
   it("should open the picker when clicked", () => {
     const wrapper = render();
     wrapper.find("[data-test='piping-button']").simulate("click");


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?

Made content pickers behave in the same way. That is:
- Close when you click the `X` usually found in the top right
- Close when Select/Submit clicked
- Close when 'Cancel' clicked
- Close when clicked off the content picker
- Remains open when clicking on another program or monitor screen etc

### How to test
- Create a questionnaire
- Test green highlighted modal's in the spreadsheet linked in the Trello ticket
- Markdown any modal's that do not meet the above requirements
- Make a quick pass over any other modal's that you think might not be listed

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
