### PR TITLE
Fix home page short title

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -46,7 +46,7 @@ export const ShortTitle = styled.span`
   text-decoration-color: ${colors.textLight};
   font-size: 0.8em;
   font-weight: bold;
-  letter-spacing: 0.05em;
+  letter-spacing: 0;
 `;
 
 const ButtonGroup = styled.div`


### PR DESCRIPTION
### What is the context of this PR?

Make spacing in short title .05 less than before

### How to review 

- Make a questionnaire
- Add a short title
- Go back to home screen
- The short title should have 0 `letter-spacing`
