### PR TITLE
Default form_type for v3 compatability

### DIFF
--- a/eq-author-api/utils/sanitiseMetadata.js
+++ b/eq-author-api/utils/sanitiseMetadata.js
@@ -31,6 +31,7 @@ const defaultMetadata = (questionnaireId, tokenIssueTime, surveyUrl) => ({
   response_id: uuidv1(),
   schema_name: "test",
   language_code: "en",
+  form_type: "H",
 });
 
 module.exports.sanitiseMetadata = (metadata, questionnaireId) => {


### PR DESCRIPTION
As part of the move from V2 to V3, we removed the `form_type` metadata from the claims that would be sent to Runner as they dropped support for it in V3; I forgot to check if that'll still run on V2 and it doesn't.

V3 only supports three values for `form_type` so, for now, Martyn and I have agreed to default the value to `H` so that it's supported on both.