### PR TITLE
Ear 235 openclose all

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
@@ -78,7 +78,7 @@ const NavLink = ({ to, title, children, icon, errorCount, ...otherProps }) => (
 );
 
 NavLink.propTypes = {
-  to: PropTypes.string.isRequired,
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   icon: PropTypes.func.isRequired,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
@@ -19,14 +19,12 @@ const NavList = styled.ol`
 class SectionNav extends Component {
   static propTypes = {
     questionnaire: CustomPropTypes.questionnaire,
-    controlGroup: PropTypes.arrayOf(
-      PropTypes.shape({ identifier: PropTypes.number, isOpen: PropTypes.bool })
-    ).isRequired,
+    isOpen: PropTypes.bool.isRequired,
     handleChange: PropTypes.func,
   };
 
   render() {
-    const { questionnaire, controlGroup, handleChange } = this.props;
+    const { questionnaire, isOpen, handleChange } = this.props;
 
     return (
       <TransitionGroup component={NavList}>
@@ -34,7 +32,7 @@ class SectionNav extends Component {
           <NavItemTransition key={section.id} onEntered={scrollIntoView}>
             <SectionNavItem
               questionnaire={questionnaire}
-              controlGroup={controlGroup || true}
+              isOpen={isOpen}
               section={section}
               handleChange={handleChange}
               identity={index}

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
-import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
+import CustomPropTypes from "custom-prop-types";
+import PropTypes from "prop-types";
 
 import { TransitionGroup } from "react-transition-group";
 import NavItemTransition from "./NavItemTransition";
@@ -18,15 +19,20 @@ const NavList = styled.ol`
 class SectionNav extends Component {
   static propTypes = {
     questionnaire: CustomPropTypes.questionnaire,
+    isGroupOpen: PropTypes.bool.isRequired,
   };
 
   render() {
-    const { questionnaire } = this.props;
+    const { questionnaire, isGroupOpen } = this.props;
     return (
       <TransitionGroup component={NavList}>
         {questionnaire.sections.map(section => (
           <NavItemTransition key={section.id} onEntered={scrollIntoView}>
-            <SectionNavItem questionnaire={questionnaire} section={section} />
+            <SectionNavItem
+              questionnaire={questionnaire}
+              isGroupOpen={isGroupOpen}
+              section={section}
+            />
           </NavItemTransition>
         ))}
       </TransitionGroup>

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
@@ -19,19 +19,25 @@ const NavList = styled.ol`
 class SectionNav extends Component {
   static propTypes = {
     questionnaire: CustomPropTypes.questionnaire,
-    isGroupOpen: PropTypes.bool.isRequired,
+    controlGroup: PropTypes.arrayOf(
+      PropTypes.shape({ identifier: PropTypes.number, isOpen: PropTypes.bool })
+    ).isRequired,
+    handleChange: PropTypes.func,
   };
 
   render() {
-    const { questionnaire, isGroupOpen } = this.props;
+    const { questionnaire, controlGroup, handleChange } = this.props;
+
     return (
       <TransitionGroup component={NavList}>
-        {questionnaire.sections.map(section => (
+        {questionnaire.sections.map((section, index) => (
           <NavItemTransition key={section.id} onEntered={scrollIntoView}>
             <SectionNavItem
               questionnaire={questionnaire}
-              isGroupOpen={isGroupOpen}
+              controlGroup={controlGroup || true}
               section={section}
+              handleChange={handleChange}
+              identity={index}
             />
           </NavItemTransition>
         ))}

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
@@ -19,7 +19,7 @@ const NavList = styled.ol`
 class SectionNav extends Component {
   static propTypes = {
     questionnaire: CustomPropTypes.questionnaire,
-    isOpen: PropTypes.bool.isRequired,
+    isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
     handleChange: PropTypes.func,
   };
 

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
@@ -31,6 +31,7 @@ describe("SectionNav", () => {
         questionnaire={questionnaire}
         currentSectionId={section.id}
         currentPageId={page.id}
+        isOpen={{ open: true }}
       />,
       {
         route: `/q/${questionnaire.id}`,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
@@ -32,6 +32,7 @@ describe("SectionNav", () => {
         currentSectionId={section.id}
         currentPageId={page.id}
         isOpen={{ open: true }}
+        handleChange={jest.fn()}
       />,
       {
         route: `/q/${questionnaire.id}`,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -44,7 +44,7 @@ const propTypes = {
   questionnaire: CustomPropTypes.questionnaire,
   section: CustomPropTypes.section.isRequired,
   match: CustomPropTypes.match.isRequired,
-  isOpen: PropTypes.bool.isRequired,
+  isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
   handleChange: PropTypes.func.isRequired,
   identity: PropTypes.number.isRequired,
 };
@@ -60,13 +60,20 @@ export const UnwrappedSectionNavItem = props => {
     ...otherProps
   } = props;
 
+  // const url = buildSectionPath({
+  //   questionnaireId: questionnaire.id,
+  //   sectionId: section.id,
+  //   tab: match.params.tab,
+  // });
   const url = useCallback(() => {
     return buildSectionPath({
       questionnaireId: questionnaire.id,
       sectionId: section.id,
       tab: match.params.tab,
     });
-  }, [questionnaire]);
+  }, [questionnaire, match]);
+
+  // console.log(test, "what do we have here");
 
   const SectionTitle = useCallback(
     () => (

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 import { withRouter } from "react-router-dom";
 import gql from "graphql-tag";
@@ -40,34 +40,36 @@ const StyledSectionLower = styled.div`
   border-bottom: 1px solid ${colors.grey};
 `;
 
-export class UnwrappedSectionNavItem extends React.Component {
-  static propTypes = {
-    questionnaire: CustomPropTypes.questionnaire,
-    section: CustomPropTypes.section.isRequired,
-    match: CustomPropTypes.match.isRequired,
-    controlGroup: PropTypes.bool.isRequired,
-    identity: PropTypes.number.isRequired,
-    handleChange: PropTypes.func.isRequired,
-  };
+const propTypes = {
+  questionnaire: CustomPropTypes.questionnaire,
+  section: CustomPropTypes.section.isRequired,
+  match: CustomPropTypes.match.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  identity: PropTypes.number.isRequired,
+};
 
-  render() {
-    const {
-      questionnaire,
-      section,
-      match,
-      controlGroup,
-      handleChange,
-      identity,
-      ...otherProps
-    } = this.props;
+export const UnwrappedSectionNavItem = props => {
+  const {
+    questionnaire,
+    section,
+    match,
+    isOpen,
+    handleChange,
+    identity,
+    ...otherProps
+  } = props;
 
-    const url = buildSectionPath({
+  const url = useCallback(() => {
+    return buildSectionPath({
       questionnaireId: questionnaire.id,
       sectionId: section.id,
       tab: match.params.tab,
     });
+  }, [questionnaire]);
 
-    const SectionTitle = () => (
+  const SectionTitle = useCallback(
+    () => (
       <>
         <StyledSectionUpper>
           <div />
@@ -87,24 +89,27 @@ export class UnwrappedSectionNavItem extends React.Component {
           <div />
         </StyledSectionLower>
       </>
-    );
+    ),
+    [section, url]
+  );
 
-    return (
-      <StyledSectionsAccordion
-        title={<SectionTitle />}
-        titleName={section.displayName}
-        url={url}
-        controlGroup={controlGroup}
-        identity={identity}
-        handleChange={handleChange}
-      >
-        <StyledSectionNavItem data-test="section-item" {...otherProps}>
-          <PageNav section={section} questionnaire={questionnaire} />
-        </StyledSectionNavItem>
-      </StyledSectionsAccordion>
-    );
-  }
-}
+  return (
+    <StyledSectionsAccordion
+      title={<SectionTitle />}
+      titleName={section.displayName}
+      url={url}
+      isOpen={isOpen}
+      identity={identity}
+      handleChange={handleChange}
+    >
+      <StyledSectionNavItem data-test="section-item" {...otherProps}>
+        <PageNav section={section} questionnaire={questionnaire} />
+      </StyledSectionNavItem>
+    </StyledSectionsAccordion>
+  );
+};
+
+UnwrappedSectionNavItem.propTypes = propTypes;
 
 UnwrappedSectionNavItem.fragments = {
   SectionNavItem: gql`

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -45,7 +45,9 @@ export class UnwrappedSectionNavItem extends React.Component {
     questionnaire: CustomPropTypes.questionnaire,
     section: CustomPropTypes.section.isRequired,
     match: CustomPropTypes.match.isRequired,
-    isGroupOpen: PropTypes.bool.isRequired,
+    controlGroup: PropTypes.bool.isRequired,
+    identity: PropTypes.number.isRequired,
+    handleChange: PropTypes.func.isRequired,
   };
 
   render() {
@@ -53,7 +55,9 @@ export class UnwrappedSectionNavItem extends React.Component {
       questionnaire,
       section,
       match,
-      isGroupOpen,
+      controlGroup,
+      handleChange,
+      identity,
       ...otherProps
     } = this.props;
 
@@ -90,7 +94,9 @@ export class UnwrappedSectionNavItem extends React.Component {
         title={<SectionTitle />}
         titleName={section.displayName}
         url={url}
-        isGroupOpen={isGroupOpen}
+        controlGroup={controlGroup}
+        identity={identity}
+        handleChange={handleChange}
       >
         <StyledSectionNavItem data-test="section-item" {...otherProps}>
           <PageNav section={section} questionnaire={questionnaire} />

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -1,13 +1,15 @@
-import gql from "graphql-tag";
 import React from "react";
 import styled from "styled-components";
 import { withRouter } from "react-router-dom";
-
+import gql from "graphql-tag";
+import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import { colors } from "constants/theme";
-import PageNav from "./PageNav";
-import NavLink from "./NavLink";
+
 import { buildSectionPath } from "utils/UrlUtils";
+import NavLink from "./NavLink";
+import PageNav from "./PageNav";
+
+import { colors } from "constants/theme";
 import SectionIcon from "./icon-section.svg?inline";
 
 import SectionsAccordion from "components/AccordionSectionsNav";
@@ -43,10 +45,17 @@ export class UnwrappedSectionNavItem extends React.Component {
     questionnaire: CustomPropTypes.questionnaire,
     section: CustomPropTypes.section.isRequired,
     match: CustomPropTypes.match.isRequired,
+    isGroupOpen: PropTypes.bool.isRequired,
   };
 
   render() {
-    const { questionnaire, section, match, ...otherProps } = this.props;
+    const {
+      questionnaire,
+      section,
+      match,
+      isGroupOpen,
+      ...otherProps
+    } = this.props;
 
     const url = buildSectionPath({
       questionnaireId: questionnaire.id,
@@ -81,6 +90,7 @@ export class UnwrappedSectionNavItem extends React.Component {
         title={<SectionTitle />}
         titleName={section.displayName}
         url={url}
+        isGroupOpen={isGroupOpen}
       >
         <StyledSectionNavItem data-test="section-item" {...otherProps}>
           <PageNav section={section} questionnaire={questionnaire} />

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -60,11 +60,6 @@ export const UnwrappedSectionNavItem = props => {
     ...otherProps
   } = props;
 
-  // const url = buildSectionPath({
-  //   questionnaireId: questionnaire.id,
-  //   sectionId: section.id,
-  //   tab: match.params.tab,
-  // });
   const url = useCallback(() => {
     return buildSectionPath({
       questionnaireId: questionnaire.id,
@@ -72,8 +67,6 @@ export const UnwrappedSectionNavItem = props => {
       tab: match.params.tab,
     });
   }, [questionnaire, match]);
-
-  // console.log(test, "what do we have here");
 
   const SectionTitle = useCallback(
     () => (

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
@@ -30,6 +30,7 @@ describe("SectionNavItem", () => {
         onAddPage={handleAddPage}
         duration={123}
         isActive={jest.fn()}
+        isOpen={{ open: true }}
         match={{
           params: {
             questionnaireId: questionnaire.id,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
@@ -31,6 +31,8 @@ describe("SectionNavItem", () => {
         duration={123}
         isActive={jest.fn()}
         isOpen={{ open: true }}
+        handleChange={jest.fn()}
+        identity={1}
         match={{
           params: {
             questionnaireId: questionnaire.id,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
@@ -2,9 +2,14 @@
 
 exports[`SectionNavItem should render 1`] = `
 <SectionNavItem__StyledSectionsAccordion
-  title={<SectionTitle />}
+  isOpen={
+    Object {
+      "open": true,
+    }
+  }
+  title={<Unknown />}
   titleName="Section"
-  url="/q/1/section/3/design"
+  url={[Function]}
 >
   <SectionNavItem__StyledSectionNavItem
     data-test="section-item"

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`SectionNavItem should render 1`] = `
 <SectionNavItem__StyledSectionsAccordion
+  handleChange={[MockFunction]}
+  identity={1}
   isOpen={
     Object {
       "open": true,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -43,8 +43,17 @@ exports[`NavigationSidebar should render 1`] = `
     permanentScrollBar={false}
   >
     <NavigationSidebar__NavList>
+      <NavigationSidebar__AccordionGroupToggle
+        data-test="toggle-all-accordions"
+        onClick={[Function]}
+        type="button"
+        variant="primary"
+      >
+        Close all
+      </NavigationSidebar__AccordionGroupToggle>
       <li>
         <SectionNav
+          isGroupOpen={true}
           questionnaire={
             Object {
               "id": "1",

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -42,26 +42,26 @@ exports[`NavigationSidebar should render 1`] = `
       }
     }
   />
+  <NavigationSidebar__AccordionGroupToggle
+    data-test="toggle-all-accordions"
+    onClick={[Function]}
+    type="button"
+    variant="primary"
+  >
+    Close all
+  </NavigationSidebar__AccordionGroupToggle>
   <NavigationSidebar__NavigationScrollPane
     permanentScrollBar={false}
   >
     <NavigationSidebar__NavList>
-      <NavigationSidebar__AccordionGroupToggle
-        data-test="toggle-all-accordions"
-        onClick={[Function]}
-        type="button"
-        variant="primary"
-      >
-        Close all
-      </NavigationSidebar__AccordionGroupToggle>
       <li>
         <SectionNav
-          controlGroup={
+          handleChange={[Function]}
+          isOpen={
             Object {
               "open": true,
             }
           }
-          handleChange={[Function]}
           questionnaire={
             Object {
               "id": "1",

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -56,7 +56,11 @@ exports[`NavigationSidebar should render 1`] = `
       </NavigationSidebar__AccordionGroupToggle>
       <li>
         <SectionNav
-          controlGroup={Array []}
+          controlGroup={
+            Object {
+              "open": true,
+            }
+          }
           handleChange={[Function]}
           questionnaire={
             Object {

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -56,7 +56,8 @@ exports[`NavigationSidebar should render 1`] = `
       </NavigationSidebar__AccordionGroupToggle>
       <li>
         <SectionNav
-          isGroupOpen={true}
+          controlGroup={Array []}
+          handleChange={[Function]}
           questionnaire={
             Object {
               "id": "1",

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -33,6 +33,9 @@ exports[`NavigationSidebar should render 1`] = `
               },
             ],
             "title": "Section",
+            "validationErrorInfo": Object {
+              "totalCount": 0,
+            },
           },
         ],
         "title": "Questionnaire",
@@ -68,6 +71,9 @@ exports[`NavigationSidebar should render 1`] = `
                     },
                   ],
                   "title": "Section",
+                  "validationErrorInfo": Object {
+                    "totalCount": 0,
+                  },
                 },
               ],
               "title": "Questionnaire",

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -74,10 +74,10 @@ const actionTypes = {
 function reducer(state, action) {
   switch (action.type) {
     case actionTypes.updateGroup: {
-      const { identity } = action.payload;
+      const { identity, isOpen } = action.payload;
       const updateAccordionState = state.controlGroup
         .filter(x => x.identity !== identity)
-        .concat({ identity, isOpen: !action.payload.isOpen });
+        .concat({ identity, isOpen: !isOpen });
 
       const allOpen = updateAccordionState.every(x => x.isOpen === false);
       return { controlGroup: updateAccordionState, label: allOpen };

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -79,7 +79,7 @@ export const reducer = (state, action) => {
       return { label: !state.label, isOpen: toOpen };
     }
     default:
-      throw new Error(`${action.type} isn't a valid dispatch type`);
+      throw new Error(`${action.type} is not a valid dispatch type`);
   }
 };
 
@@ -99,10 +99,6 @@ export const UnwrappedNavigationSidebar = props => {
   } = props;
 
   const { label, isOpen } = state;
-
-  // const handleAddSection = () => {
-  //   onAddSection(questionnaire.id);
-  // };
 
   const handleAddSection = useCallback(() => {
     onAddSection(questionnaire.id);
@@ -161,7 +157,7 @@ export const UnwrappedNavigationSidebar = props => {
               <li>
                 <SectionNav
                   questionnaire={questionnaire}
-                  controlGroup={isOpen}
+                  isOpen={isOpen}
                   handleChange={handleAccordionChange}
                 />
               </li>

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -1,17 +1,19 @@
-import React, { Component } from "react";
+import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
+import gql from "graphql-tag";
+
 import { colors } from "constants/theme";
 import { flowRight } from "lodash";
 import { withRouter } from "react-router-dom";
-import gql from "graphql-tag";
-
-import ScrollPane from "components/ScrollPane";
 
 import SectionNav from "./SectionNav";
 import NavigationHeader from "./NavigationHeader";
 import IntroductionNavItem from "./IntroductionNavItem";
+
+import Button from "components/buttons/Button";
+import ScrollPane from "components/ScrollPane";
 
 const Container = styled.div`
   background: ${colors.black};
@@ -36,8 +38,18 @@ const NavList = styled.ol`
   list-style: none;
 `;
 
-export class UnwrappedNavigationSidebar extends Component {
-  static propTypes = {
+const AccordionGroupToggle = styled(Button).attrs({
+  variant: "tertiary-light",
+  small: true,
+})`
+  margin: 1em 0 0.425em 1.8em;
+  border: 1px solid white;
+  top: 1px; /* adjust for misalignment caused by PopoutContainer */
+  padding: 0.5em;
+`;
+
+const proptypes = {
+  UnwrappedNavigationSidebar: {
     questionnaire: CustomPropTypes.questionnaire,
     onAddQuestionPage: PropTypes.func.isRequired,
     onAddCalculatedSummaryPage: PropTypes.func.isRequired,
@@ -47,41 +59,58 @@ export class UnwrappedNavigationSidebar extends Component {
     canAddQuestionConfirmation: PropTypes.bool.isRequired,
     canAddCalculatedSummaryPage: PropTypes.bool.isRequired,
     canAddQuestionPage: PropTypes.bool.isRequired,
+  },
+};
+
+export const GroupOpenContext = React.createContext({ isOpen: true });
+
+export const UnwrappedNavigationSidebar = props => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  const {
+    questionnaire,
+    onAddQuestionPage,
+    onAddSection,
+    onAddCalculatedSummaryPage,
+    onAddQuestionConfirmation,
+    canAddQuestionConfirmation,
+    canAddCalculatedSummaryPage,
+    canAddQuestionPage,
+    loading,
+  } = props;
+
+  const handleAddSection = () => {
+    onAddSection(questionnaire.id);
   };
 
-  handleAddSection = () => {
-    this.props.onAddSection(this.props.questionnaire.id);
+  const handleClick = () => {
+    setIsOpen(isOpen => !isOpen);
   };
 
-  render() {
-    const {
-      questionnaire,
-      onAddQuestionPage,
-      onAddCalculatedSummaryPage,
-      onAddQuestionConfirmation,
-      canAddQuestionConfirmation,
-      canAddCalculatedSummaryPage,
-      canAddQuestionPage,
-      loading,
-    } = this.props;
-
-    return (
-      <Container data-test="side-nav">
-        {loading ? null : (
-          <>
-            <NavigationHeader
-              questionnaire={questionnaire}
-              onAddSection={this.handleAddSection}
-              onAddCalculatedSummaryPage={onAddCalculatedSummaryPage}
-              canAddCalculatedSummaryPage={canAddCalculatedSummaryPage}
-              onAddQuestionPage={onAddQuestionPage}
-              canAddQuestionPage={canAddQuestionPage}
-              onAddQuestionConfirmation={onAddQuestionConfirmation}
-              canAddQuestionConfirmation={canAddQuestionConfirmation}
-              data-test="nav-section-header"
-            />
-            <NavigationScrollPane>
+  return (
+    <Container data-test="side-nav">
+      {loading ? null : (
+        <>
+          <NavigationHeader
+            questionnaire={questionnaire}
+            onAddSection={handleAddSection}
+            onAddCalculatedSummaryPage={onAddCalculatedSummaryPage}
+            canAddCalculatedSummaryPage={canAddCalculatedSummaryPage}
+            onAddQuestionPage={onAddQuestionPage}
+            canAddQuestionPage={canAddQuestionPage}
+            onAddQuestionConfirmation={onAddQuestionConfirmation}
+            canAddQuestionConfirmation={canAddQuestionConfirmation}
+            data-test="nav-section-header"
+          />
+          <NavigationScrollPane>
+            <GroupOpenContext.Provider value={isOpen}>
               <NavList>
+                <AccordionGroupToggle
+                  onClick={() => handleClick()}
+                  data-test="toggle-all-accordions"
+                >
+                  {isOpen ? "Close all" : "Open all"}
+                </AccordionGroupToggle>
                 {questionnaire.introduction && (
                   <IntroductionNavItem
                     questionnaire={questionnaire}
@@ -92,13 +121,15 @@ export class UnwrappedNavigationSidebar extends Component {
                   <SectionNav questionnaire={questionnaire} />
                 </li>
               </NavList>
-            </NavigationScrollPane>
-          </>
-        )}
-      </Container>
-    );
-  }
-}
+            </GroupOpenContext.Provider>
+          </NavigationScrollPane>
+        </>
+      )}
+    </Container>
+  );
+};
+
+UnwrappedNavigationSidebar.propTypes = proptypes.UnwrappedNavigationSidebar;
 
 UnwrappedNavigationSidebar.fragments = {
   NavigationSidebar: gql`

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -62,8 +62,6 @@ const proptypes = {
   },
 };
 
-export const GroupOpenContext = React.createContext({ isOpen: true });
-
 export const UnwrappedNavigationSidebar = props => {
   const [isOpen, setIsOpen] = React.useState(true);
 
@@ -103,25 +101,26 @@ export const UnwrappedNavigationSidebar = props => {
             data-test="nav-section-header"
           />
           <NavigationScrollPane>
-            <GroupOpenContext.Provider value={isOpen}>
-              <NavList>
-                <AccordionGroupToggle
-                  onClick={() => handleClick()}
-                  data-test="toggle-all-accordions"
-                >
-                  {isOpen ? "Close all" : "Open all"}
-                </AccordionGroupToggle>
-                {questionnaire.introduction && (
-                  <IntroductionNavItem
-                    questionnaire={questionnaire}
-                    data-test="nav-introduction"
-                  />
-                )}
-                <li>
-                  <SectionNav questionnaire={questionnaire} />
-                </li>
-              </NavList>
-            </GroupOpenContext.Provider>
+            <NavList>
+              <AccordionGroupToggle
+                onClick={() => handleClick()}
+                data-test="toggle-all-accordions"
+              >
+                {isOpen ? "Close all" : "Open all"}
+              </AccordionGroupToggle>
+              {questionnaire.introduction && (
+                <IntroductionNavItem
+                  questionnaire={questionnaire}
+                  data-test="nav-introduction"
+                />
+              )}
+              <li>
+                <SectionNav
+                  questionnaire={questionnaire}
+                  isGroupOpen={isOpen}
+                />
+              </li>
+            </NavList>
           </NavigationScrollPane>
         </>
       )}

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -64,14 +64,14 @@ const proptypes = {
 
 const initialState = { label: true, controlGroup: [] };
 
-const actionTypes = {
+export const actionTypes = {
   updateGroup: "updateControlGroup",
   toggleLabel: "toggleLabel",
   toggleAll: "toggleAllAccordions",
   setInitial: "setInitialControlGroup",
 };
 
-function reducer(state, action) {
+export const reducer = (state, action) => {
   switch (action.type) {
     case actionTypes.updateGroup: {
       const { identity, isOpen } = action.payload;
@@ -96,7 +96,7 @@ function reducer(state, action) {
     default:
       throw new Error(`${action.type} isn't a valid dispatch type`);
   }
-}
+};
 
 export const UnwrappedNavigationSidebar = props => {
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -42,10 +42,11 @@ const AccordionGroupToggle = styled(Button).attrs({
   variant: "tertiary-light",
   small: true,
 })`
-  margin: 1em 0 0.425em 1.8em;
+  margin: 0.425em 0 0.425em 1.8em;
   border: 1px solid white;
   top: 1px; /* adjust for misalignment caused by PopoutContainer */
   padding: 0.5em;
+  align-self: baseline;
 `;
 
 const proptypes = {
@@ -140,14 +141,14 @@ export const UnwrappedNavigationSidebar = props => {
             canAddQuestionConfirmation={canAddQuestionConfirmation}
             data-test="nav-section-header"
           />
+          <AccordionGroupToggle
+            onClick={() => handleClick()}
+            data-test="toggle-all-accordions"
+          >
+            {label ? "Close all" : "Open all"}
+          </AccordionGroupToggle>
           <NavigationScrollPane>
             <NavList>
-              <AccordionGroupToggle
-                onClick={() => handleClick()}
-                data-test="toggle-all-accordions"
-              >
-                {label ? "Close all" : "Open all"}
-              </AccordionGroupToggle>
               {questionnaire.introduction && (
                 <IntroductionNavItem
                   questionnaire={questionnaire}

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
+// import { render, fireEvent } from "tests/utils/rtl";
 import { UnwrappedNavigationSidebar as NavigationSidebar } from "./";
 import { SynchronousPromise } from "synchronous-promise";
 
@@ -7,7 +8,12 @@ describe("NavigationSidebar", () => {
   let props;
   beforeEach(() => {
     const page = { id: "2", title: "Page", position: 0 };
-    const section = { id: "3", title: "Section", pages: [page] };
+    const section = {
+      id: "3",
+      title: "Section",
+      pages: [page],
+      validationErrorInfo: { totalCount: 0 },
+    };
     const questionnaire = {
       id: "1",
       title: "Questionnaire",
@@ -58,5 +64,24 @@ describe("NavigationSidebar", () => {
     };
     const wrapper = shallow(<NavigationSidebar {...props} />);
     expect(wrapper.find("[data-test='nav-introduction']")).toHaveLength(1);
+  });
+
+  it("should have all accordions open on default and then close them", () => {
+    const extraSection = {
+      id: "3",
+      title: "Section",
+      pages: [{ id: "4", title: "Page", position: 0 }],
+    };
+    props.questionnaire.sections.concat(extraSection);
+    const wrapper = shallow(<NavigationSidebar {...props} />);
+    const toggleAll = wrapper.find("[data-test='toggle-all-accordions']");
+
+    expect(toggleAll.text()).toEqual("Close all");
+    expect(toggleAll).toHaveLength(1);
+
+    wrapper.find("[data-test='toggle-all-accordions']").simulate("click");
+    expect(wrapper.find("[data-test='toggle-all-accordions']").text()).toEqual(
+      "Open all"
+    );
   });
 });

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
@@ -93,10 +93,7 @@ describe("NavigationSidebar", () => {
     beforeEach(() => {
       state = {
         label: true,
-        controlGroup: [
-          { identity: 0, isOpen: true },
-          { identity: 1, isOpen: true },
-        ],
+        isOpen: { open: true },
       };
     });
 
@@ -105,39 +102,30 @@ describe("NavigationSidebar", () => {
       expect(reducerWrapper).toThrow();
     });
 
-    it("it update controlGroup", () => {
+    it("it should handleClick", () => {
       const updatedState = reducer(state, {
-        type: actionTypes.updateGroup,
-        payload: { identity: 0, isOpen: true },
+        type: actionTypes.handleClick,
       });
-      expect(updatedState.controlGroup).toEqual([
-        { identity: 1, isOpen: true },
-        { identity: 0, isOpen: false },
-      ]);
+
+      expect(updatedState.isOpen).toEqual({ open: false });
       expect(updatedState.label).toEqual(false);
-    });
 
-    it("it should toggle all in the controlGroup", () => {
       state.label = false;
-      const updatedState = reducer(state, {
-        type: actionTypes.toggleAll,
+      const alternateState = reducer(state, {
+        type: actionTypes.handleClick,
       });
-      expect(updatedState.controlGroup).toEqual([
-        { identity: 0, isOpen: false },
-        { identity: 1, isOpen: false },
-      ]);
-      expect(updatedState.label).toEqual(true);
+
+      expect(alternateState.isOpen).toEqual({ open: true });
+      expect(alternateState.label).toEqual(true);
     });
 
-    it("it should set initial state", () => {
+    it("it should toggle label", () => {
       const updatedState = reducer(state, {
-        type: actionTypes.setInitial,
-        payload: [{ identity: "hello", isOpen: "yes" }],
+        type: actionTypes.toggleLabel,
       });
-      expect(updatedState.controlGroup).toEqual([
-        { identity: "hello", isOpen: "yes" },
-      ]);
-      expect(updatedState.label).toEqual(true);
+
+      expect(updatedState.isOpen).toEqual({ open: true });
+      expect(updatedState.label).toEqual(false);
     });
   });
 });

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { shallow } from "enzyme";
-// import { render, fireEvent } from "tests/utils/rtl";
-import { UnwrappedNavigationSidebar as NavigationSidebar } from "./";
+import {
+  UnwrappedNavigationSidebar as NavigationSidebar,
+  reducer,
+  actionTypes,
+} from "./";
 import { SynchronousPromise } from "synchronous-promise";
 
 describe("NavigationSidebar", () => {
@@ -83,5 +86,58 @@ describe("NavigationSidebar", () => {
     expect(wrapper.find("[data-test='toggle-all-accordions']").text()).toEqual(
       "Open all"
     );
+  });
+
+  describe("Reducer function", () => {
+    let state;
+    beforeEach(() => {
+      state = {
+        label: true,
+        controlGroup: [
+          { identity: 0, isOpen: true },
+          { identity: 1, isOpen: true },
+        ],
+      };
+    });
+
+    it("it should throw", () => {
+      const reducerWrapper = () => reducer(state, { type: "dummy" });
+      expect(reducerWrapper).toThrow();
+    });
+
+    it("it update controlGroup", () => {
+      const updatedState = reducer(state, {
+        type: actionTypes.updateGroup,
+        payload: { identity: 0, isOpen: true },
+      });
+      expect(updatedState.controlGroup).toEqual([
+        { identity: 1, isOpen: true },
+        { identity: 0, isOpen: false },
+      ]);
+      expect(updatedState.label).toEqual(false);
+    });
+
+    it("it should toggle all in the controlGroup", () => {
+      state.label = false;
+      const updatedState = reducer(state, {
+        type: actionTypes.toggleAll,
+      });
+      expect(updatedState.controlGroup).toEqual([
+        { identity: 0, isOpen: false },
+        { identity: 1, isOpen: false },
+      ]);
+      expect(updatedState.label).toEqual(true);
+    });
+
+    it("it should set initial state", () => {
+      const updatedState = reducer(state, {
+        type: actionTypes.setInitial,
+        payload: [{ identity: "hello", isOpen: "yes" }],
+      });
+      expect(updatedState.controlGroup).toEqual([
+        { identity: "hello", isOpen: "yes" },
+      ]);
+      expect(updatedState.label).toEqual(true);
+    });
   });
 });

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -85,13 +85,29 @@ export const DisplayContent = styled.div`
 `;
 
 const SectionAccordion = props => {
-  const { children, title, titleName, isGroupOpen } = props;
+  const [isOpen, setIsOpen] = useState(true);
 
-  const [isOpen, setIsOpen] = useState(isGroupOpen || true);
+  const {
+    children,
+    title,
+    titleName,
+    controlGroup,
+    handleChange,
+    identity,
+  } = props;
 
   useEffect(() => {
-    setIsOpen(isGroupOpen);
-  }, [isGroupOpen]);
+    if (controlGroup.length) {
+      const open = controlGroup.find(x => x.identity === identity);
+      const newSection = open ? !open.isOpen : true;
+      setIsOpen(newSection);
+    }
+  }, [controlGroup]);
+
+  const handleClick = () => {
+    setIsOpen(isOpen => !isOpen);
+    handleChange({ isOpen: !isOpen, identity });
+  };
 
   return (
     <>
@@ -99,13 +115,11 @@ const SectionAccordion = props => {
         <Title>
           <Button
             isOpen={isOpen}
-            onClick={() => setIsOpen(isOpen => !isOpen)}
+            onClick={() => handleClick()}
             aria-expanded={isOpen}
             aria-controls={`accordion-${titleName}`}
             data-test={`accordion-${titleName}-button`}
-          >
-            {}
-          </Button>
+          />
           <SectionTitle data-test={`accordion-${titleName}-title`}>
             {title}
           </SectionTitle>
@@ -127,7 +141,11 @@ SectionAccordion.propTypes = {
   title: PropTypes.node.isRequired,
   titleName: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
-  isGroupOpen: PropTypes.bool.isRequired,
+  identity: PropTypes.number,
+  handleChange: PropTypes.func,
+  controlGroup: PropTypes.arrayOf(
+    PropTypes.shape({ identifier: PropTypes.number, isOpen: PropTypes.bool })
+  ),
 };
 
 export default SectionAccordion;

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -1,8 +1,10 @@
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { colors } from "constants/theme";
 import chevron from "./icon-chevron.svg";
+
+// import { GroupOpenContext } from "App/QuestionnaireDesignPage/NavigationSidebar";
 
 const Header = styled.div`
   padding: 0 0 0.5em;
@@ -84,45 +86,47 @@ export const DisplayContent = styled.div`
   display: ${props => (props.isOpen ? "block" : "none")};
 `;
 
-class SectionAccordion extends Component {
-  state = { isOpen: true, height: "auto" };
+const SectionAccordion = props => {
+  const { children, title, titleName } = props;
 
-  handleAccordionToggle = () => this.setState({ isOpen: !this.state.isOpen });
+  // const value = React.useContext(GroupOpenContext);
+  const value = true;
 
-  render() {
-    const { children, title, titleName } = this.props;
-    const { isOpen } = this.state;
+  const [isOpen, setIsOpen] = useState(value);
 
-    return (
-      <>
-        <Header>
-          <Title>
-            <Button
-              isOpen={isOpen}
-              onClick={this.handleAccordionToggle}
-              aria-expanded={isOpen}
-              aria-controls={`accordion-${titleName}`}
-              data-test={`accordion-${titleName}-button`}
-            >
-              {}
-            </Button>
-            <SectionTitle data-test={`accordion-${titleName}-title`}>
-              {title}
-            </SectionTitle>
-          </Title>
-        </Header>
-        <Body
-          id={`accordion-${titleName}`}
-          data-test={`accordion-${titleName}-body`}
-          isOpen={isOpen}
-          aria-hidden={!isOpen}
-        >
-          <DisplayContent isOpen={isOpen}>{children}</DisplayContent>
-        </Body>
-      </>
-    );
-  }
-}
+  useEffect(() => {
+    setIsOpen(value);
+  }, [value]);
+
+  return (
+    <>
+      <Header>
+        <Title>
+          <Button
+            isOpen={isOpen}
+            onClick={() => setIsOpen(isOpen => !isOpen)}
+            aria-expanded={isOpen}
+            aria-controls={`accordion-${titleName}`}
+            data-test={`accordion-${titleName}-button`}
+          >
+            {}
+          </Button>
+          <SectionTitle data-test={`accordion-${titleName}-title`}>
+            {title}
+          </SectionTitle>
+        </Title>
+      </Header>
+      <Body
+        id={`accordion-${titleName}`}
+        data-test={`accordion-${titleName}-body`}
+        isOpen={isOpen}
+        aria-hidden={!isOpen}
+      >
+        <DisplayContent isOpen={isOpen}>{children}</DisplayContent>
+      </Body>
+    </>
+  );
+};
 
 SectionAccordion.propTypes = {
   title: PropTypes.node.isRequired,

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -97,16 +97,12 @@ const SectionAccordion = props => {
   } = props;
 
   useEffect(() => {
-    if (controlGroup.length) {
-      const open = controlGroup.find(x => x.identity === identity);
-      const newSection = open ? !open.isOpen : true;
-      setIsOpen(newSection);
-    }
+    setIsOpen(controlGroup.open);
   }, [controlGroup]);
 
   const handleClick = () => {
     setIsOpen(isOpen => !isOpen);
-    handleChange({ isOpen: !isOpen, identity });
+    handleChange({ isOpen: !isOpen, id: identity });
   };
 
   return (

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -91,7 +91,7 @@ const propTypes = {
     children: PropTypes.node.isRequired,
     identity: PropTypes.number,
     handleChange: PropTypes.func,
-    isOpen: PropTypes.bool.isRequired,
+    isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
   },
 };
 

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -4,8 +4,6 @@ import styled from "styled-components";
 import { colors } from "constants/theme";
 import chevron from "./icon-chevron.svg";
 
-// import { GroupOpenContext } from "App/QuestionnaireDesignPage/NavigationSidebar";
-
 const Header = styled.div`
   padding: 0 0 0.5em;
 

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -87,16 +87,13 @@ export const DisplayContent = styled.div`
 `;
 
 const SectionAccordion = props => {
-  const { children, title, titleName } = props;
+  const { children, title, titleName, isGroupOpen } = props;
 
-  // const value = React.useContext(GroupOpenContext);
-  const value = true;
-
-  const [isOpen, setIsOpen] = useState(value);
+  const [isOpen, setIsOpen] = useState(isGroupOpen || true);
 
   useEffect(() => {
-    setIsOpen(value);
-  }, [value]);
+    setIsOpen(isGroupOpen);
+  }, [isGroupOpen]);
 
   return (
     <>
@@ -132,6 +129,7 @@ SectionAccordion.propTypes = {
   title: PropTypes.node.isRequired,
   titleName: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  isGroupOpen: PropTypes.bool.isRequired,
 };
 
 export default SectionAccordion;

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -84,6 +84,17 @@ export const DisplayContent = styled.div`
   display: ${props => (props.isOpen ? "block" : "none")};
 `;
 
+const propTypes = {
+  SectionAccordion: {
+    title: PropTypes.node.isRequired,
+    titleName: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+    identity: PropTypes.number,
+    handleChange: PropTypes.func,
+    isOpen: PropTypes.bool.isRequired,
+  },
+};
+
 const SectionAccordion = props => {
   const [isOpen, setIsOpen] = useState(true);
 
@@ -91,14 +102,14 @@ const SectionAccordion = props => {
     children,
     title,
     titleName,
-    controlGroup,
+    isOpen: isOpenProp,
     handleChange,
     identity,
   } = props;
 
   useEffect(() => {
-    setIsOpen(controlGroup.open);
-  }, [controlGroup]);
+    setIsOpen(isOpenProp.open);
+  }, [isOpenProp]);
 
   const handleClick = () => {
     setIsOpen(isOpen => !isOpen);
@@ -133,15 +144,6 @@ const SectionAccordion = props => {
   );
 };
 
-SectionAccordion.propTypes = {
-  title: PropTypes.node.isRequired,
-  titleName: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  identity: PropTypes.number,
-  handleChange: PropTypes.func,
-  controlGroup: PropTypes.arrayOf(
-    PropTypes.shape({ identifier: PropTypes.number, isOpen: PropTypes.bool })
-  ),
-};
+SectionAccordion.propTypes = propTypes.SectionAccordion;
 
 export default SectionAccordion;

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -8,7 +8,7 @@ import NavLink, {
 describe("Section Accordion", () => {
   it("default should render accordion as expanded", () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section1">
+      <SectionAccordion title="test" titleName="section1" isGroupOpen>
         section accordion panel
       </SectionAccordion>
     );
@@ -31,7 +31,11 @@ describe("Section Accordion", () => {
       </>
     );
     const { getByTestId } = render(
-      <SectionAccordion title={<SectionTitle />} titleName="section1">
+      <SectionAccordion
+        title={<SectionTitle />}
+        titleName="section1"
+        isGroupOpen
+      >
         section accordion panel
       </SectionAccordion>
     );
@@ -42,7 +46,7 @@ describe("Section Accordion", () => {
 
   it("click on the arrow - it should open and close section accordion", async () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section2">
+      <SectionAccordion title="test" titleName="section2" isGroupOpen>
         section accordion panel2
       </SectionAccordion>
     );
@@ -60,7 +64,7 @@ describe("Section Accordion", () => {
 
   it("click on the section title - it should not activate the accordion", async () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section3">
+      <SectionAccordion title="test" titleName="section3" isGroupOpen>
         section accordion panel3
       </SectionAccordion>
     );

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -6,9 +6,16 @@ import NavLink, {
 } from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
 
 describe("Section Accordion", () => {
+  const controlGroup = [{ identifier: 0, isOpen: true }];
   it("default should render accordion as expanded", () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section1" isGroupOpen>
+      <SectionAccordion
+        title="test"
+        titleName="section1"
+        controlGroup={controlGroup}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel
       </SectionAccordion>
     );
@@ -34,7 +41,9 @@ describe("Section Accordion", () => {
       <SectionAccordion
         title={<SectionTitle />}
         titleName="section1"
-        isGroupOpen
+        controlGroup={controlGroup}
+        identity={0}
+        handleChange={jest.fn()}
       >
         section accordion panel
       </SectionAccordion>
@@ -46,7 +55,13 @@ describe("Section Accordion", () => {
 
   it("click on the arrow - it should open and close section accordion", async () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section2" isGroupOpen>
+      <SectionAccordion
+        title="test"
+        titleName="section2"
+        controlGroup={controlGroup}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel2
       </SectionAccordion>
     );
@@ -64,7 +79,13 @@ describe("Section Accordion", () => {
 
   it("click on the section title - it should not activate the accordion", async () => {
     const { getByTestId } = render(
-      <SectionAccordion title="test" titleName="section3" isGroupOpen>
+      <SectionAccordion
+        title="test"
+        titleName="section3"
+        controlGroup={controlGroup}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel3
       </SectionAccordion>
     );

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -6,13 +6,13 @@ import NavLink, {
 } from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
 
 describe("Section Accordion", () => {
-  const controlGroup = [{ identifier: 0, isOpen: true }];
+  const isOpen = { open: true };
   it("default should render accordion as expanded", () => {
     const { getByTestId } = render(
       <SectionAccordion
         title="test"
         titleName="section1"
-        controlGroup={controlGroup}
+        isOpen={isOpen}
         identity={0}
         handleChange={jest.fn()}
       >
@@ -41,7 +41,7 @@ describe("Section Accordion", () => {
       <SectionAccordion
         title={<SectionTitle />}
         titleName="section1"
-        controlGroup={controlGroup}
+        isOpen={isOpen}
         identity={0}
         handleChange={jest.fn()}
       >
@@ -58,7 +58,7 @@ describe("Section Accordion", () => {
       <SectionAccordion
         title="test"
         titleName="section2"
-        controlGroup={controlGroup}
+        isOpen={isOpen}
         identity={0}
         handleChange={jest.fn()}
       >
@@ -82,7 +82,7 @@ describe("Section Accordion", () => {
       <SectionAccordion
         title="test"
         titleName="section3"
-        controlGroup={controlGroup}
+        isOpen={isOpen}
         identity={0}
         handleChange={jest.fn()}
       >


### PR DESCRIPTION
> BEFORE MAKING YOUR PR... There must be no linting errors and all tests must pass

### What is the context of this PR?

~~Allows all the section accordions to be opened and closed with a single click.~~

~~The current method involves drilling props down a few layers which works, but I wish the context method would work.~~

~~I did try to use useContext to pass the props down the several layers. But the tests kept breaking even when wrapped in the context provider...~~

So this has been reworked ever so slightly since everyone looked at it last. Basically I noticed there were significant performance issues when you started to add loads of sections. I think they were being caused by lots of rerenders when the open/close state of the accordion was updated.  Which would cause the whole nav to render again including the section-title.

There are several things I've done to address these performance issues:
- Only update the label of the button if one of the accordions is closed
- Removed the useEffect at the top level -  could be done in an event handler instead
- Wrapped a few Callback hooks around certain functions in various components. The callback hook only instantiates a new function if one of the dependencies change in the callback hook. Wrapping this around the SectionTitle helped minimize the amount of stuff being rendered each time

### How to review 
0.5 Open chrome dev tools and click this button in the top left
![Screenshot 2020-06-11 at 12 06 54](https://user-images.githubusercontent.com/22731314/84428855-0bf54680-abdc-11ea-8285-1f0aa116f07e.png)

It should open up tabs on the left like this
![Screenshot 2020-06-11 at 12 07 21](https://user-images.githubusercontent.com/22731314/84428894-1c0d2600-abdc-11ea-896a-9c64d3750de7.png)

The verbose tab at the bottom shows when certain actions are taking longer than expected

1. Open questionnaire
2. Create as many sections as you want but more than 1 (Try like 20 if you can)
3. Hit Open all
    - should change to close all
    - if individual section is opened, they should all change to the expected state instead of the opposite of the current state 
4. Adding a new section and see if that works
5. When all sections are open, the button should say 'Close all'
6. When one section is open, the button should say 'Open all'
7. When there are a lot of sections, you should be able to scroll down the nav and the open all button should be fixed under the add content button.


