### PR TITLE
Add answer type to routing out picker

### DIFF
--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/RoutingAnswerContentPicker.js
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/RoutingAnswerContentPicker.js
@@ -20,6 +20,7 @@ const GET_AVAILABLE_ROUTING_ANSWERS = gql`
         availableRoutingAnswers {
           id
           displayName
+          type
           page {
             id
             displayName


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?

Routing out content picker was missing small answer type to the right. 

Added answer type to the graphql query

### How to review 

1. Check routing out content picker for answer type on the right

