### PR TITLE
change 'new questionnaire' modal layout to look like setting page

### DIFF
--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -108,7 +108,7 @@ exports[`QuestionnaireMeta should render 1`] = `
         />
       </QuestionnaireMeta__InlineField>
       <Panel__InformationPanel>
-        Let respondents move between sections while they're completing the questionnaire.
+        Let respondents move between sections while they're completing their questionnaire.
       </Panel__InformationPanel>
       <QuestionnaireMeta__HorizontalSeparator />
       <QuestionnaireMeta__InlineField>

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -1,159 +1,154 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QuestionnaireMeta should render 1`] = `
-<Form
-  onSubmit={[MockFunction]}
+<ScrollPane
+  permanentScrollBar={false}
 >
-  <Field
-    disabled={false}
-    last={false}
+  <Form
+    onSubmit={[MockFunction]}
   >
-    <Label
-      bold={true}
-      htmlFor="title"
+    <Field
+      disabled={false}
+      last={false}
     >
-      Questionnaire Title
-    </Label>
-    <withChangeHandler(UncontrolledInput)
-      autoFocus={true}
-      data-test="txt-questionnaire-title"
-      defaultValue="I am the title"
-      id="title"
-      onChange={[MockFunction]}
-      required={true}
-    />
-  </Field>
-  <Grid
-    align="top"
-    fillHeight={true}
-  >
-    <Column
-      cols={6}
-    >
-      <Field
-        disabled={false}
-        last={false}
+      <Label
+        bold={true}
+        htmlFor="title"
       >
-        <Label
-          bold={true}
-          htmlFor="shortTitle"
-        >
-          Short title (optional)
-        </Label>
-        <withChangeHandler(UncontrolledInput)
-          data-test="txt-questionnaire-short-title"
-          defaultValue="I am the shortTitle"
-          id="shortTitle"
-          onChange={[MockFunction]}
-        />
-      </Field>
-    </Column>
-    <Column
-      cols={6}
+        Questionnaire Title
+      </Label>
+      <withChangeHandler(UncontrolledInput)
+        autoFocus={true}
+        data-test="txt-questionnaire-title"
+        defaultValue="I am the title"
+        id="title"
+        onChange={[MockFunction]}
+        required={true}
+      />
+    </Field>
+    <Grid
+      align="top"
+      fillHeight={true}
     >
-      <Field
-        disabled={false}
-        last={false}
+      <Column
+        cols={6}
       >
-        <Label
-          bold={true}
-          htmlFor="type"
-        >
-          Questionnaire type
-        </Label>
-        <withChangeHandler(Select__SimpleSelect)
-          data-test="select-questionnaire-type"
-          defaultValue=""
+        <Field
           disabled={false}
-          id="type"
+          last={false}
+        >
+          <Label
+            bold={true}
+            htmlFor="shortTitle"
+          >
+            Short title (optional)
+          </Label>
+          <withChangeHandler(UncontrolledInput)
+            data-test="txt-questionnaire-short-title"
+            defaultValue="I am the shortTitle"
+            id="shortTitle"
+            onChange={[MockFunction]}
+          />
+        </Field>
+      </Column>
+      <Column
+        cols={6}
+      >
+        <Field
+          disabled={false}
+          last={false}
+        >
+          <Label
+            bold={true}
+            htmlFor="type"
+          >
+            Questionnaire type
+          </Label>
+          <withChangeHandler(Select__SimpleSelect)
+            data-test="select-questionnaire-type"
+            defaultValue=""
+            disabled={false}
+            id="type"
+            onChange={[MockFunction]}
+          >
+            <option
+              disabled={true}
+              value=""
+            >
+              Please select...
+            </option>
+            <option
+              value="Business"
+            >
+              Business
+            </option>
+            <option
+              value="Social"
+            >
+              Social
+            </option>
+          </withChangeHandler(Select__SimpleSelect)>
+        </Field>
+      </Column>
+    </Grid>
+    <QuestionnaireMeta__ToggleWrapper>
+      <QuestionnaireMeta__InlineField>
+        <Label
+          bold={true}
+        >
+          Section navigation
+        </Label>
+        <QuestionnaireMeta__VerticalSeparator />
+        <ToggleSwitch
+          checked={false}
+          hideLabels={false}
+          id="navigation"
+          name="navigation"
           onChange={[MockFunction]}
-        >
-          <option
-            disabled={true}
-            value=""
-          >
-            Please select...
-          </option>
-          <option
-            value="Business"
-          >
-            Business
-          </option>
-          <option
-            value="Social"
-          >
-            Social
-          </option>
-        </withChangeHandler(Select__SimpleSelect)>
-      </Field>
-    </Column>
-  </Grid>
-  <QuestionnaireMeta__ToggleWrapper>
-    <QuestionnaireMeta__InlineField>
-      <QuestionnaireMeta__FlexLabel
-        htmlFor="navigation"
-        inline={true}
-      >
-        <QuestionnaireMeta__Icon
-          alt=""
-          fade={true}
-          src="icon-show-nav.svg"
         />
-        <DescribedText
-          description="Allows respondents to navigate between sections when they are completing the survey."
+      </QuestionnaireMeta__InlineField>
+      <Panel__InformationPanel>
+        Let respondents move between sections while they're completing the questionnaire.
+      </Panel__InformationPanel>
+      <QuestionnaireMeta__HorizontalSeparator />
+      <QuestionnaireMeta__InlineField>
+        <Label
+          bold={true}
         >
-          Show section navigation
-        </DescribedText>
-      </QuestionnaireMeta__FlexLabel>
-      <ToggleSwitch
-        checked={false}
-        id="navigation"
-        name="navigation"
-        onChange={[MockFunction]}
-      />
-    </QuestionnaireMeta__InlineField>
-    <QuestionnaireMeta__InlineField>
-      <QuestionnaireMeta__FlexLabel
-        htmlFor="summary"
-        inline={true}
-      >
-        <QuestionnaireMeta__Icon
-          alt=""
-          fade={true}
-          src="icon-show-confirmation.svg"
+          Answers summary
+        </Label>
+        <QuestionnaireMeta__VerticalSeparator />
+        <ToggleSwitch
+          checked={false}
+          hideLabels={false}
+          id="summary"
+          name="summary"
+          onChange={[MockFunction]}
         />
-        <DescribedText
-          description="A summary of all of the respondent's answers will be shown on the confirmation page at the end of the survey."
-        >
-          Show summary on confirmation page
-        </DescribedText>
-      </QuestionnaireMeta__FlexLabel>
-      <ToggleSwitch
-        checked={false}
-        id="summary"
-        name="summary"
-        onChange={[MockFunction]}
-      />
-    </QuestionnaireMeta__InlineField>
-  </QuestionnaireMeta__ToggleWrapper>
-  <ButtonGroup
-    align="right"
-    horizontal={true}
-  >
-    <Button
-      type="button"
-      variant="secondary"
+      </QuestionnaireMeta__InlineField>
+      <Panel__InformationPanel>
+        Let respondents check their answers before submitting their questionnaire
+      </Panel__InformationPanel>
+    </QuestionnaireMeta__ToggleWrapper>
+    <ButtonGroup
+      align="right"
+      horizontal={true}
     >
-      Cancel
-    </Button>
-    <Button
-      data-test="questionnaire-submit-button"
-      disabled={true}
-      type="submit"
-      variant="primary"
-    >
-      Create
-    </Button>
-  </ButtonGroup>
-</Form>
+      <Button
+        type="button"
+        variant="secondary"
+      >
+        Cancel
+      </Button>
+      <Button
+        data-test="questionnaire-submit-button"
+        disabled={true}
+        type="submit"
+        variant="primary"
+      >
+        Create
+      </Button>
+    </ButtonGroup>
+  </Form>
+</ScrollPane>
 `;

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QuestionnaireMeta should render 1`] = `
-<ScrollPane
+<QuestionnaireMeta__StyledScrollPane
   permanentScrollBar={false}
 >
   <Form
@@ -157,5 +157,5 @@ exports[`QuestionnaireMeta should render 1`] = `
       </Button>
     </ButtonGroup>
   </Form>
-</ScrollPane>
+</QuestionnaireMeta__StyledScrollPane>
 `;

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -91,6 +91,13 @@ exports[`QuestionnaireMeta should render 1`] = `
         </Field>
       </Column>
     </Grid>
+    <QuestionnaireMeta__HorizontalSeparator
+      style={
+        Object {
+          "marginTop": "0.5em",
+        }
+      }
+    />
     <QuestionnaireMeta__ToggleWrapper>
       <QuestionnaireMeta__InlineField>
         <Label

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -22,7 +22,7 @@ const ToggleWrapper = styled.div`
 const HorizontalSeparator = styled.hr`
   border: 0;
   border-top: 0.0625em solid ${colors.lightMediumGrey};
-  margin: 1.5em 0;
+  margin: 1.5em 0 0.7em 0;
 `;
 
 const VerticalSeparator = styled.div`
@@ -94,6 +94,8 @@ export const StatelessQuestionnaireMeta = ({
           </Field>
         </Column>
       </Grid>
+
+      <HorizontalSeparator style={{ marginTop: "0.5em" }} />
 
       <ToggleWrapper>
         <InlineField>

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -8,38 +8,38 @@ import ToggleSwitch from "components/buttons/ToggleSwitch";
 import withEntityEditor from "components/withEntityEditor";
 import ButtonGroup from "components/buttons/ButtonGroup";
 import Button from "components/buttons/Button";
-import DescribedText from "components/DescribedText";
 import { Grid, Column } from "components/Grid";
+import ScrollPane from "components/ScrollPane";
+import { InformationPanel } from "components/Panel";
+import { colors } from "constants/theme";
 
 import questionnaireFragment from "graphql/fragments/questionnaire.graphql";
-
-import showConfirmationIcon from "./icon-show-confirmation.svg";
-import showNavIcon from "./icon-show-nav.svg";
-
-const Icon = styled.img`
-  height: 3em;
-  vertical-align: middle;
-  margin-right: 1em;
-  transition: opacity 100ms linear;
-  opacity: ${props => (props.fade ? 0.5 : 1)};
-`;
-
-const InlineField = styled(Field)`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1em 0;
-  margin: 0 1em 0 0;
-`;
 
 const ToggleWrapper = styled.div`
   margin: 0 0 1em;
 `;
 
-const FlexLabel = styled(Label)`
+const HorizontalSeparator = styled.hr`
+  border: 0;
+  border-top: 0.0625em solid ${colors.lightMediumGrey};
+  margin: 1.5em 0;
+`;
+
+const VerticalSeparator = styled.div`
+  width: 1px;
+  height: 1.5em;
+  background-color: ${colors.blue};
+  margin: 0 1em;
+  margin-bottom: 0.4em;
+`;
+
+const InlineField = styled(Field)`
   display: flex;
   align-items: center;
+  margin-bottom: 0.4em;
+  > * {
+    margin-bottom: 0;
+  }
 `;
 
 export const StatelessQuestionnaireMeta = ({
@@ -50,98 +50,99 @@ export const StatelessQuestionnaireMeta = ({
   confirmText,
   canEditType,
 }) => (
-  <Form onSubmit={onSubmit}>
-    <Field>
-      <Label htmlFor="title">Questionnaire Title</Label>
-      <Input
-        id="title"
-        autoFocus
-        defaultValue={questionnaire.title}
-        onChange={onChange}
-        required
-        data-test="txt-questionnaire-title"
-      />
-    </Field>
-    <Grid>
-      <Column cols={6}>
-        <Field>
-          <Label htmlFor="shortTitle">Short title (optional)</Label>
-          <Input
-            id="shortTitle"
-            defaultValue={questionnaire.shortTitle}
-            onChange={onChange}
-            data-test="txt-questionnaire-short-title"
-          />
-        </Field>
-      </Column>
-      <Column cols={6}>
-        <Field disabled={!canEditType}>
-          <Label htmlFor="type">Questionnaire type</Label>
-          <Select
-            id="type"
-            onChange={onChange}
-            defaultValue={questionnaire.type || ""}
-            data-test="select-questionnaire-type"
-            disabled={!canEditType}
-          >
-            <option value="" disabled>
-              Please select...
-            </option>
-            <option value="Business">Business</option>
-            <option value="Social">Social</option>
-          </Select>
-        </Field>
-      </Column>
-    </Grid>
+  <ScrollPane>
+    <Form onSubmit={onSubmit}>
+      <Field>
+        <Label htmlFor="title">Questionnaire Title</Label>
+        <Input
+          id="title"
+          autoFocus
+          defaultValue={questionnaire.title}
+          onChange={onChange}
+          required
+          data-test="txt-questionnaire-title"
+        />
+      </Field>
+      <Grid>
+        <Column cols={6}>
+          <Field>
+            <Label htmlFor="shortTitle">Short title (optional)</Label>
+            <Input
+              id="shortTitle"
+              defaultValue={questionnaire.shortTitle}
+              onChange={onChange}
+              data-test="txt-questionnaire-short-title"
+            />
+          </Field>
+        </Column>
+        <Column cols={6}>
+          <Field disabled={!canEditType}>
+            <Label htmlFor="type">Questionnaire type</Label>
+            <Select
+              id="type"
+              onChange={onChange}
+              defaultValue={questionnaire.type || ""}
+              data-test="select-questionnaire-type"
+              disabled={!canEditType}
+            >
+              <option value="" disabled>
+                Please select...
+              </option>
+              <option value="Business">Business</option>
+              <option value="Social">Social</option>
+            </Select>
+          </Field>
+        </Column>
+      </Grid>
 
-    <ToggleWrapper>
-      <InlineField>
-        <FlexLabel inline htmlFor="navigation">
-          <Icon src={showNavIcon} alt="" fade={!questionnaire.navigation} />
-          <DescribedText description="Allows respondents to navigate between sections when they are completing the survey.">
-            Show section navigation
-          </DescribedText>
-        </FlexLabel>
-        <ToggleSwitch
-          id="navigation"
-          name="navigation"
-          onChange={onChange}
-          checked={questionnaire.navigation}
-        />
-      </InlineField>
-      <InlineField>
-        <FlexLabel inline htmlFor="summary">
-          <Icon
-            src={showConfirmationIcon}
-            alt=""
-            fade={!questionnaire.summary}
+      <ToggleWrapper>
+        <InlineField>
+          <Label>Section navigation</Label>
+          <VerticalSeparator />
+          <ToggleSwitch
+            id="navigation"
+            name="navigation"
+            onChange={onChange}
+            checked={questionnaire.navigation}
+            hideLabels={false}
           />
-          <DescribedText description="A summary of all of the respondent's answers will be shown on the confirmation page at the end of the survey.">
-            Show summary on confirmation page
-          </DescribedText>
-        </FlexLabel>
-        <ToggleSwitch
-          id="summary"
-          name="summary"
-          onChange={onChange}
-          checked={questionnaire.summary}
-        />
-      </InlineField>
-    </ToggleWrapper>
-    <ButtonGroup horizontal align="right">
-      <Button onClick={onCancel} variant="secondary" type="button">
-        Cancel
-      </Button>
-      <Button
-        type="submit"
-        variant="primary"
-        disabled={!(questionnaire.title && questionnaire.type)}
-        data-test="questionnaire-submit-button"
-      >
-        {confirmText}
-      </Button>
-    </ButtonGroup>
-  </Form>
+        </InlineField>
+        <InformationPanel>
+          Let respondents move between sections while they&apos;re completing
+          the questionnaire.
+        </InformationPanel>
+        <HorizontalSeparator />
+        <InlineField>
+          <Label>Answers summary</Label>
+          <VerticalSeparator />
+          <ToggleSwitch
+            id="summary"
+            name="summary"
+            onChange={onChange}
+            checked={questionnaire.summary}
+            hideLabels={false}
+          />
+        </InlineField>
+        <InformationPanel>
+          Let respondents check their answers before submitting their
+          questionnaire
+        </InformationPanel>
+      </ToggleWrapper>
+      <ButtonGroup horizontal align="right">
+        <Button onClick={onCancel} variant="secondary" type="button">
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!(questionnaire.title && questionnaire.type)}
+          data-test="questionnaire-submit-button"
+        >
+          {confirmText}
+        </Button>
+      </ButtonGroup>
+    </Form>
+  </ScrollPane>
 );
 
 StatelessQuestionnaireMeta.defaultProps = {

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -22,7 +22,7 @@ const ToggleWrapper = styled.div`
 const HorizontalSeparator = styled.hr`
   border: 0;
   border-top: 0.0625em solid ${colors.lightMediumGrey};
-  margin: 1.5em 0 0.7em 0;
+  margin: 1.5em 0 0.7em;
 `;
 
 const VerticalSeparator = styled.div`

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -109,7 +109,7 @@ export const StatelessQuestionnaireMeta = ({
         </InlineField>
         <InformationPanel>
           Let respondents move between sections while they&apos;re completing
-          the questionnaire.
+          their questionnaire.
         </InformationPanel>
         <HorizontalSeparator />
         <InlineField>

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -15,6 +15,10 @@ import { colors } from "constants/theme";
 
 import questionnaireFragment from "graphql/fragments/questionnaire.graphql";
 
+const StyledScrollPane = styled(ScrollPane)`
+  padding: 5px;
+`;
+
 const ToggleWrapper = styled.div`
   margin: 0 0 1em;
 `;
@@ -50,7 +54,7 @@ export const StatelessQuestionnaireMeta = ({
   confirmText,
   canEditType,
 }) => (
-  <ScrollPane>
+  <StyledScrollPane>
     <Form onSubmit={onSubmit}>
       <Field>
         <Label htmlFor="title">Questionnaire Title</Label>
@@ -144,7 +148,7 @@ export const StatelessQuestionnaireMeta = ({
         </Button>
       </ButtonGroup>
     </Form>
-  </ScrollPane>
+  </StyledScrollPane>
 );
 
 StatelessQuestionnaireMeta.defaultProps = {

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/FieldWithInclude.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/FieldWithInclude.test.js.snap
@@ -16,6 +16,7 @@ exports[`FieldWithInclude should render 1`] = `
   <FieldWithInclude__InlineField>
     <ToggleSwitch
       checked={false}
+      hideLabels={true}
       id="1"
       name="name"
       onChange={[MockFunction]}

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/ValidationView.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/ValidationView.test.js.snap
@@ -7,6 +7,7 @@ exports[`ValidationView should render children when enabled 1`] = `
   >
     <ToggleSwitch
       checked={true}
+      hideLabels={true}
       id="ValidationView1"
       name="ValidationView1"
       onChange={[MockFunction]}
@@ -47,6 +48,7 @@ exports[`ValidationView should render disabled messaged when disabled 1`] = `
   >
     <ToggleSwitch
       checked={false}
+      hideLabels={true}
       id="ValidationView2"
       name="ValidationView2"
       onChange={[MockFunction]}

--- a/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/Properties/__snapshots__/Required.test.js.snap
+++ b/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/AnswerProperties/Properties/__snapshots__/Required.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Required Property should render 1`] = `
 <ToggleSwitch
   checked={true}
+  hideLabels={true}
   id="1"
   name="1"
   onChange={[MockFunction]}

--- a/eq-author/src/App/page/PropertiesPanel/QuestionProperties/__snapshots__/Property.test.js.snap
+++ b/eq-author/src/App/page/PropertiesPanel/QuestionProperties/__snapshots__/Property.test.js.snap
@@ -12,6 +12,7 @@ exports[`Property should render 1`] = `
   </Property__PropertyLabel>
   <ToggleSwitch
     checked={false}
+    hideLabels={true}
     id="1"
     name="1"
     onChange={[MockFunction]}

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -4,10 +4,6 @@ exports[`ToggleSwitch should render 1`] = `
 <DocumentFragment>
   .c0 {
   padding: 0 0.8em;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -184,10 +180,6 @@ exports[`ToggleSwitch should render 1`] = `
   </div>
   .c0 {
   padding: 0 0.8em;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -209,10 +201,6 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
 <DocumentFragment>
   .c0 {
   padding: 0 0.8em;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -389,10 +377,6 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
   </div>
   .c0 {
   padding: 0 0.8em;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -2,6 +2,26 @@
 
 exports[`ToggleSwitch should render 1`] = `
 <DocumentFragment>
+  .c0 {
+  padding: 0 0.8em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: none;
+  color: #333333;
+  font-weight: 600;
+}
+
+<div
+    class="c0"
+  >
+    Off
+  </div>
   .c1 {
   font-size: 1em;
   border: thin solid #999999;
@@ -162,11 +182,51 @@ exports[`ToggleSwitch should render 1`] = `
       />
     </div>
   </div>
+  .c0 {
+  padding: 0 0.8em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: none;
+  color: #666666;
+  font-weight: normal;
+}
+
+<div
+    class="c0"
+  >
+    On
+  </div>
 </DocumentFragment>
 `;
 
 exports[`ToggleSwitch should render a large toggle button 1`] = `
 <DocumentFragment>
+  .c0 {
+  padding: 0 0.8em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: none;
+  color: #333333;
+  font-weight: 600;
+}
+
+<div
+    class="c0"
+  >
+    Off
+  </div>
   .c1 {
   font-size: 1em;
   border: thin solid #999999;
@@ -326,6 +386,26 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
         class="c5"
       />
     </div>
+  </div>
+  .c0 {
+  padding: 0 0.8em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: none;
+  color: #666666;
+  font-weight: normal;
+}
+
+<div
+    class="c0"
+  >
+    On
   </div>
 </DocumentFragment>
 `;

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -185,7 +185,7 @@ exports[`ToggleSwitch should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: none;
-  color: #666666;
+  color: #999999;
   font-weight: normal;
 }
 
@@ -382,7 +382,7 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: none;
-  color: #666666;
+  color: #999999;
   font-weight: normal;
 }
 

--- a/eq-author/src/components/buttons/ToggleSwitch/index.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.js
@@ -21,6 +21,11 @@ const backgroundSize = {
   height: 1,
 };
 
+const labelColors = {
+  on: colors.black,
+  off: colors.darkGrey,
+};
+
 const knobSize = 1;
 
 const border = {
@@ -86,16 +91,27 @@ const FlexInline = styled.div`
   position: relative;
 `;
 
+const ToggleLabel = styled.div`
+  padding: 0 0.8em;
+  display: flex;
+  align-items: center;
+  display: ${props => (props.isHidden ? "none" : "flex")};
+  color: ${props => (props.checked ? labelColors.on : labelColors.off)};
+  font-weight: ${props => (props.checked ? 600 : "normal")};
+`;
+
 class ToggleSwitch extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     checked: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     name: PropTypes.string.isRequired,
+    hideLabels: PropTypes.bool,
   };
 
   static defaultProps = {
     checked: false,
+    hideLabels: true,
   };
 
   constructor(props) {
@@ -121,26 +137,35 @@ class ToggleSwitch extends React.Component {
   };
 
   render() {
-    const { id, checked, onChange } = this.props;
+    const { id, checked, onChange, hideLabels } = this.props;
+
     return (
-      <FlexInline role="switch" aria-checked={checked} data-test={id}>
-        <HiddenInput
-          id={this.id}
-          type="checkbox"
-          role="checkbox"
-          aria-checked={checked}
-          onChange={onChange}
-          checked={checked}
-          ref={this.inputRef}
-        />
-        <ToggleSwitchBackground
-          role="presentation"
-          checked={checked}
-          onClick={this.handleToggle}
-        >
-          <ToggleSwitchKnob checked={checked} />
-        </ToggleSwitchBackground>
-      </FlexInline>
+      <>
+        <ToggleLabel checked={!checked} isHidden={hideLabels}>
+          Off
+        </ToggleLabel>
+        <FlexInline role="switch" aria-checked={checked} data-test={id}>
+          <HiddenInput
+            id={this.id}
+            type="checkbox"
+            role="checkbox"
+            aria-checked={checked}
+            onChange={onChange}
+            checked={checked}
+            ref={this.inputRef}
+          />
+          <ToggleSwitchBackground
+            role="presentation"
+            checked={checked}
+            onClick={this.handleToggle}
+          >
+            <ToggleSwitchKnob checked={checked} />
+          </ToggleSwitchBackground>
+        </FlexInline>
+        <ToggleLabel checked={checked} isHidden={hideLabels}>
+          On
+        </ToggleLabel>
+      </>
     );
   }
 }

--- a/eq-author/src/components/buttons/ToggleSwitch/index.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.js
@@ -23,7 +23,7 @@ const backgroundSize = {
 
 const labelColors = {
   on: colors.black,
-  off: colors.darkGrey,
+  off: colors.grey,
 };
 
 const knobSize = 1;

--- a/eq-author/src/components/buttons/ToggleSwitch/index.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.js
@@ -93,7 +93,6 @@ const FlexInline = styled.div`
 
 const ToggleLabel = styled.div`
   padding: 0 0.8em;
-  display: flex;
   align-items: center;
   display: ${props => (props.isHidden ? "none" : "flex")};
   color: ${props => (props.checked ? labelColors.on : labelColors.off)};

--- a/eq-author/src/components/buttons/ToggleSwitch/index.test.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.test.js
@@ -58,7 +58,7 @@ describe("ToggleSwitch", () => {
     expect(getByText("Off")).toHaveStyleRule("color", colors.black);
     expect(getByText("Off")).toHaveStyleRule("display", "flex");
 
-    expect(getByText("On")).toHaveStyleRule("color", colors.darkGrey);
+    expect(getByText("On")).toHaveStyleRule("color", colors.grey);
     expect(getByText("On")).toHaveStyleRule("display", "flex");
   });
 
@@ -69,7 +69,7 @@ describe("ToggleSwitch", () => {
       checked: true,
       hideLabels: false,
     });
-    expect(getByText("Off")).toHaveStyleRule("color", colors.darkGrey);
+    expect(getByText("Off")).toHaveStyleRule("color", colors.grey);
     expect(getByText("Off")).toHaveStyleRule("display", "flex");
 
     expect(getByText("On")).toHaveStyleRule("color", colors.black);

--- a/eq-author/src/components/buttons/ToggleSwitch/index.test.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.test.js
@@ -41,6 +41,41 @@ describe("ToggleSwitch", () => {
     );
   });
 
+  it("should not render on/off labels by default", () => {
+    const { getByText } = renderComponent({
+      ...props,
+    });
+    expect(getByText("Off")).toHaveStyleRule("display", "none");
+    expect(getByText("On")).toHaveStyleRule("display", "none");
+  });
+
+  it("should render on/off labels when label prop is passed", () => {
+    const { getByText } = renderComponent({
+      ...props,
+      id: "toggle-2",
+      hideLabels: false,
+    });
+    expect(getByText("Off")).toHaveStyleRule("color", colors.black);
+    expect(getByText("Off")).toHaveStyleRule("display", "flex");
+
+    expect(getByText("On")).toHaveStyleRule("color", colors.darkGrey);
+    expect(getByText("On")).toHaveStyleRule("display", "flex");
+  });
+
+  it("should change on/off label colors when prop is passed and checked", () => {
+    const { getByText } = renderComponent({
+      ...props,
+      id: "toggle-2",
+      checked: true,
+      hideLabels: false,
+    });
+    expect(getByText("Off")).toHaveStyleRule("color", colors.darkGrey);
+    expect(getByText("Off")).toHaveStyleRule("display", "flex");
+
+    expect(getByText("On")).toHaveStyleRule("color", colors.black);
+    expect(getByText("On")).toHaveStyleRule("display", "flex");
+  });
+
   it("should render a large toggle button", () => {
     expect(
       renderComponent({


### PR DESCRIPTION

Bring "Create questionnaire" modal in line with "Settings" page

### How to review 

Acceptance criteria (user perspective)
1. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN "Questionnaire Title" is "Questionnaire title"

2. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN "Allows respondents to navigate between sections when they are completing the survey." is "Let respondents move between sections while they're completing their questionnaire."

3. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN "Section navigation" is off by default

4. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN "Show summary on confirmation page" is "Answers summary"
AND "A summary of all of the respondent's answers will be shown on the confirmation page at the end of the survey." is "Let respondents check their answers before submitting their questionnaire."

5. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN the section navigation and answers summary toggles have off/on labels

6. GIVEN I'm on the homepage
WHEN I click "Create questionnaire"
THEN "Answers summary" is off by default

New modal look when creating a new questionnaire...
Should look like this:
![Settings Modal](https://user-images.githubusercontent.com/6759437/83252792-c8deb080-a1a3-11ea-8d89-e7a72120696b.jpg)


### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
