### PR TITLE
1520 pipe unit answer types into questions

### DIFF
--- a/eq-author-api/constants/pipingAnswerTypes.js
+++ b/eq-author-api/constants/pipingAnswerTypes.js
@@ -7,4 +7,5 @@ module.exports.PIPING_ANSWER_TYPES = [
   type.PERCENTAGE,
   type.DATE,
   type.DATE_RANGE,
+  type.UNIT,
 ];

--- a/eq-author/src/graphql/fragments/available-answers.graphql
+++ b/eq-author/src/graphql/fragments/available-answers.graphql
@@ -4,6 +4,7 @@ fragment AvailableAnswers on Answer {
   secondaryLabel
   secondaryLabelDefault
   type
+  properties
   page {
     id
     displayName

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -33,7 +33,7 @@ const PIPE_TYPES = {
     retrieve: ({ id }, ctx) => getAnswer(ctx, id.toString()),
     render: ({ id }) => `answers['answer${id}']`,
     getType: ({ type }) => type,
-    getUnit: ({ properties }) => properties,
+    getUnit: ({ properties: { unit } }) => unit,
   },
   metadata: {
     retrieve: ({ id }, ctx) => getMetadata(ctx, id.toString()),
@@ -69,7 +69,7 @@ const convertElementToPipe = ($elem, ctx) => {
   let unitType;
 
   if (dataType === "Unit") {
-    unitType = pipeConfig.getUnit(entity).unit;
+    unitType = pipeConfig.getUnit(entity);
     return filter ? `{{ ${filter(output, unitType)} }}` : `{{ ${output} }}`;
   } else {
     return filter ? `{{ ${filter(output)} }}` : `{{ ${output} }}`;

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -58,7 +58,6 @@ const convertElementToPipe = ($elem, ctx) => {
   }
 
   const entity = pipeConfig.retrieve(elementData, ctx);
-
   if (!entity) {
     return "";
   }

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -25,7 +25,7 @@ const FILTER_MAP = {
   Currency: (value, unit = "GBP") => `format_currency(${value}, '${unit}')`,
   Date: value => `${value} | format_date`,
   DateRange: value => `${value} | format_date`,
-  Unit: (value, unit = "cm") => `format_unit(${value}, '${unit}')`,
+  Unit: (value, unit = "centimeter") => `format_unit('${unit}',${value})`,
 };
 
 const PIPE_TYPES = {
@@ -46,7 +46,9 @@ const PIPE_TYPES = {
 
 const convertElementToPipe = ($elem, ctx) => {
   const { piped, ...elementData } = $elem.data();
+
   const pipeConfig = PIPE_TYPES[piped];
+
   if (piped === "variable") {
     return pipeConfig.render();
   }
@@ -55,13 +57,21 @@ const convertElementToPipe = ($elem, ctx) => {
   }
 
   const entity = pipeConfig.retrieve(elementData, ctx);
+  console.log("\n\nentity = = =", entity);
+
   if (!entity) {
     return "";
   }
   const output = pipeConfig.render(entity);
+  console.log("\n\noutput - -", output);
+
   const dataType = pipeConfig.getType(entity);
 
+  console.log("\n\ndataType - - ", dataType);
+
   const filter = FILTER_MAP[dataType];
+
+  console.log("\n\nfilter - - ", filter);
 
   return filter ? `{{ ${filter(output)} }}` : `{{ ${output} }}`;
 };

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -25,6 +25,7 @@ const FILTER_MAP = {
   Currency: (value, unit = "GBP") => `format_currency(${value}, '${unit}')`,
   Date: value => `${value} | format_date`,
   DateRange: value => `${value} | format_date`,
+  Unit: (value, unit = "cm") => `format_unit(${value}, '${unit}')`,
 };
 
 const PIPE_TYPES = {

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -2,6 +2,8 @@ const cheerio = require("cheerio");
 const { flatMap, includes, compact } = require("lodash");
 const { unescapePiping } = require("./HTMLUtils");
 
+const { UNIT } = require("../constants/answerTypes");
+
 const getMetadata = (ctx, metadataId) =>
   ctx.questionnaireJson.metadata.find(({ id }) => id === metadataId);
 
@@ -67,7 +69,7 @@ const convertElementToPipe = ($elem, ctx) => {
   const filter = FILTER_MAP[dataType];
   let unitType;
 
-  if (dataType === "Unit") {
+  if (dataType === UNIT) {
     unitType = pipeConfig.getUnit(entity);
     return filter ? `{{ ${filter(output, unitType)} }}` : `{{ ${output} }}`;
   } else {

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -25,7 +25,7 @@ const FILTER_MAP = {
   Currency: (value, unit = "GBP") => `format_currency(${value}, '${unit}')`,
   Date: value => `${value} | format_date`,
   DateRange: value => `${value} | format_date`,
-  Unit: (value, unit = "centimeter") => `format_unit('${unit}',${value})`,
+  Unit: (value, unit) => `format_unit('${unit}',${value})`,
 };
 
 const PIPE_TYPES = {
@@ -33,6 +33,7 @@ const PIPE_TYPES = {
     retrieve: ({ id }, ctx) => getAnswer(ctx, id.toString()),
     render: ({ id }) => `answers['answer${id}']`,
     getType: ({ type }) => type,
+    getUnit: ({ properties }) => properties,
   },
   metadata: {
     retrieve: ({ id }, ctx) => getMetadata(ctx, id.toString()),
@@ -57,23 +58,22 @@ const convertElementToPipe = ($elem, ctx) => {
   }
 
   const entity = pipeConfig.retrieve(elementData, ctx);
-  console.log("\n\nentity = = =", entity);
 
   if (!entity) {
     return "";
   }
+
   const output = pipeConfig.render(entity);
-  console.log("\n\noutput - -", output);
-
   const dataType = pipeConfig.getType(entity);
-
-  console.log("\n\ndataType - - ", dataType);
-
   const filter = FILTER_MAP[dataType];
+  let unitType;
 
-  console.log("\n\nfilter - - ", filter);
-
-  return filter ? `{{ ${filter(output)} }}` : `{{ ${output} }}`;
+  if (dataType === "Unit") {
+    unitType = pipeConfig.getUnit(entity).unit;
+    return filter ? `{{ ${filter(output, unitType)} }}` : `{{ ${output} }}`;
+  } else {
+    return filter ? `{{ ${filter(output)} }}` : `{{ ${output} }}`;
+  }
 };
 
 const parseHTML = html => {

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -17,6 +17,7 @@ const createContext = (metadata = []) => ({
               { id: `3`, type: "DateRange" },
               { id: `4`, type: "Date" },
               { id: `5`, type: "Number" },
+              { id: `6`, type: "Unit", unit: "cm" },
             ],
           },
           {},
@@ -56,6 +57,7 @@ describe("convertPipes", () => {
       convertPipes(createContext())(createPipe({ pipeType: "Foo" }))
     ).toEqual("");
   });
+
   it("should handle empty answer in page", () => {
     expect(convertPipes(createContext())("<p></p>")).toEqual("<p></p>");
   });
@@ -114,6 +116,13 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "5" });
         expect(convertPipes(createContext())(html)).toEqual(
           "{{ answers['answer5'] | format_number }}"
+        );
+      });
+
+      it("should format Units answers with `format_unit`", () => {
+        const html = createPipe({ id: "6" });
+        expect(convertPipes(createContext())(html)).toEqual(
+          "{{ format_unit(answers['answer6'], 'cm') }}"
         );
       });
     });

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -1,6 +1,12 @@
 const convertPipes = require("../utils/convertPipes");
 const getAllAnswers = require("../utils/convertPipes").getAllAnswers;
-
+const {
+  CURRENCY,
+  DATE_RANGE,
+  DATE,
+  NUMBER,
+  UNIT,
+} = require("../constants/answerTypes");
 const createPipe = ({ pipeType = "answers", id = 1, text = "foo" } = {}) =>
   `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
@@ -13,13 +19,13 @@ const createContext = (metadata = []) => ({
           {
             answers: [
               { id: `1`, type: "Text" },
-              { id: `2`, type: "Currency" },
-              { id: `3`, type: "DateRange" },
-              { id: `4`, type: "Date" },
-              { id: `5`, type: "Number" },
+              { id: `2`, type: CURRENCY },
+              { id: `3`, type: DATE_RANGE },
+              { id: `4`, type: DATE },
+              { id: `5`, type: NUMBER },
               {
                 id: `6`,
-                type: "Unit",
+                type: UNIT,
                 properties: { required: false, decimals: 0, unit: "Metres" },
               },
             ],

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -20,7 +20,7 @@ const createContext = (metadata = []) => ({
               {
                 id: `6`,
                 type: "Unit",
-                properties: { required: false, decimals: 0, Unit: "Metres" },
+                properties: { required: false, decimals: 0, unit: "Metres" },
               },
             ],
           },

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -17,7 +17,11 @@ const createContext = (metadata = []) => ({
               { id: `3`, type: "DateRange" },
               { id: `4`, type: "Date" },
               { id: `5`, type: "Number" },
-              { id: `6`, type: "Unit", unit: "cm" },
+              {
+                id: `6`,
+                type: "Unit",
+                properties: { required: false, decimals: 0, Unit: "Metres" },
+              },
             ],
           },
           {},
@@ -122,7 +126,7 @@ describe("convertPipes", () => {
       it("should format Units answers with `format_unit`", () => {
         const html = createPipe({ id: "6" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ format_unit(answers['answer6'], 'cm') }}"
+          "{{ format_unit('Metres',answers['answer6']) }}"
         );
       });
     });

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -123,7 +123,7 @@ describe("convertPipes", () => {
         );
       });
 
-      it("should format Units answers with `format_unit`", () => {
+      it("should format Units answers with `format_unit` and includes the unit type", () => {
         const html = createPipe({ id: "6" });
         expect(convertPipes(createContext())(html)).toEqual(
           "{{ format_unit('Metres',answers['answer6']) }}"


### PR DESCRIPTION
### What is the context of this PR?

here we are adding units to piping in Author and publisher V2

### How to review 

* create a new questionnaire that has a unit answer and select a unit type in the right hand panel - eg 'Metres'

- create a 2nd question after this and 'pipe the unit answer into the Question title

- make sure you have eq-survey runner spun up using the following:
**_Banch_** - 1520 pipe unit answer types into questions survey runner 
then, ensure it can be viewed in Runner by pressing the **view survey** button

**to double check the formatting of the unit piping:**

- browse to http://localhost:9000/publish/+YOUR_QUESTOINNAIRE_ID
in the resulting JSON you should see your piping question in the following layout:
{{format_unit(‘Metres’, answers[‘answerYOUR_ANSWER|_ID’])}}

- copy the resultant JSON to Postman where you will send the following request:
localhost:9000/publish/validate/+YOUR_QUESTOINNAIRE_ID

if you have no validation errors - then all is gooD!

once you are happy with this PR - please give eq-survey-runner a tick too as it's part of this PR but a seperate repo - ta

https://github.com/ONSdigital/eq-survey-runner/pull/2559

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
