### PR TITLE
Return docker compose vals to old state

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -25,9 +25,8 @@ services:
       - DYNAMO_USER_TABLE_NAME=dev-author-users
       - DYNAMO_COMMENTS_TABLE_NAME=dev-author-comments
       - NODE_ENV=development
-      - RUNNER_SESSION_URL=http://staging-author-runner.eqbs.gcp.onsdigital.uk/session?token=
-      - CONVERSION_URL=http://docker.for.mac.localhost:9000/publish/
-      - PUBLISHER_URL=http://docker.for.mac.localhost:4000/convert/
+      - RUNNER_SESSION_URL=http://localhost:5000/session?token=
+      - PUBLISHER_URL=http://host.docker.internal:9000/publish/
       - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api
@@ -37,7 +36,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
-      - DATABASE=firestore
+      - DATABASE=dynamodb
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api


### PR DESCRIPTION
In a PR I've just merged I accidentally left the GCP configuration in the docker compose file where it should be the AWS version until we do the swap. 

This PR reverts that change so that devs can carry on working.