### PR TITLE
Ear 465 pipe date range not showing on runner

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - DYNAMO_COMMENTS_TABLE_NAME=dev-author-comments
       - NODE_ENV=development
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
-      - PUBLISHER_URL=http://host.docker.internal:9000/publish/
+      - PUBLISHER_URL=http://localhost:9000/publish/
       - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api

--- a/eq-publisher/src/eq_schema/Block.test.js
+++ b/eq-publisher/src/eq_schema/Block.test.js
@@ -90,13 +90,13 @@ describe("Block", () => {
 
   describe("piping", () => {
     const createPipeInText = ({
-      id = 1,
+      id = "7151378b-579d-40bf-b4d4-a378c573706a",
       text = "foo",
       pipeType = "answers",
     } = {}) => `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
     const createPipeInHtml = ({
-      id = 1,
+      id = "7151378b-579d-40bf-b4d4-a378c573706a",
       text = "foo",
       pipeType = "answers",
     } = {}) =>
@@ -107,7 +107,17 @@ describe("Block", () => {
     ) => ({
       questionnaireJson: {
         metadata,
-        sections: [{ pages: [{ answers: [{ id: `1`, type: "Text" }] }] }],
+        sections: [
+          {
+            pages: [
+              {
+                answers: [
+                  { id: `7151378b-579d-40bf-b4d4-a378c573706a`, type: "Text" },
+                ],
+              },
+            ],
+          },
+        ],
       },
     });
 
@@ -119,7 +129,9 @@ describe("Block", () => {
         createContext()
       );
 
-      expect(introBlock.title).toEqual("{{ answers['answer1'] }}");
+      expect(introBlock.title).toEqual(
+        "{{ answers['answer7151378b-579d-40bf-b4d4-a378c573706a'] }}"
+      );
     });
 
     it("should handle piped values in title while stripping html", () => {
@@ -130,7 +142,9 @@ describe("Block", () => {
         createContext()
       );
 
-      expect(introBlock.title).toEqual("{{ answers['answer1'] }}");
+      expect(introBlock.title).toEqual(
+        "{{ answers['answer7151378b-579d-40bf-b4d4-a378c573706a'] }}"
+      );
     });
 
     it("should handle piped values in description", () => {
@@ -142,7 +156,7 @@ describe("Block", () => {
       );
 
       expect(introBlock.description).toEqual(
-        "<strong>{{ answers['answer1'] }}</strong><ul><li>Some Value</li></ul>"
+        "<strong>{{ answers['answer7151378b-579d-40bf-b4d4-a378c573706a'] }}</strong><ul><li>Some Value</li></ul>"
       );
     });
 

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -461,15 +461,28 @@ describe("Question", () => {
   });
 
   describe("piping", () => {
-    const createPipe = ({ id = 1, text = "foo", pipeType = "answers" } = {}) =>
-      `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
+    const createPipe = ({
+      id = "7151378b-579d-40bf-b4d4-a378c573706a",
+      text = "foo",
+      pipeType = "answers",
+    } = {}) => `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
     const createContext = (
       metadata = [{ id: "123", type: "Text", key: "my_metadata" }]
     ) => ({
       questionnaireJson: {
         metadata,
-        sections: [{ pages: [{ answers: [{ id: `1`, type: "Text" }] }] }],
+        sections: [
+          {
+            pages: [
+              {
+                answers: [
+                  { id: `7151378b-579d-40bf-b4d4-a378c573706a`, type: "Text" },
+                ],
+              },
+            ],
+          },
+        ],
       },
     });
 
@@ -481,7 +494,9 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.title).toEqual("{{ answers['answer1'] }}");
+      expect(question.title).toEqual(
+        "{{ answers['answer7151378b-579d-40bf-b4d4-a378c573706a'] }}"
+      );
     });
 
     it("should handle piped values in guidance", () => {
@@ -519,7 +534,9 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.description).toEqual("<h2>{{ answers['answer1'] }}</h2>");
+      expect(question.description).toEqual(
+        "<h2>{{ answers['answer7151378b-579d-40bf-b4d4-a378c573706a'] }}</h2>"
+      );
     });
   });
 

--- a/eq-publisher/src/utils/convertPipes.test.js
+++ b/eq-publisher/src/utils/convertPipes.test.js
@@ -7,8 +7,11 @@ const {
   NUMBER,
   UNIT,
 } = require("../constants/answerTypes");
-const createPipe = ({ pipeType = "answers", id = 1, text = "foo" } = {}) =>
-  `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
+const createPipe = ({
+  pipeType = "answers",
+  id = "0151378b-579d-40bf-b4d4-a378c573706a",
+  text = "foo",
+} = {}) => `<span data-piped="${pipeType}" data-id="${id}">${text}</span>`;
 
 const createContext = (metadata = []) => ({
   questionnaireJson: {
@@ -18,13 +21,13 @@ const createContext = (metadata = []) => ({
         pages: [
           {
             answers: [
-              { id: `1`, type: "Text" },
-              { id: `2`, type: CURRENCY },
-              { id: `3`, type: DATE_RANGE },
-              { id: `4`, type: DATE },
-              { id: `5`, type: NUMBER },
+              { id: `0151378b-579d-40bf-b4d4-a378c573706a`, type: "Text" },
+              { id: `1151378b-579d-40bf-b4d4-a378c573706a`, type: CURRENCY },
+              { id: `2151378b-579d-40bf-b4d4-a378c573706a`, type: DATE_RANGE },
+              { id: `3151378b-579d-40bf-b4d4-a378c573706a`, type: DATE },
+              { id: `4151378b-579d-40bf-b4d4-a378c573706a`, type: NUMBER },
               {
-                id: `6`,
+                id: `5151378b-579d-40bf-b4d4-a378c573706a`,
                 type: UNIT,
                 properties: { required: false, decimals: 0, unit: "Metres" },
               },
@@ -76,63 +79,69 @@ describe("convertPipes", () => {
     it("should convert relevant elements to pipe format", () => {
       const html = createPipe();
       expect(convertPipes(createContext())(html)).toEqual(
-        "{{ answers['answer1'] }}"
+        "{{ answers['answer0151378b-579d-40bf-b4d4-a378c573706a'] }}"
       );
     });
 
     it("should handle multiple piped values", () => {
       const pipe1 = createPipe();
-      const pipe2 = createPipe({ id: "2", text: "bar" });
+      const pipe2 = createPipe({
+        id: "1151378b-579d-40bf-b4d4-a378c573706a",
+        text: "bar",
+      });
       const html = `${pipe1}${pipe2}`;
 
       expect(convertPipes(createContext())(html)).toEqual(
-        "{{ answers['answer1'] }}{{ format_currency(answers['answer2'], 'GBP') }}"
+        "{{ answers['answer0151378b-579d-40bf-b4d4-a378c573706a'] }}{{ format_currency(answers['answer1151378b-579d-40bf-b4d4-a378c573706a'], 'GBP') }}"
       );
     });
 
     it("should handle piped values amongst regular text", () => {
       const pipe1 = createPipe();
-      const pipe2 = createPipe({ id: "2", text: "bar" });
+      const pipe2 = createPipe({
+        id: "1151378b-579d-40bf-b4d4-a378c573706a",
+        text: "bar",
+      });
       const html = `hello ${pipe1}${pipe2} world`;
 
       expect(convertPipes(createContext())(html)).toEqual(
-        "hello {{ answers['answer1'] }}{{ format_currency(answers['answer2'], 'GBP') }} world"
+        "hello {{ answers['answer0151378b-579d-40bf-b4d4-a378c573706a'] }}{{ format_currency(answers['answer1151378b-579d-40bf-b4d4-a378c573706a'], 'GBP') }} world"
       );
     });
 
     describe("formatting", () => {
       it("should format Date Range answers with `format_date`", () => {
-        const html = createPipe({ id: "3" });
+        const html = createPipe({ id: "2151378b-579d-40bf-b4d4-a378c573706a" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ answers['answer3'] | format_date }}"
+          "{{ answers['answer2151378b-579d-40bf-b4d4-a378c573706a'] | format_date }}"
         );
       });
 
       it("should format Date answers with `format_date`", () => {
-        const html = createPipe({ id: "4" });
+        const html = createPipe({ id: "3151378b-579d-40bf-b4d4-a378c573706a" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ answers['answer4'] | format_date }}"
+          "{{ answers['answer3151378b-579d-40bf-b4d4-a378c573706a'] | format_date }}"
         );
       });
 
       it("should format Currency answers with `format_currency`", () => {
-        const html = createPipe({ id: "2" });
+        const html = createPipe({ id: "1151378b-579d-40bf-b4d4-a378c573706a" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ format_currency(answers['answer2'], 'GBP') }}"
+          "{{ format_currency(answers['answer1151378b-579d-40bf-b4d4-a378c573706a'], 'GBP') }}"
         );
       });
 
       it("should format Number answers with `format_number`", () => {
-        const html = createPipe({ id: "5" });
+        const html = createPipe({ id: "4151378b-579d-40bf-b4d4-a378c573706a" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ answers['answer5'] | format_number }}"
+          "{{ answers['answer4151378b-579d-40bf-b4d4-a378c573706a'] | format_number }}"
         );
       });
 
       it("should format Units answers with `format_unit` and includes the unit type", () => {
-        const html = createPipe({ id: "6" });
+        const html = createPipe({ id: "5151378b-579d-40bf-b4d4-a378c573706a" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{ format_unit('length-meter',answers['answer6']) }}"
+          "{{ format_unit('length-meter',answers['answer5151378b-579d-40bf-b4d4-a378c573706a']) }}"
         );
       });
     });


### PR DESCRIPTION
### What is the context of this PR?

If you piped a date range in Author and then viewed it in Runner, the piped value would not show. This was because the IDs for a date range work a little different; date ranges on Author are one answer type but converted in Publisher to two Date answers so that Runner can display them. To do this, we append `to` and `from` onto the ID from Author and make them the IDs of the two generated date answers. However, Publisher was still acting as if it was the single ID without the added `to` or `from` value. I've jigged the code around and added some regex to fix this.

### How to review 

* Make a new questionnaire with a Date Range answer
* Pipe that date range answer into the text of the next question
* View the survey on Runner and see if you can see the piped value
* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
