### PR TITLE
change focus when section is deleted

### DIFF
--- a/eq-author/src/App/page/Design/withDeletePage.js
+++ b/eq-author/src/App/page/Design/withDeletePage.js
@@ -39,10 +39,8 @@ const handleDeletion = (
 export const mapMutateToProps = ({ ownProps, mutate }) => ({
   onDeletePage(page) {
     const { client } = ownProps;
-
     const cachedSection = getCachedSection(client, page.section.id);
     const nextPage = getNextPage(cachedSection.pages, page.id);
-
     const mutation = mutate({
       variables: { input: { id: page.id } },
     });

--- a/eq-author/src/App/section/Design/withDeleteSection.js
+++ b/eq-author/src/App/section/Design/withDeleteSection.js
@@ -7,7 +7,7 @@ import { withShowToast } from "components/Toasts";
 import deleteSectionMutation from "graphql/deleteSection.graphql";
 
 import getNextSection from "utils/getNextOnDelete";
-import { buildPagePath } from "utils/UrlUtils";
+import { buildSectionPath } from "utils/UrlUtils";
 
 const questionnaireFragment = gql`
   fragment DeleteSectionFragment on Questionnaire {
@@ -37,13 +37,11 @@ export const handleDeletion = (
   }
 
   const nextSection = getNextSection(oldQuestionnaire.sections, sectionId);
-  const nextPage = nextSection.pages[0];
 
   history.push(
-    buildPagePath({
+    buildSectionPath({
       questionnaireId,
       sectionId: nextSection.id,
-      pageId: nextPage.id,
     })
   );
 };

--- a/eq-author/src/App/section/Design/withDeleteSection.js
+++ b/eq-author/src/App/section/Design/withDeleteSection.js
@@ -37,13 +37,11 @@ export const handleDeletion = (
   }
 
   const nextSection = getNextSection(oldQuestionnaire.sections, sectionId);
-
-  history.push(
-    buildSectionPath({
-      questionnaireId,
-      sectionId: nextSection.id,
-    })
-  );
+  const nextSectionPath = buildSectionPath({
+    questionnaireId,
+    sectionId: nextSection.id,
+  });
+  history.push(nextSectionPath);
 };
 
 export const displayToast = (ownProps, questionnaire) => {

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { render, fireEvent, act } from "tests/utils/rtl";
 import SectionAccordion from "./";
-import NavLink from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
+import NavLink, {
+  activeClassName,
+} from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
 import SectionIcon from "../../App/QuestionnaireDesignPage/NavigationSidebar/icon-section.svg";
-
-// import { colors } from "constants/theme";
 
 describe("Section Accordion", () => {
   it("default should render accordion as expanded", () => {
@@ -17,33 +17,28 @@ describe("Section Accordion", () => {
     expect(getByTestId("accordion-section1-button")).toBeVisible();
   });
 
-  it("default should render accordion as expanded and focus on first section", () => {
+  it("should focus on a section when active", async () => {
+    const props = {
+      to: "q/QID1/section/section1/design",
+      "data-test": "nav-section-link",
+      title: "TestName",
+      icon: () => <svg />,
+      errorCount: 0,
+      isActive: () => true,
+    };
     const SectionTitle = () => (
       <>
-        <NavLink
-          exact
-          to="q/QID1/section/section1/design"
-          data-test="nav-section-link"
-          title="TestName"
-          icon={SectionIcon}
-          id="sectionName"
-          errorCount={0}
-        >
-          sectionDisplayName
-        </NavLink>
+        <NavLink {...props}>section1</NavLink>
       </>
     );
-    const { getByTestId, debug } = render(
+    const { getByTestId } = render(
       <SectionAccordion title={<SectionTitle />} titleName="section1">
         section accordion panel
       </SectionAccordion>
     );
-    debug();
     expect(getByTestId("nav-section-link")).toBeVisible();
-    // expect(getByTestId("nav-section-link")).toHaveStyleRule(
-    //   "background",
-    //   colors.orange
-    // );
+
+    expect(getByTestId("nav-section-link")).toHaveClass(activeClassName);
   });
 
   it("click on the arrow - it should open and close section accordion", async () => {

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, fireEvent, act } from "tests/utils/rtl";
 import SectionAccordion from "./";
+import NavLink from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
+import SectionIcon from "../../App/QuestionnaireDesignPage/NavigationSidebar/icon-section.svg";
+
+// import { colors } from "constants/theme";
 
 describe("Section Accordion", () => {
   it("default should render accordion as expanded", () => {
@@ -11,6 +15,35 @@ describe("Section Accordion", () => {
     );
     expect(getByTestId("accordion-section1-body")).toBeVisible();
     expect(getByTestId("accordion-section1-button")).toBeVisible();
+  });
+
+  it("default should render accordion as expanded and focus on first section", () => {
+    const SectionTitle = () => (
+      <>
+        <NavLink
+          exact
+          to="q/QID1/section/section1/design"
+          data-test="nav-section-link"
+          title="TestName"
+          icon={SectionIcon}
+          id="sectionName"
+          errorCount={0}
+        >
+          sectionDisplayName
+        </NavLink>
+      </>
+    );
+    const { getByTestId, debug } = render(
+      <SectionAccordion title={<SectionTitle />} titleName="section1">
+        section accordion panel
+      </SectionAccordion>
+    );
+    debug();
+    expect(getByTestId("nav-section-link")).toBeVisible();
+    // expect(getByTestId("nav-section-link")).toHaveStyleRule(
+    //   "background",
+    //   colors.orange
+    // );
   });
 
   it("click on the arrow - it should open and close section accordion", async () => {

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -4,7 +4,6 @@ import SectionAccordion from "./";
 import NavLink, {
   activeClassName,
 } from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
-import SectionIcon from "../../App/QuestionnaireDesignPage/NavigationSidebar/icon-section.svg";
 
 describe("Section Accordion", () => {
   it("default should render accordion as expanded", () => {


### PR DESCRIPTION

### What is the context of this PR?

Changing focus in the left hand nav when a section is deleted

### How to review 

create a questionnaire with at least 2 sections...

GIVEN I've deleted a focussed section
WHEN the previous section is expanded
THEN the focus moves to the previous section

GIVEN I've deleted a focussed section
WHEN the previous section is collapsed
THEN the focus moves to the previous section
AND the section is in focus

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
