### PR TITLE
Ear 266 remove default answer in routing out

### DIFF
--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -18,6 +18,11 @@ const {
 const { createMutation } = require("../../createMutation");
 
 const {
+  NO_ROUTABLE_ANSWER_ON_PAGE,
+  NULL,
+} = require("../../../../constants/routingNoLeftSide");
+
+const {
   getPages,
   getAnswers,
   getAnswerById,
@@ -167,10 +172,15 @@ Resolvers.Mutation = {
       condition = answerTypeToConditions.getDefault(firstAnswer.type);
     }
 
-    const left = {
-      answerId: firstAnswer.id,
-      type: "Default",
-    };
+    const left = hasRoutableFirstAnswer
+      ? {
+          answerId: firstAnswer.id,
+          type: "Default",
+        }
+      : {
+          type: NULL,
+          nullReason: NO_ROUTABLE_ANSWER_ON_PAGE,
+        };
 
     const expression = createExpression({
       left,

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/RoutingAnswerContentPicker.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/RoutingAnswerContentPicker.js
@@ -20,6 +20,8 @@ const GET_AVAILABLE_ROUTING_ANSWERS = gql`
         availableRoutingAnswers {
           id
           displayName
+          properties
+          type
           page {
             id
             displayName

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/index.js
@@ -311,7 +311,10 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
           <Column gutters={false} cols={2.5}>
             <ActionButtons
               data-test="action-btns"
-              isHidden={this.props.expression.left.reason === DEFAULT_ROUTING}
+              isHidden={
+                this.props.expression.left.reason === DEFAULT_ROUTING ||
+                this.props.expression.left.reason === NO_ROUTABLE_ANSWER_ON_PAGE
+              }
             >
               <RemoveButton
                 onClick={this.handleDeleteClick}
@@ -333,7 +336,10 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
 
         <DefaultRouteDiv
           className={className}
-          hasPadding={this.props.expression.left.reason === DEFAULT_ROUTING}
+          hasPadding={
+            this.props.expression.left.reason === DEFAULT_ROUTING ||
+            this.props.expression.left.reason === NO_ROUTABLE_ANSWER_ON_PAGE
+          }
         >
           <Grid>
             <Column gutters={false} cols={1.5}>
@@ -342,7 +348,11 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
             <Column gutters={false} cols={8}>
               <StyledTransition
                 data-test="transition-condition"
-                isHidden={this.props.expression.left.reason === DEFAULT_ROUTING}
+                isHidden={
+                  this.props.expression.left.reason === DEFAULT_ROUTING ||
+                  this.props.expression.left.reason ===
+                    NO_ROUTABLE_ANSWER_ON_PAGE
+                }
               >
                 <TransitionGroup>
                   <Transition key="answer">{routingEditor}</Transition>


### PR DESCRIPTION
### What is the context of this PR?

Change the default routing out rule from the current answer to a 'select and answer' drop down

### How to review 

Create at least 3 questions with routable answers - (radio, units or number)
on the 3rd question go to routing
The default setting should look like this....
![screencapture-localhost-routing1](https://user-images.githubusercontent.com/6759437/82424099-9be01e80-9a7c-11ea-96ec-ec1984240ed2.png)

Select an answer from the drop down
the 'remove' button (disabled) and 'add' buttons should appear next to your selected answer along with the condition....
![screencapture-localhost-routing3](https://user-images.githubusercontent.com/6759437/82425280-355c0000-9a7e-11ea-8528-d8b8f94060b3.png)

Add another answer.
This should also show the default ' select an answer' drop down.
![screencapture-localhost-routing2](https://user-images.githubusercontent.com/6759437/82424466-2294fb80-9a7d-11ea-9520-bd07b4131da1.png)

CREATE another question - don't fill in the title etc so that it has validation errors
go straight to routing
it should look like the default route setting:
![screencapture-localhost-routing1](https://user-images.githubusercontent.com/6759437/82424099-9be01e80-9a7c-11ea-96ec-ec1984240ed2.png)

on hitting 'select an answer' - the answer with validation errors should NOT be on the list