### PR TITLE
removed unused select from routing out

### DIFF
--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/__snapshots__/index.test.js.snap
@@ -20,27 +20,10 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
       </BinaryExpressionEditor__Label>
     </Column>
     <Column
-      cols={9}
+      cols={8}
       gutters={false}
     >
       <BinaryExpressionEditor__Flex>
-        <BinaryExpressionEditor__StyledSelect
-          defaultValue="answer"
-          disabled={true}
-        >
-          <option
-            onChange={[Function]}
-            value="answer"
-          >
-            Answer
-          </option>
-          <option
-            disabled={true}
-            value="metadata"
-          >
-            Metadata
-          </option>
-        </BinaryExpressionEditor__StyledSelect>
         <BinaryExpressionEditor__ContentPicker
           data-test="routing-answer-picker"
           onSubmit={[Function]}
@@ -50,7 +33,7 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
       </BinaryExpressionEditor__Flex>
     </Column>
     <Column
-      cols={1.5}
+      cols={2.5}
       gutters={false}
     >
       <BinaryExpressionEditor__ActionButtons>
@@ -93,7 +76,7 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
       />
     </Column>
     <Column
-      cols={9}
+      cols={8}
       gutters={false}
     >
       <TransitionGroup
@@ -123,7 +106,7 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
       </TransitionGroup>
     </Column>
     <Column
-      cols={1.5}
+      cols={2.5}
     />
   </Grid>
 </div>

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { PropTypes } from "prop-types";
 import styled from "styled-components";
 import { TransitionGroup } from "react-transition-group";
-import { get, uniqueId, flow, noop } from "lodash/fp";
+import { get, uniqueId, flow } from "lodash/fp";
 import { propType } from "graphql-anywhere";
 import { NavLink, withRouter } from "react-router-dom";
 
@@ -41,7 +41,6 @@ import withUpdateBinaryExpression from "./withUpdateBinaryExpression";
 import MultipleChoiceAnswerOptionsSelector from "./MultipleChoiceAnswerOptionsSelector";
 import NumberAnswerSelector from "./NumberAnswerSelector";
 import { colors } from "constants/theme";
-import { Select } from "components/Forms";
 
 const Label = styled.label`
   width: 100%;
@@ -124,12 +123,6 @@ const AddButton = styled(ActionButton)`
 
 const Flex = styled.div`
   display: flex;
-`;
-
-const StyledSelect = styled(Select)`
-  flex: 1 1 auto;
-  width: auto;
-  margin-right: 1em;
 `;
 
 const ContentPicker = styled(RoutingAnswerContentPicker)`
@@ -292,16 +285,8 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
               {label}
             </Label>
           </Column>
-          <Column gutters={false} cols={9}>
+          <Column gutters={false} cols={8}>
             <Flex>
-              <StyledSelect disabled defaultValue="answer">
-                <option value="answer" onChange={noop}>
-                  Answer
-                </option>
-                <option value="metadata" disabled>
-                  Metadata
-                </option>
-              </StyledSelect>
               <ContentPicker
                 path="page.availableRoutingAnswers"
                 selectedContentDisplayName={get("left.displayName", expression)}
@@ -311,7 +296,7 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
               />
             </Flex>
           </Column>
-          <Column gutters={false} cols={1.5}>
+          <Column gutters={false} cols={2.5}>
             <ActionButtons>
               <RemoveButton
                 onClick={this.handleDeleteClick}
@@ -334,12 +319,12 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
           <Column gutters={false} cols={1.5}>
             <ConnectedPath pathEnd={isLastExpression} />
           </Column>
-          <Column gutters={false} cols={9}>
+          <Column gutters={false} cols={8}>
             <TransitionGroup>
               <Transition key="answer">{routingEditor}</Transition>
             </TransitionGroup>
           </Column>
-          <Column cols={1.5} />
+          <Column cols={2.5} />
         </Grid>
       </div>
     );


### PR DESCRIPTION

### What is the context of this PR?

when routing out, there is an unused select box with 'answer' that has no purpose and needs to be removed

### How to review 

create  a new question with routing and you should only see the default answer select box next to the 'IF'
there will no longer be a greyed out 'answer' select (box) there.

as in this example
![screencapture-localhost-3000-2020-05-18-11_30_35](https://user-images.githubusercontent.com/6759437/82206106-842f5b80-98ff-11ea-9adc-836a8af4447d.png)



### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
