### PR TITLE
1413 reset to version 1 on duplicated questionnaires

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
       - DATABASE=dynamodb
-      - FIRESTORE_EMULATOR_HOST=host.docker.internal:8090
+      - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api
     entrypoint:
@@ -49,7 +49,7 @@ services:
     environment:
       - FIRESTORE_PROJECT_ID=eq-author-api
     ports:
-      - 8090:8080
+      - 8070:8080
 
   dynamo:
     image: amazon/dynamodb-local

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -284,6 +284,7 @@ const Resolvers = {
         createdBy: ctx.user.id,
         editors: [],
         publishStatus: UNPUBLISHED,
+        surveyVersion: 1,
       };
       return createQuestionnaire(newQuestionnaire, ctx);
     },


### PR DESCRIPTION
### What is the context of this PR?

The Firestore emulator db for the API and the Survey Register's db run on the same port so they cannot be spun up together. In this PR, I have moved the Firestore emulator to a different port so that the entire app can be run at once.

Also, this PR makes it so that when duplicating a questionnaire that is above version 1 initialises the new questionnaire at version 1

### How to review 

* Create a new questionnaire; publish it and then make a change to force it to be version 2 (you can verify this on the History page)
* Duplicate that questionnaire and navigate to the History page; it should be initialised at version 1
* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
