### PR TITLE
Added answer type to piping entity

### DIFF
--- a/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
@@ -303,7 +303,7 @@ describe("components/RichTextEditor", function() {
       });
 
       it("should load labels for piped answers when mounted", () => {
-        const html = `<p><span data-piped="answers" data-id="1">[Piped Value]</span> <span data-piped="answers" data-id="2">[Piped Value]</span> <span data-piped="metadata" data-id="1">[Piped Value]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="1" data-type="number">[Piped Value]</span> <span data-piped="answers" data-id="2" data-type="number">[Piped Value]</span> <span data-piped="metadata" data-id="1" data-type="number">[Piped Value]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -320,6 +320,7 @@ describe("components/RichTextEditor", function() {
             createPipedEntity(createEntity, {
               id: answers[0].id,
               pipingType: "answers",
+              type: "number",
             }),
             0,
             10
@@ -328,6 +329,7 @@ describe("components/RichTextEditor", function() {
             createPipedEntity(createEntity, {
               id: answers[1].id,
               pipingType: "answers",
+              type: "number",
             }),
             11,
             10
@@ -336,6 +338,7 @@ describe("components/RichTextEditor", function() {
             createPipedEntity(createEntity, {
               id: metadata[0].id,
               pipingType: "metadata",
+              type: "number",
             }),
             22,
             12
@@ -349,12 +352,14 @@ describe("components/RichTextEditor", function() {
         const nonExistentAnswer = {
           id: "4",
           pipingType: "answers",
+          type: "number",
         };
         const nonExistentMetadata = {
           id: "2",
           pipingType: "metadata",
+          type: "number",
         };
-        const html = `<p><span data-piped="answers" data-id="4">[Piped Value]</span> <span data-piped="answers" data-id="2">[Piped Value]</span> <span data-piped="metadata" data-id="2">[Piped Value]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="4" data-type="number">[Piped Value]</span> <span data-piped="answers" data-id="2" data-type="number">[Piped Value]</span> <span data-piped="metadata" data-id="2" data-type="number">[Piped Value]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -372,6 +377,7 @@ describe("components/RichTextEditor", function() {
             createPipedEntity(createEntity, {
               id: answers[1].id,
               pipingType: "answers",
+              type: "number",
             }),
             17,
             10
@@ -392,11 +398,12 @@ describe("components/RichTextEditor", function() {
       });
 
       it("should not update piped value text if answer or metadata doesn't have name to display", () => {
-        const html = `<p><span data-piped="answers" data-id="123">[Piped Value]</span> <span data-piped="metadata" data-id="456">[Piped Metadata]</span></p>`;
-        const answer = { id: "123", pipingType: "answers" };
+        const html = `<p><span data-piped="answers" data-id="123" data-type="number">[Piped Value]</span> <span data-piped="metadata" data-id="456" data-type="number">[Piped Metadata]</span></p>`;
+        const answer = { id: "123", pipingType: "answers", type: "number" };
         const metadataNoAlias = {
           id: "456",
           pipingType: "metadata",
+          type: "number",
         };
         fetch = jest.fn(() => Promise.resolve([answer]));
 
@@ -469,10 +476,11 @@ describe("components/RichTextEditor", function() {
           label: "from label",
           secondaryLabel: "to label",
           pipingType: "answers",
+          type: "DateRange",
         };
 
         const fetchDateRange = jest.fn(() => Promise.resolve([answer]));
-        const html = `<p><span data-piped="answers" data-id="123">[FooBar]</span></p>`;
+        const html = `<p><span data-piped="answers" data-id="123" data-type="DateRange">[FooBar]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor
@@ -503,10 +511,11 @@ describe("components/RichTextEditor", function() {
           id: "123",
           displayName: "FooBar",
           pipingType: "metadata",
+          type: "number",
         };
 
         const fetch = jest.fn(() => Promise.resolve([]));
-        const html = `<p><span data-piped="metadata" data-id="123">[Piped Answer]</span></p>`;
+        const html = `<p><span data-piped="metadata" data-id="123" data-type="number">[Piped Answer]</span></p>`;
 
         wrapper = shallow(
           <RichTextEditor

--- a/eq-author/src/components/RichTextEditor/entities/PipedValue.js
+++ b/eq-author/src/components/RichTextEditor/entities/PipedValue.js
@@ -22,8 +22,8 @@ const PipedValueDecorator = styled.span`
   white-space: pre;
 `;
 
-const PipedValueSerialized = ({ data: { id, text, pipingType } }) => (
-  <span data-piped={pipingType} data-id={id}>
+const PipedValueSerialized = ({ data: { id, text, pipingType, type } }) => (
+  <span data-piped={pipingType} data-id={id} data-type={type}>
     {text}
   </span>
 );
@@ -46,7 +46,8 @@ export const htmlToEntity = (nodeName, node, createEntity) => {
   if (node.hasAttribute && node.hasAttribute("data-piped")) {
     const id = node.getAttribute("data-id");
     const pipingType = node.getAttribute("data-piped");
-    return createPipedEntity(createEntity, { id, pipingType });
+    const type = node.getAttribute("data-type");
+    return createPipedEntity(createEntity, { id, pipingType, type });
   }
 };
 

--- a/eq-author/src/components/RichTextEditor/entities/PipedValue.test.js
+++ b/eq-author/src/components/RichTextEditor/entities/PipedValue.test.js
@@ -85,6 +85,7 @@ describe("PipedValue", () => {
     const id = "123";
     const text = "hello world";
     const pipingType = "SomeType";
+    const type = "SomeAnswerType";
 
     let elem, createEntity, entity;
 
@@ -93,6 +94,7 @@ describe("PipedValue", () => {
       elem.innerText = text;
       elem.setAttribute("data-piped", pipingType);
       elem.setAttribute("data-id", id);
+      elem.setAttribute("data-type", type);
 
       entity = {};
       createEntity = jest.fn(() => entity);
@@ -109,6 +111,7 @@ describe("PipedValue", () => {
       expect(createEntity).toHaveBeenCalledWith(ENTITY_TYPE, "IMMUTABLE", {
         pipingType,
         id,
+        type,
       });
     });
 

--- a/eq-author/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
@@ -35,6 +35,7 @@ exports[`PipedValue entityToHTML should convert entity to HTML 1`] = `
 <span
   data-id="123"
   data-piped="SomeType"
+  data-type="TextField"
 >
   hello world
 </span>


### PR DESCRIPTION
### What is the context of this PR?

Piping DateRange answer types into question text has them be displayed as `[Deleted Answer]` if you leave and return to the page, or refresh. This is because the code which replaces piped answers in Author with `[Deleted Answer]` was triggering as, earlier down the line, another piece of code could not find the DateRange question ID from the Ritch Text Editor.

### How to review 

* Create a new questionnaire
* Have the first question be a date range answer
* Pipe either the first or second part of the date range answer into the text of the second question
* Refresh the page; if you do not see `[Deleted Answer]` then it works
* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
