### PR TITLE
max / min validation errors when using previous answer

### DIFF
--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -629,6 +629,53 @@ describe("schema validation", () => {
           expect(pageErrors.totalCount).toBe(0);
         });
       });
+
+      it("should not validate if one of the two is a previous answer", () => {
+        ["minValue", "maxValue", "none"].forEach(entity => {
+          const answer = {
+            id: "a1",
+            type: NUMBER,
+            label: "some answer",
+            validation: {
+              minValue: {
+                id: "123",
+                enabled: entity === "minValue",
+                custom: 50,
+                inclusive: true,
+                entityType: "Custom",
+                previousAnswer: null,
+              },
+              maxValue: {
+                id: "321",
+                enabled: entity === "maxValue",
+                custom: 40,
+                inclusive: true,
+                entityType: "PreviousAnswer",
+                previousAnswer: { displayName: "a previous answer", id: "1" },
+              },
+            },
+          };
+
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                pages: [
+                  {
+                    id: "p1",
+                    answers: [answer],
+                  },
+                ],
+              },
+            ],
+          };
+          const pageErrors = validation(questionnaire);
+
+          expect(pageErrors.validation).toMatchObject({});
+          expect(pageErrors.totalCount).toBe(0);
+        });
+      });
     });
   });
 

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -215,6 +215,9 @@
                       "properties": {
                         "enabled": {
                           "const": true
+                        },
+                        "previousAnswer": {
+                          "const": null
                         }
                       }
                     }
@@ -226,6 +229,9 @@
                       "properties": {
                         "enabled": {
                           "const": true
+                        },
+                        "previousAnswer": {
+                          "const": null
                         }
                       }
                     }

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -46,7 +46,7 @@ export const ShortTitle = styled.span`
   text-decoration-color: ${colors.textLight};
   font-size: 0.8em;
   font-weight: bold;
-  letter-spacing: 0.05em;
+  letter-spacing: 0;
 `;
 
 const ButtonGroup = styled.div`


### PR DESCRIPTION
### What is the context of this PR?

This PR is to remove any validation on Min/Max values when one or both of them contain a previous answer

### How to review 

- create a Questionnaire with 2 number answers

- the first should have min and max values enabled and be tested for normal validation working - eg, max no. must be greater than min no. This should still show relevant errors

- The second answer should have both min and max values enabled

- One of these should be a previous answer

- In this case, there should be NO validation error shown regardless of the value of the other.
