### PR TITLE
EAR-389-add-3-dots-to-long-page-titles

### DIFF
--- a/eq-author/src/components/IconText/index.js
+++ b/eq-author/src/components/IconText/index.js
@@ -51,14 +51,16 @@ const IconwithTextBelow = styled.div`
 `;
 
 const IconText = ({ icon: Icon, nav, hideText, children, ...otherProps }) => (
-  <IconOuter>
+  <>
     {nav && (
-      <IconwithTextBelow hideText={hideText} {...otherProps}>
-        <Icon />
-        <div>
-          {hideText ? <VisuallyHidden>{children}</VisuallyHidden> : children}
-        </div>
-      </IconwithTextBelow>
+      <IconOuter>
+        <IconwithTextBelow hideText={hideText} {...otherProps}>
+          <Icon />
+          <div>
+            {hideText ? <VisuallyHidden>{children}</VisuallyHidden> : children}
+          </div>
+        </IconwithTextBelow>
+      </IconOuter>
     )}
     {!nav && (
       <IconWithText hideText={hideText} {...otherProps}>
@@ -66,7 +68,7 @@ const IconText = ({ icon: Icon, nav, hideText, children, ...otherProps }) => (
         {hideText ? <VisuallyHidden>{children}</VisuallyHidden> : children}
       </IconWithText>
     )}
-  </IconOuter>
+  </>
 );
 
 const component = PropTypes.oneOfType([


### PR DESCRIPTION
### What is the context of this PR?

Question title that are too long for their container should cut off with ... and still show any errors to the right

### How to review 

Create a question within a section that has a very long title.
make sure that it has an error - eg no answer type or answer label

The title name on the left hand section nav should cut off with ... before the end of the container and still show the error (red circle with number) on the right hand edge of that container

When resizing the browser - the title should re-adjust to always show the error and keep cutting off with 3 dots.
It should NOT fall out of the container or overlap into the design section
It should NOT affect the new side nav that Jason created

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
