### PR TITLE
Revert and add media query to adjust max height

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -2082,149 +2082,153 @@ exports[`QuestionnaireDesignPage should render 1`] = `
       }
     }
   >
-    <GetContext
-      title={[Function]}
+    <ScrollPane
+      permanentScrollBar={false}
     >
-      <Grid
-        align="top"
-        fillHeight={true}
+      <GetContext
+        title={[Function]}
       >
-        <QuestionnaireDesignPage__NavColumn
-          cols={3}
-          gutters={false}
+        <Grid
+          align="top"
+          fillHeight={true}
         >
-          <QuestionnaireDesignPage__MainNav>
-            <Component />
-          </QuestionnaireDesignPage__MainNav>
-          <withRouter(UnwrappedNavigationSidebar)
-            canAddCalculatedSummaryPage={true}
-            canAddQuestionConfirmation={true}
-            canAddQuestionPage={true}
-            data-test="side-nav"
-            loading={false}
-            onAddCalculatedSummaryPage={[Function]}
-            onAddQuestionConfirmation={[Function]}
-            onAddQuestionPage={[Function]}
-            onAddSection={[MockFunction]}
-            questionnaire={
-              Object {
-                "displayName": "my displayName",
-                "id": "3",
-                "sections": Array [
-                  Object {
-                    "id": "2",
-                    "pages": Array [
-                      Object {
-                        "answers": Array [
-                          Object {
-                            "id": "1",
-                            "label": "",
-                            "options": Array [
-                              Object {
-                                "id": "1",
-                              },
-                            ],
-                          },
-                        ],
-                        "description": "",
-                        "guidance": "",
-                        "id": "1",
-                        "pageType": "QuestionPage",
-                        "position": 0,
-                        "title": "",
-                      },
-                    ],
-                    "title": "",
-                  },
-                ],
-                "title": "hello world",
+          <QuestionnaireDesignPage__NavColumn
+            cols={3}
+            gutters={false}
+          >
+            <QuestionnaireDesignPage__MainNav>
+              <Component />
+            </QuestionnaireDesignPage__MainNav>
+            <withRouter(UnwrappedNavigationSidebar)
+              canAddCalculatedSummaryPage={true}
+              canAddQuestionConfirmation={true}
+              canAddQuestionPage={true}
+              data-test="side-nav"
+              loading={false}
+              onAddCalculatedSummaryPage={[Function]}
+              onAddQuestionConfirmation={[Function]}
+              onAddQuestionPage={[Function]}
+              onAddSection={[MockFunction]}
+              questionnaire={
+                Object {
+                  "displayName": "my displayName",
+                  "id": "3",
+                  "sections": Array [
+                    Object {
+                      "id": "2",
+                      "pages": Array [
+                        Object {
+                          "answers": Array [
+                            Object {
+                              "id": "1",
+                              "label": "",
+                              "options": Array [
+                                Object {
+                                  "id": "1",
+                                },
+                              ],
+                            },
+                          ],
+                          "description": "",
+                          "guidance": "",
+                          "id": "1",
+                          "pageType": "QuestionPage",
+                          "position": 0,
+                          "title": "",
+                        },
+                      ],
+                      "title": "",
+                    },
+                  ],
+                  "title": "hello world",
+                }
               }
-            }
-          />
-        </QuestionnaireDesignPage__NavColumn>
-        <Column
-          cols={9}
-          gutters={false}
-        >
-          <Switch>
-            <Route
-              component={[Function]}
-              key="page-design"
-              path="/q/:questionnaireId/page/:pageId/design/:modifier?"
             />
-            <Route
-              component={[Function]}
-              key="page-preview"
-              path="/q/:questionnaireId/page/:pageId/preview"
-            />
-            <Route
-              component={[Function]}
-              key="page-routing"
-              path="/q/:questionnaireId/page/:pageId/routing"
-            />
-            <Route
-              component={[Function]}
-              key="section-design"
-              path="/q/:questionnaireId/section/:sectionId/design"
-            />
-            <Route
-              component={[Function]}
-              key="section-preview"
-              path="/q/:questionnaireId/section/:sectionId/preview"
-            />
-            <Route
-              component={[Function]}
-              key="confirmation-design"
-              path="/q/:questionnaireId/question-confirmation/:confirmationId/design"
-            />
-            <Route
-              component={[Function]}
-              key="confirmation-preview"
-              path="/q/:questionnaireId/question-confirmation/:confirmationId/preview"
-            />
-            <Route
-              component={[Function]}
-              key="introduction-design"
-              path="/q/:questionnaireId/introduction/:introductionId/design/:modifier?"
-            />
-            <Route
-              component={[Function]}
-              key="introduction-preview"
-              path="/q/:questionnaireId/introduction/:introductionId/preview"
-            />
-            <Route
-              component={[Function]}
-              key="metadata"
-              path="/q/:questionnaireId/metadata"
-            />
-            <Route
-              component={[Function]}
-              key="history"
-              path="/q/:questionnaireId/history"
-            />
-            <Route
-              key="publish"
-              path="/q/:questionnaireId/publish"
-              render={[Function]}
-            />
-            <Route
-              component={[Function]}
-              key="review"
-              path="/q/:questionnaireId/review"
-            />
-            <Route
-              key="qcodes"
-              path="/q/:questionnaireId/qcodes"
-              render={[Function]}
-            />
-            <Route
-              path="*"
-              render={[Function]}
-            />
-          </Switch>
-        </Column>
-      </Grid>
-    </GetContext>
+          </QuestionnaireDesignPage__NavColumn>
+          <Column
+            cols={9}
+            gutters={false}
+          >
+            <Switch>
+              <Route
+                component={[Function]}
+                key="page-design"
+                path="/q/:questionnaireId/page/:pageId/design/:modifier?"
+              />
+              <Route
+                component={[Function]}
+                key="page-preview"
+                path="/q/:questionnaireId/page/:pageId/preview"
+              />
+              <Route
+                component={[Function]}
+                key="page-routing"
+                path="/q/:questionnaireId/page/:pageId/routing"
+              />
+              <Route
+                component={[Function]}
+                key="section-design"
+                path="/q/:questionnaireId/section/:sectionId/design"
+              />
+              <Route
+                component={[Function]}
+                key="section-preview"
+                path="/q/:questionnaireId/section/:sectionId/preview"
+              />
+              <Route
+                component={[Function]}
+                key="confirmation-design"
+                path="/q/:questionnaireId/question-confirmation/:confirmationId/design"
+              />
+              <Route
+                component={[Function]}
+                key="confirmation-preview"
+                path="/q/:questionnaireId/question-confirmation/:confirmationId/preview"
+              />
+              <Route
+                component={[Function]}
+                key="introduction-design"
+                path="/q/:questionnaireId/introduction/:introductionId/design/:modifier?"
+              />
+              <Route
+                component={[Function]}
+                key="introduction-preview"
+                path="/q/:questionnaireId/introduction/:introductionId/preview"
+              />
+              <Route
+                component={[Function]}
+                key="metadata"
+                path="/q/:questionnaireId/metadata"
+              />
+              <Route
+                component={[Function]}
+                key="history"
+                path="/q/:questionnaireId/history"
+              />
+              <Route
+                key="publish"
+                path="/q/:questionnaireId/publish"
+                render={[Function]}
+              />
+              <Route
+                component={[Function]}
+                key="review"
+                path="/q/:questionnaireId/review"
+              />
+              <Route
+                key="qcodes"
+                path="/q/:questionnaireId/qcodes"
+                render={[Function]}
+              />
+              <Route
+                path="*"
+                render={[Function]}
+              />
+            </Switch>
+          </Column>
+        </Grid>
+      </GetContext>
+    </ScrollPane>
   </BaseLayout>
 </ContextProvider>
 `;

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -21,6 +21,7 @@ import {
 } from "constants/error-codes";
 
 import { buildSectionPath, buildIntroductionPath } from "utils/UrlUtils";
+import ScrollPane from "components/ScrollPane";
 import pageRoutes from "App/page";
 import sectionRoutes from "App/section";
 import questionConfirmationRoutes from "App/questionConfirmation";
@@ -204,45 +205,49 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
     return (
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <BaseLayout questionnaire={questionnaire}>
-          <Titled title={this.getTitle}>
-            <Grid>
-              <NavColumn cols={3} gutters={false}>
-                <MainNav>
-                  <MainNavigation />
-                </MainNav>
-                <NavigationSidebar
-                  data-test="side-nav"
-                  loading={loading}
-                  onAddSection={this.props.onAddSection}
-                  onAddQuestionPage={this.handleAddPage("QuestionPage")}
-                  canAddQuestionPage={this.canAddQuestionAndCalculatedSummmaryPages()}
-                  onAddCalculatedSummaryPage={this.handleAddPage(
-                    "CalculatedSummaryPage"
-                  )}
-                  canAddCalculatedSummaryPage={this.canAddQuestionAndCalculatedSummmaryPages()}
-                  questionnaire={questionnaire}
-                  canAddQuestionConfirmation={this.canAddQuestionConfirmation()}
-                  onAddQuestionConfirmation={this.handleAddQuestionConfirmation}
-                />
-              </NavColumn>
-              <Column cols={9} gutters={false}>
-                <Switch location={location}>
-                  {[
-                    ...pageRoutes,
-                    ...sectionRoutes,
-                    ...questionConfirmationRoutes,
-                    ...introductionRoutes,
-                    ...metadataRoutes,
-                    ...historyRoutes,
-                    ...publishRoutes,
-                    ...reviewRoutes,
-                    ...qcodeRoutes,
-                  ]}
-                  <Route path="*" render={this.renderRedirect} />
-                </Switch>
-              </Column>
-            </Grid>
-          </Titled>
+          <ScrollPane>
+            <Titled title={this.getTitle}>
+              <Grid>
+                <NavColumn cols={3} gutters={false}>
+                  <MainNav>
+                    <MainNavigation />
+                  </MainNav>
+                  <NavigationSidebar
+                    data-test="side-nav"
+                    loading={loading}
+                    onAddSection={this.props.onAddSection}
+                    onAddQuestionPage={this.handleAddPage("QuestionPage")}
+                    canAddQuestionPage={this.canAddQuestionAndCalculatedSummmaryPages()}
+                    onAddCalculatedSummaryPage={this.handleAddPage(
+                      "CalculatedSummaryPage"
+                    )}
+                    canAddCalculatedSummaryPage={this.canAddQuestionAndCalculatedSummmaryPages()}
+                    questionnaire={questionnaire}
+                    canAddQuestionConfirmation={this.canAddQuestionConfirmation()}
+                    onAddQuestionConfirmation={
+                      this.handleAddQuestionConfirmation
+                    }
+                  />
+                </NavColumn>
+                <Column cols={9} gutters={false}>
+                  <Switch location={location}>
+                    {[
+                      ...pageRoutes,
+                      ...sectionRoutes,
+                      ...questionConfirmationRoutes,
+                      ...introductionRoutes,
+                      ...metadataRoutes,
+                      ...historyRoutes,
+                      ...publishRoutes,
+                      ...reviewRoutes,
+                      ...qcodeRoutes,
+                    ]}
+                    <Route path="*" render={this.renderRedirect} />
+                  </Switch>
+                </Column>
+              </Grid>
+            </Titled>
+          </ScrollPane>
         </BaseLayout>
       </QuestionnaireContext.Provider>
     );

--- a/eq-author/src/components/Grid/Grid.js
+++ b/eq-author/src/components/Grid/Grid.js
@@ -5,6 +5,7 @@ const Grid = styled.div.attrs(() => ({ "data-test": "grid" }))`
   display: flex;
   width: 100%;
   height: 100%;
+
   @media (max-height: 680px) {
     height: auto;
   }

--- a/eq-author/src/components/Grid/Grid.js
+++ b/eq-author/src/components/Grid/Grid.js
@@ -5,6 +5,9 @@ const Grid = styled.div.attrs(() => ({ "data-test": "grid" }))`
   display: flex;
   width: 100%;
   height: 100%;
+  @media (max-height: 680px) {
+    height: auto;
+  }
   flex: ${({ fillHeight }) => (fillHeight ? 1 : 0)} 1 auto;
   flex-direction: row;
   align-items: ${({ align }) => alignOptions[align]};

--- a/eq-author/src/components/Grid/__snapshots__/Grid.test.js.snap
+++ b/eq-author/src/components/Grid/__snapshots__/Grid.test.js.snap
@@ -55,6 +55,12 @@ exports[`components/Grid Columns should render an asymmetrical two column grid  
   padding-right: 0;
 }
 
+@media (max-height:680px) {
+  .c0 {
+    height: auto;
+  }
+}
+
 <div
     class="c0"
     data-test="grid"


### PR DESCRIPTION
### What is the context of this PR?

Screens with a smaller height cause parts of the interface to become cut off. 

Removing the scrollpane prevented the left-hand nav from being accessible

Added a media query at 680px height to remove the height CSS rule from 100% to auto. This fills the gap at the bottom of the screen.

### How to review 

Using dev tools, adjust the height of the screen from starting size to be less than 680px, say 400px. There should be no gap present at the bottom of the screen and the left-hand nav should be scrollable.

This should now 
a) ~~show only one scroll bar in the Properties window(previously there were 2).~~
a) Scroll bar will be present, think this is to highlight the left-hand nav
b) have no unused (whitespace) near the bottom after scrolling is initiated.
