### PR TITLE
Updated summary page title label and error label

### DIFF
--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/index.test.js.snap
@@ -13,8 +13,8 @@ exports[`CalculatedSummaryPageEditor should render 1`] = `
           Array [
             Object {
               "field": "title",
-              "label": "Page title",
-              "requiredMsg": "Enter a page title",
+              "label": "Calculated summary title",
+              "requiredMsg": "Enter a calculated summary title",
             },
           ],
         ],
@@ -71,7 +71,7 @@ exports[`CalculatedSummaryPageEditor should render 1`] = `
       disabled={false}
       fetchAnswers={[MockFunction]}
       id="summary-title"
-      label="Page title"
+      label="Calculated summary title"
       maxHeight={12}
       metadata={Array []}
       multiline={false}

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -61,7 +61,7 @@ export const CalculatedSummaryPageEditor = props => {
         <RichTextEditor
           id="summary-title"
           name="title"
-          label="Page title"
+          label="Calculated summary title"
           placeholder="e.g. We calculate the answer as [total], are you sure this is correct?"
           value={page.title}
           onUpdate={onChangeUpdate}
@@ -74,8 +74,8 @@ export const CalculatedSummaryPageEditor = props => {
           defaultTab="variables"
           errorValidationMsg={getValidationError({
             field: "title",
-            label: "Page title",
-            requiredMsg: "Enter a page title",
+            label: "Calculated summary title",
+            requiredMsg: "Enter a calculated summary title",
           })}
         />
         <div>


### PR DESCRIPTION
GIVEN I've created a calculated summary page
THEN the area where I enter the title of the page is called "Calculated summary title"

GIVEN I've created a calculated summary page
WHEN I haven't entered any text in the "Calculated summary title" section
THEN I see a validation message which says: "Enter a calculated summary title"

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
