### PR TITLE
Small Screen cuts off body of author

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -2082,153 +2082,149 @@ exports[`QuestionnaireDesignPage should render 1`] = `
       }
     }
   >
-    <ScrollPane
-      permanentScrollBar={false}
+    <GetContext
+      title={[Function]}
     >
-      <GetContext
-        title={[Function]}
+      <Grid
+        align="top"
+        fillHeight={true}
       >
-        <Grid
-          align="top"
-          fillHeight={true}
+        <QuestionnaireDesignPage__NavColumn
+          cols={3}
+          gutters={false}
         >
-          <QuestionnaireDesignPage__NavColumn
-            cols={3}
-            gutters={false}
-          >
-            <QuestionnaireDesignPage__MainNav>
-              <Component />
-            </QuestionnaireDesignPage__MainNav>
-            <withRouter(UnwrappedNavigationSidebar)
-              canAddCalculatedSummaryPage={true}
-              canAddQuestionConfirmation={true}
-              canAddQuestionPage={true}
-              data-test="side-nav"
-              loading={false}
-              onAddCalculatedSummaryPage={[Function]}
-              onAddQuestionConfirmation={[Function]}
-              onAddQuestionPage={[Function]}
-              onAddSection={[MockFunction]}
-              questionnaire={
-                Object {
-                  "displayName": "my displayName",
-                  "id": "3",
-                  "sections": Array [
-                    Object {
-                      "id": "2",
-                      "pages": Array [
-                        Object {
-                          "answers": Array [
-                            Object {
-                              "id": "1",
-                              "label": "",
-                              "options": Array [
-                                Object {
-                                  "id": "1",
-                                },
-                              ],
-                            },
-                          ],
-                          "description": "",
-                          "guidance": "",
-                          "id": "1",
-                          "pageType": "QuestionPage",
-                          "position": 0,
-                          "title": "",
-                        },
-                      ],
-                      "title": "",
-                    },
-                  ],
-                  "title": "hello world",
-                }
+          <QuestionnaireDesignPage__MainNav>
+            <Component />
+          </QuestionnaireDesignPage__MainNav>
+          <withRouter(UnwrappedNavigationSidebar)
+            canAddCalculatedSummaryPage={true}
+            canAddQuestionConfirmation={true}
+            canAddQuestionPage={true}
+            data-test="side-nav"
+            loading={false}
+            onAddCalculatedSummaryPage={[Function]}
+            onAddQuestionConfirmation={[Function]}
+            onAddQuestionPage={[Function]}
+            onAddSection={[MockFunction]}
+            questionnaire={
+              Object {
+                "displayName": "my displayName",
+                "id": "3",
+                "sections": Array [
+                  Object {
+                    "id": "2",
+                    "pages": Array [
+                      Object {
+                        "answers": Array [
+                          Object {
+                            "id": "1",
+                            "label": "",
+                            "options": Array [
+                              Object {
+                                "id": "1",
+                              },
+                            ],
+                          },
+                        ],
+                        "description": "",
+                        "guidance": "",
+                        "id": "1",
+                        "pageType": "QuestionPage",
+                        "position": 0,
+                        "title": "",
+                      },
+                    ],
+                    "title": "",
+                  },
+                ],
+                "title": "hello world",
               }
+            }
+          />
+        </QuestionnaireDesignPage__NavColumn>
+        <Column
+          cols={9}
+          gutters={false}
+        >
+          <Switch>
+            <Route
+              component={[Function]}
+              key="page-design"
+              path="/q/:questionnaireId/page/:pageId/design/:modifier?"
             />
-          </QuestionnaireDesignPage__NavColumn>
-          <Column
-            cols={9}
-            gutters={false}
-          >
-            <Switch>
-              <Route
-                component={[Function]}
-                key="page-design"
-                path="/q/:questionnaireId/page/:pageId/design/:modifier?"
-              />
-              <Route
-                component={[Function]}
-                key="page-preview"
-                path="/q/:questionnaireId/page/:pageId/preview"
-              />
-              <Route
-                component={[Function]}
-                key="page-routing"
-                path="/q/:questionnaireId/page/:pageId/routing"
-              />
-              <Route
-                component={[Function]}
-                key="section-design"
-                path="/q/:questionnaireId/section/:sectionId/design"
-              />
-              <Route
-                component={[Function]}
-                key="section-preview"
-                path="/q/:questionnaireId/section/:sectionId/preview"
-              />
-              <Route
-                component={[Function]}
-                key="confirmation-design"
-                path="/q/:questionnaireId/question-confirmation/:confirmationId/design"
-              />
-              <Route
-                component={[Function]}
-                key="confirmation-preview"
-                path="/q/:questionnaireId/question-confirmation/:confirmationId/preview"
-              />
-              <Route
-                component={[Function]}
-                key="introduction-design"
-                path="/q/:questionnaireId/introduction/:introductionId/design/:modifier?"
-              />
-              <Route
-                component={[Function]}
-                key="introduction-preview"
-                path="/q/:questionnaireId/introduction/:introductionId/preview"
-              />
-              <Route
-                component={[Function]}
-                key="metadata"
-                path="/q/:questionnaireId/metadata"
-              />
-              <Route
-                component={[Function]}
-                key="history"
-                path="/q/:questionnaireId/history"
-              />
-              <Route
-                key="publish"
-                path="/q/:questionnaireId/publish"
-                render={[Function]}
-              />
-              <Route
-                component={[Function]}
-                key="review"
-                path="/q/:questionnaireId/review"
-              />
-              <Route
-                key="qcodes"
-                path="/q/:questionnaireId/qcodes"
-                render={[Function]}
-              />
-              <Route
-                path="*"
-                render={[Function]}
-              />
-            </Switch>
-          </Column>
-        </Grid>
-      </GetContext>
-    </ScrollPane>
+            <Route
+              component={[Function]}
+              key="page-preview"
+              path="/q/:questionnaireId/page/:pageId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="page-routing"
+              path="/q/:questionnaireId/page/:pageId/routing"
+            />
+            <Route
+              component={[Function]}
+              key="section-design"
+              path="/q/:questionnaireId/section/:sectionId/design"
+            />
+            <Route
+              component={[Function]}
+              key="section-preview"
+              path="/q/:questionnaireId/section/:sectionId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="confirmation-design"
+              path="/q/:questionnaireId/question-confirmation/:confirmationId/design"
+            />
+            <Route
+              component={[Function]}
+              key="confirmation-preview"
+              path="/q/:questionnaireId/question-confirmation/:confirmationId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="introduction-design"
+              path="/q/:questionnaireId/introduction/:introductionId/design/:modifier?"
+            />
+            <Route
+              component={[Function]}
+              key="introduction-preview"
+              path="/q/:questionnaireId/introduction/:introductionId/preview"
+            />
+            <Route
+              component={[Function]}
+              key="metadata"
+              path="/q/:questionnaireId/metadata"
+            />
+            <Route
+              component={[Function]}
+              key="history"
+              path="/q/:questionnaireId/history"
+            />
+            <Route
+              key="publish"
+              path="/q/:questionnaireId/publish"
+              render={[Function]}
+            />
+            <Route
+              component={[Function]}
+              key="review"
+              path="/q/:questionnaireId/review"
+            />
+            <Route
+              key="qcodes"
+              path="/q/:questionnaireId/qcodes"
+              render={[Function]}
+            />
+            <Route
+              path="*"
+              render={[Function]}
+            />
+          </Switch>
+        </Column>
+      </Grid>
+    </GetContext>
   </BaseLayout>
 </ContextProvider>
 `;

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -21,7 +21,6 @@ import {
 } from "constants/error-codes";
 
 import { buildSectionPath, buildIntroductionPath } from "utils/UrlUtils";
-import ScrollPane from "components/ScrollPane";
 import pageRoutes from "App/page";
 import sectionRoutes from "App/section";
 import questionConfirmationRoutes from "App/questionConfirmation";

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -205,49 +205,45 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
     return (
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <BaseLayout questionnaire={questionnaire}>
-          <ScrollPane>
-            <Titled title={this.getTitle}>
-              <Grid>
-                <NavColumn cols={3} gutters={false}>
-                  <MainNav>
-                    <MainNavigation />
-                  </MainNav>
-                  <NavigationSidebar
-                    data-test="side-nav"
-                    loading={loading}
-                    onAddSection={this.props.onAddSection}
-                    onAddQuestionPage={this.handleAddPage("QuestionPage")}
-                    canAddQuestionPage={this.canAddQuestionAndCalculatedSummmaryPages()}
-                    onAddCalculatedSummaryPage={this.handleAddPage(
-                      "CalculatedSummaryPage"
-                    )}
-                    canAddCalculatedSummaryPage={this.canAddQuestionAndCalculatedSummmaryPages()}
-                    questionnaire={questionnaire}
-                    canAddQuestionConfirmation={this.canAddQuestionConfirmation()}
-                    onAddQuestionConfirmation={
-                      this.handleAddQuestionConfirmation
-                    }
-                  />
-                </NavColumn>
-                <Column cols={9} gutters={false}>
-                  <Switch location={location}>
-                    {[
-                      ...pageRoutes,
-                      ...sectionRoutes,
-                      ...questionConfirmationRoutes,
-                      ...introductionRoutes,
-                      ...metadataRoutes,
-                      ...historyRoutes,
-                      ...publishRoutes,
-                      ...reviewRoutes,
-                      ...qcodeRoutes,
-                    ]}
-                    <Route path="*" render={this.renderRedirect} />
-                  </Switch>
-                </Column>
-              </Grid>
-            </Titled>
-          </ScrollPane>
+          <Titled title={this.getTitle}>
+            <Grid>
+              <NavColumn cols={3} gutters={false}>
+                <MainNav>
+                  <MainNavigation />
+                </MainNav>
+                <NavigationSidebar
+                  data-test="side-nav"
+                  loading={loading}
+                  onAddSection={this.props.onAddSection}
+                  onAddQuestionPage={this.handleAddPage("QuestionPage")}
+                  canAddQuestionPage={this.canAddQuestionAndCalculatedSummmaryPages()}
+                  onAddCalculatedSummaryPage={this.handleAddPage(
+                    "CalculatedSummaryPage"
+                  )}
+                  canAddCalculatedSummaryPage={this.canAddQuestionAndCalculatedSummmaryPages()}
+                  questionnaire={questionnaire}
+                  canAddQuestionConfirmation={this.canAddQuestionConfirmation()}
+                  onAddQuestionConfirmation={this.handleAddQuestionConfirmation}
+                />
+              </NavColumn>
+              <Column cols={9} gutters={false}>
+                <Switch location={location}>
+                  {[
+                    ...pageRoutes,
+                    ...sectionRoutes,
+                    ...questionConfirmationRoutes,
+                    ...introductionRoutes,
+                    ...metadataRoutes,
+                    ...historyRoutes,
+                    ...publishRoutes,
+                    ...reviewRoutes,
+                    ...qcodeRoutes,
+                  ]}
+                  <Route path="*" render={this.renderRedirect} />
+                </Switch>
+              </Column>
+            </Grid>
+          </Titled>
         </BaseLayout>
       </QuestionnaireContext.Provider>
     );

--- a/eq-author/src/App/QuestionnaireDesignPage/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.test.js
@@ -149,7 +149,7 @@ describe("QuestionnaireDesignPage", () => {
       ).toEqual(false);
     });
 
-    it("should disable adding confirmation queation when on introduction page", () => {
+    it("should disable adding confirmation question when on introduction page", () => {
       expect(
         wrapper.find(NavigationSidebar).prop("canAddQuestionConfirmation")
       ).toEqual(false);


### PR DESCRIPTION
### What is the context of this PR?

On ONS laptops, part of the design and properties panel is being cut off when scrolling
There is also a double scroll bar on the far right of the screen
This is due to an unnecessary scrollPane in the main layout (questionnaireDesignPage/index.js)
see screen shot in ticket - EAR-384

### How to review 

Resize your browser to approximate ONS laptop sizing 
or select Ipad on the Chrome inspector (toggle device toolbar) and rotate to landscape
choose a date range answer type in a question
You should see scroll bars in both the design and properties panel.

This should now 
a) show only one scroll bar in the Properties window(previously there were 2).
b) have no unused (whitespace) near the bottom after scrolling is initiated.
