### PR TITLE
Ear 235 merger

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
@@ -98,7 +98,7 @@ const NavLink = ({
 );
 
 NavLink.propTypes = {
-  to: PropTypes.string.isRequired,
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   icon: PropTypes.func.isRequired,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
-import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
+import CustomPropTypes from "custom-prop-types";
+import PropTypes from "prop-types";
 
 import { TransitionGroup } from "react-transition-group";
 import NavItemTransition from "./NavItemTransition";
@@ -18,15 +19,24 @@ const NavList = styled.ol`
 class SectionNav extends Component {
   static propTypes = {
     questionnaire: CustomPropTypes.questionnaire,
+    isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
+    handleChange: PropTypes.func,
   };
 
   render() {
-    const { questionnaire } = this.props;
+    const { questionnaire, isOpen, handleChange } = this.props;
+
     return (
       <TransitionGroup component={NavList}>
-        {questionnaire.sections.map(section => (
+        {questionnaire.sections.map((section, index) => (
           <NavItemTransition key={section.id} onEntered={scrollIntoView}>
-            <SectionNavItem questionnaire={questionnaire} section={section} />
+            <SectionNavItem
+              questionnaire={questionnaire}
+              isOpen={isOpen}
+              section={section}
+              handleChange={handleChange}
+              identity={index}
+            />
           </NavItemTransition>
         ))}
       </TransitionGroup>

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNav.test.js
@@ -36,6 +36,8 @@ describe("SectionNav", () => {
         questionnaire={questionnaire}
         currentSectionId={section.id}
         currentPageId={page.id}
+        isOpen={{ open: true }}
+        handleChange={jest.fn()}
       />,
       {
         route: `/q/${questionnaire.id}`,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -1,13 +1,15 @@
-import gql from "graphql-tag";
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 import { withRouter } from "react-router-dom";
-
+import gql from "graphql-tag";
+import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import { colors } from "constants/theme";
-import PageNav from "./PageNav";
-import NavLink from "./NavLink";
+
 import { buildSectionPath } from "utils/UrlUtils";
+import NavLink from "./NavLink";
+import PageNav from "./PageNav";
+
+import { colors } from "constants/theme";
 import SectionIcon from "./icon-section.svg?inline";
 
 import SectionsAccordion from "components/AccordionSectionsNav";
@@ -38,31 +40,44 @@ const StyledSectionLower = styled.div`
   border-bottom: 1px solid ${colors.grey};
 `;
 
-export class UnwrappedSectionNavItem extends React.Component {
-  static propTypes = {
-    questionnaire: CustomPropTypes.questionnaire,
-    section: CustomPropTypes.section.isRequired,
-    match: CustomPropTypes.match.isRequired,
-  };
+const propTypes = {
+  questionnaire: CustomPropTypes.questionnaire,
+  section: CustomPropTypes.section.isRequired,
+  match: CustomPropTypes.match.isRequired,
+  isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
+  handleChange: PropTypes.func.isRequired,
+  identity: PropTypes.number.isRequired,
+};
 
-  render() {
-    const { questionnaire, section, match, ...otherProps } = this.props;
+export const UnwrappedSectionNavItem = props => {
+  const {
+    questionnaire,
+    section,
+    match,
+    isOpen,
+    handleChange,
+    identity,
+    ...otherProps
+  } = props;
 
-    const url = buildSectionPath({
+  const url = useCallback(() => {
+    return buildSectionPath({
       questionnaireId: questionnaire.id,
       sectionId: section.id,
       tab: match.params.tab,
     });
+  }, [questionnaire, match]);
 
-    let questionErrorCount = 0;
+  let questionErrorCount = 0;
 
-    section.pages.map(item => {
-      questionErrorCount =
-        questionErrorCount + item.validationErrorInfo.totalCount;
-      return questionErrorCount;
-    });
+  section.pages.map(item => {
+    questionErrorCount =
+      questionErrorCount + item.validationErrorInfo.totalCount;
+    return questionErrorCount;
+  });
 
-    const SectionTitle = ({ isOpen }) => (
+  const SectionTitle = useCallback(
+    isOpen => (
       <>
         <StyledSectionUpper>
           <div />
@@ -85,21 +100,27 @@ export class UnwrappedSectionNavItem extends React.Component {
           <div />
         </StyledSectionLower>
       </>
-    );
+    ),
+    [section, url, isOpen]
+  );
 
-    return (
-      <StyledSectionsAccordion
-        title={<SectionTitle />}
-        titleName={section.displayName}
-        url={url}
-      >
-        <StyledSectionNavItem data-test="section-item" {...otherProps}>
-          <PageNav section={section} questionnaire={questionnaire} />
-        </StyledSectionNavItem>
-      </StyledSectionsAccordion>
-    );
-  }
-}
+  return (
+    <StyledSectionsAccordion
+      title={SectionTitle}
+      titleName={section.displayName}
+      url={url}
+      isOpen={isOpen}
+      identity={identity}
+      handleChange={handleChange}
+    >
+      <StyledSectionNavItem data-test="section-item" {...otherProps}>
+        <PageNav section={section} questionnaire={questionnaire} />
+      </StyledSectionNavItem>
+    </StyledSectionsAccordion>
+  );
+};
+
+UnwrappedSectionNavItem.propTypes = propTypes;
 
 UnwrappedSectionNavItem.fragments = {
   SectionNavItem: gql`

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.test.js
@@ -35,6 +35,9 @@ describe("SectionNavItem", () => {
         onAddPage={handleAddPage}
         duration={123}
         isActive={jest.fn()}
+        isOpen={{ open: true }}
+        handleChange={jest.fn()}
+        identity={1}
         match={{
           params: {
             questionnaireId: questionnaire.id,

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
@@ -2,9 +2,16 @@
 
 exports[`SectionNavItem should render 1`] = `
 <SectionNavItem__StyledSectionsAccordion
-  title={<SectionTitle />}
+  handleChange={[MockFunction]}
+  identity={1}
+  isOpen={
+    Object {
+      "open": true,
+    }
+  }
+  title={[Function]}
   titleName="Section"
-  url="/q/1/section/3/design"
+  url={[Function]}
 >
   <SectionNavItem__StyledSectionNavItem
     data-test="section-item"

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/index.test.js.snap
@@ -30,21 +30,41 @@ exports[`NavigationSidebar should render 1`] = `
                 "id": "2",
                 "position": 0,
                 "title": "Page",
+                "validationErrorInfo": Object {
+                  "totalCount": 5,
+                },
               },
             ],
             "title": "Section",
+            "validationErrorInfo": Object {
+              "totalCount": 0,
+            },
           },
         ],
         "title": "Questionnaire",
       }
     }
   />
+  <NavigationSidebar__AccordionGroupToggle
+    data-test="toggle-all-accordions"
+    onClick={[Function]}
+    type="button"
+    variant="primary"
+  >
+    Close all
+  </NavigationSidebar__AccordionGroupToggle>
   <NavigationSidebar__NavigationScrollPane
     permanentScrollBar={false}
   >
     <NavigationSidebar__NavList>
       <li>
         <SectionNav
+          handleChange={[Function]}
+          isOpen={
+            Object {
+              "open": true,
+            }
+          }
           questionnaire={
             Object {
               "id": "1",
@@ -56,9 +76,15 @@ exports[`NavigationSidebar should render 1`] = `
                       "id": "2",
                       "position": 0,
                       "title": "Page",
+                      "validationErrorInfo": Object {
+                        "totalCount": 5,
+                      },
                     },
                   ],
                   "title": "Section",
+                  "validationErrorInfo": Object {
+                    "totalCount": 0,
+                  },
                 },
               ],
               "title": "Questionnaire",

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -1,17 +1,19 @@
-import React, { Component } from "react";
+import React, { useReducer, useCallback, useRef } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
+import gql from "graphql-tag";
+
 import { colors } from "constants/theme";
 import { flowRight } from "lodash";
 import { withRouter } from "react-router-dom";
-import gql from "graphql-tag";
-
-import ScrollPane from "components/ScrollPane";
 
 import SectionNav from "./SectionNav";
 import NavigationHeader from "./NavigationHeader";
 import IntroductionNavItem from "./IntroductionNavItem";
+
+import Button from "components/buttons/Button";
+import ScrollPane from "components/ScrollPane";
 
 const Container = styled.div`
   background: ${colors.black};
@@ -36,8 +38,19 @@ const NavList = styled.ol`
   list-style: none;
 `;
 
-export class UnwrappedNavigationSidebar extends Component {
-  static propTypes = {
+const AccordionGroupToggle = styled(Button).attrs({
+  variant: "tertiary-light",
+  small: true,
+})`
+  margin: 0.425em 0 0.425em 1.8em;
+  border: 1px solid white;
+  top: 1px; /* adjust for misalignment caused by PopoutContainer */
+  padding: 0.5em;
+  align-self: baseline;
+`;
+
+const proptypes = {
+  UnwrappedNavigationSidebar: {
     questionnaire: CustomPropTypes.questionnaire,
     onAddQuestionPage: PropTypes.func.isRequired,
     onAddCalculatedSummaryPage: PropTypes.func.isRequired,
@@ -47,58 +60,177 @@ export class UnwrappedNavigationSidebar extends Component {
     canAddQuestionConfirmation: PropTypes.bool.isRequired,
     canAddCalculatedSummaryPage: PropTypes.bool.isRequired,
     canAddQuestionPage: PropTypes.bool.isRequired,
-  };
+  },
+};
 
-  handleAddSection = () => {
-    this.props.onAddSection(this.props.questionnaire.id);
-  };
+export const sidebarActionTypes = {
+  toggleLabel: "toggleLabel",
+  handleClick: "handleClick",
+};
 
-  render() {
-    const {
-      questionnaire,
-      onAddQuestionPage,
-      onAddCalculatedSummaryPage,
-      onAddQuestionConfirmation,
-      canAddQuestionConfirmation,
-      canAddCalculatedSummaryPage,
-      canAddQuestionPage,
-      loading,
-    } = this.props;
-
-    return (
-      <Container data-test="side-nav">
-        {loading ? null : (
-          <>
-            <NavigationHeader
-              questionnaire={questionnaire}
-              onAddSection={this.handleAddSection}
-              onAddCalculatedSummaryPage={onAddCalculatedSummaryPage}
-              canAddCalculatedSummaryPage={canAddCalculatedSummaryPage}
-              onAddQuestionPage={onAddQuestionPage}
-              canAddQuestionPage={canAddQuestionPage}
-              onAddQuestionConfirmation={onAddQuestionConfirmation}
-              canAddQuestionConfirmation={canAddQuestionConfirmation}
-              data-test="nav-section-header"
-            />
-            <NavigationScrollPane>
-              <NavList>
-                {questionnaire.introduction && (
-                  <IntroductionNavItem
-                    questionnaire={questionnaire}
-                    data-test="nav-introduction"
-                  />
-                )}
-                <li>
-                  <SectionNav questionnaire={questionnaire} />
-                </li>
-              </NavList>
-            </NavigationScrollPane>
-          </>
-        )}
-      </Container>
-    );
+export const sidebarReducer = (state, action) => {
+  const { toggleLabel, handleClick } = sidebarActionTypes;
+  switch (action.type) {
+    case toggleLabel: {
+      return { ...state, label: !state.label };
+    }
+    case handleClick: {
+      const toOpen = !state.label ? { open: true } : { open: false };
+      return { label: !state.label, isOpen: toOpen };
+    }
+    default:
+      throw new Error(`${action.type} is not a valid dispatch type`);
   }
-}
+};
+
+export const accordionActionTypes = {
+  create: "create",
+  update: "update",
+  createAndUpdate: "createAndUpdate",
+};
+
+export const accordionGroupReducer = (array, action) => {
+  const { create, update, createAndUpdate } = accordionActionTypes;
+  switch (action.type) {
+    case create: {
+      const { isOpen } = action.payload;
+      return array.map((item, index) => ({
+        isOpen: isOpen,
+        id: index,
+      }));
+    }
+    case update: {
+      const { event } = action.payload;
+      return array.filter(item => item.id !== event.id).concat(event);
+    }
+    case createAndUpdate: {
+      const { isOpen, event } = action.payload;
+      return array
+        .map((item, index) => ({
+          isOpen: isOpen,
+          id: index,
+        }))
+        .filter(item => item.id !== event.id)
+        .concat(event);
+    }
+    default:
+      throw new Error(`${action.type} is not a valid type`);
+  }
+};
+
+const sidebarInitialState = {
+  label: true,
+  isOpen: { open: true },
+};
+
+export const UnwrappedNavigationSidebar = props => {
+  const [state, dispatch] = useReducer(sidebarReducer, sidebarInitialState);
+
+  let accordionsRef = useRef(null);
+
+  const {
+    questionnaire,
+    onAddQuestionPage,
+    onAddSection,
+    onAddCalculatedSummaryPage,
+    onAddQuestionConfirmation,
+    canAddQuestionConfirmation,
+    canAddCalculatedSummaryPage,
+    canAddQuestionPage,
+    loading,
+  } = props;
+
+  const { label, isOpen } = state;
+
+  const handleAddSection = useCallback(() => {
+    onAddSection(questionnaire.id);
+  }, [questionnaire]);
+
+  const handleClick = () => {
+    const accordions = accordionGroupReducer(questionnaire.sections, {
+      type: accordionActionTypes.create,
+      payload: { isOpen: !state.label },
+    });
+
+    accordionsRef.current = accordions;
+
+    dispatch({ type: sidebarActionTypes.handleClick });
+  };
+
+  const handleAccordionChange = event => {
+    let accordions;
+
+    if (accordionsRef.current) {
+      accordions = accordionGroupReducer(accordionsRef.current, {
+        type: accordionActionTypes.update,
+        payload: { event },
+      });
+    } else {
+      accordions = accordionGroupReducer(questionnaire.sections, {
+        type: accordionActionTypes.createAndUpdate,
+        payload: {
+          event,
+          isOpen: true,
+        },
+      });
+    }
+
+    accordionsRef.current = accordions;
+
+    const allOpen = accordionsRef.current.every(item => item.isOpen === true);
+
+    if (allOpen !== state.label) {
+      dispatch({
+        type: sidebarActionTypes.toggleLabel,
+      });
+    }
+  };
+
+  return (
+    <Container data-test="side-nav">
+      {loading ? null : (
+        <>
+          <NavigationHeader
+            questionnaire={questionnaire}
+            onAddSection={handleAddSection}
+            onAddCalculatedSummaryPage={onAddCalculatedSummaryPage}
+            canAddCalculatedSummaryPage={canAddCalculatedSummaryPage}
+            onAddQuestionPage={onAddQuestionPage}
+            canAddQuestionPage={canAddQuestionPage}
+            onAddQuestionConfirmation={onAddQuestionConfirmation}
+            canAddQuestionConfirmation={canAddQuestionConfirmation}
+            data-test="nav-section-header"
+          />
+          <AccordionGroupToggle
+            onClick={() => handleClick()}
+            data-test="toggle-all-accordions"
+          >
+            {label ? "Close all" : "Open all"}
+          </AccordionGroupToggle>
+          <NavigationScrollPane>
+            <NavList>
+              {questionnaire.introduction && (
+                <IntroductionNavItem
+                  questionnaire={questionnaire}
+                  data-test="nav-introduction"
+                />
+              )}
+              <li>
+                <SectionNav
+                  questionnaire={questionnaire}
+                  isOpen={isOpen}
+                  handleChange={handleAccordionChange}
+                />
+              </li>
+            </NavList>
+          </NavigationScrollPane>
+        </>
+      )}
+    </Container>
+  );
+};
+
+UnwrappedNavigationSidebar.propTypes = proptypes.UnwrappedNavigationSidebar;
 
 UnwrappedNavigationSidebar.fragments = {
   NavigationSidebar: gql`

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.test.js
@@ -1,13 +1,32 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { UnwrappedNavigationSidebar as NavigationSidebar } from "./";
+import { render, fireEvent } from "tests/utils/rtl";
+import {
+  UnwrappedNavigationSidebar as NavigationSidebar,
+  sidebarActionTypes,
+  sidebarReducer,
+  accordionActionTypes,
+  accordionGroupReducer,
+} from "./";
 import { SynchronousPromise } from "synchronous-promise";
 
 describe("NavigationSidebar", () => {
   let props;
   beforeEach(() => {
-    const page = { id: "2", title: "Page", position: 0 };
-    const section = { id: "3", title: "Section", pages: [page] };
+    const page = {
+      id: "2",
+      title: "Page",
+      position: 0,
+      validationErrorInfo: {
+        totalCount: 5,
+      },
+    };
+    const section = {
+      id: "3",
+      title: "Section",
+      pages: [page],
+      validationErrorInfo: { totalCount: 0 },
+    };
     const questionnaire = {
       id: "1",
       title: "Questionnaire",
@@ -58,5 +77,128 @@ describe("NavigationSidebar", () => {
     };
     const wrapper = shallow(<NavigationSidebar {...props} />);
     expect(wrapper.find("[data-test='nav-introduction']")).toHaveLength(1);
+  });
+
+  it("should have all accordions open on default and then close them", () => {
+    const extraSection = {
+      id: "3",
+      title: "Section",
+      pages: [{ id: "4", title: "Page", position: 0 }],
+    };
+    props.questionnaire.sections.concat(extraSection);
+    const wrapper = shallow(<NavigationSidebar {...props} />);
+    const toggleAll = wrapper.find("[data-test='toggle-all-accordions']");
+
+    expect(toggleAll.text()).toEqual("Close all");
+    expect(toggleAll).toHaveLength(1);
+
+    wrapper.find("[data-test='toggle-all-accordions']").simulate("click");
+    expect(wrapper.find("[data-test='toggle-all-accordions']").text()).toEqual(
+      "Open all"
+    );
+  });
+
+  it("should handle accordions opening/closing", () => {
+    // using this to temp disable proptype errors from nested components
+    jest.spyOn(console, "error").mockImplementation(() => jest.fn());
+    const { queryAllByTestId } = render(<NavigationSidebar {...props} />);
+
+    const firstAccordion = queryAllByTestId("accordion-undefined-button")[0];
+
+    expect(firstAccordion.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(firstAccordion);
+    expect(firstAccordion.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  describe("Sidebar sidebarReducer function", () => {
+    let state;
+    beforeEach(() => {
+      state = {
+        label: true,
+        isOpen: { open: true },
+      };
+    });
+
+    it("it should throw", () => {
+      const reducerWrapper = () => sidebarReducer(state, { type: "dummy" });
+      expect(reducerWrapper).toThrow();
+    });
+
+    it("it should handleClick", () => {
+      const updatedState = sidebarReducer(state, {
+        type: sidebarActionTypes.handleClick,
+      });
+
+      expect(updatedState.isOpen).toEqual({ open: false });
+      expect(updatedState.label).toEqual(false);
+
+      state.label = false;
+      const alternateState = sidebarReducer(state, {
+        type: sidebarActionTypes.handleClick,
+      });
+
+      expect(alternateState.isOpen).toEqual({ open: true });
+      expect(alternateState.label).toEqual(true);
+    });
+
+    it("it should toggle label", () => {
+      const updatedState = sidebarReducer(state, {
+        type: sidebarActionTypes.toggleLabel,
+      });
+
+      expect(updatedState.isOpen).toEqual({ open: true });
+      expect(updatedState.label).toEqual(false);
+    });
+  });
+
+  describe("Accordion group sidebarReducer function", () => {
+    let array;
+    beforeEach(() => {
+      array = [
+        { id: 0, isOpen: true },
+        { id: 1, isOpen: true },
+        { id: 2, isOpen: true },
+      ];
+    });
+
+    it("should throw", () => {
+      const reducerWrapper = () =>
+        accordionGroupReducer(array, { type: "dummy" });
+      expect(reducerWrapper).toThrow();
+    });
+
+    it("should create a new array", () => {
+      const testArray = [1, 2, 3, 4, 5];
+      const newArray = accordionGroupReducer(testArray, {
+        type: "create",
+        payload: { isOpen: false },
+      });
+
+      expect(newArray.length).toBe(testArray.length);
+      expect(newArray.every(item => item.isOpen === false)).toBeTruthy();
+    });
+    it("should update an existing array", () => {
+      const updatedArray = accordionGroupReducer(array, {
+        type: accordionActionTypes.update,
+        payload: { event: { id: 0, isOpen: false } },
+      });
+
+      expect(updatedArray.length).toEqual(array.length);
+      expect(updatedArray.find(item => item.id === 0).isOpen).toBeFalsy();
+    });
+    it("should create and update an array of values", () => {
+      const testArray = [1, 2];
+      const newArray = accordionGroupReducer(testArray, {
+        type: accordionActionTypes.createAndUpdate,
+        payload: { isOpen: true, event: { id: 0, isOpen: false } },
+      });
+
+      expect(newArray.length).toBe(testArray.length);
+      expect(newArray.find(item => item.id === 0).isOpen).toBeFalsy();
+      expect(newArray).toEqual([
+        { id: 1, isOpen: true },
+        { id: 0, isOpen: false },
+      ]);
+    });
   });
 });

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { colors } from "constants/theme";
@@ -84,56 +84,66 @@ export const DisplayContent = styled.div`
   display: ${props => (props.isOpen ? "block" : "none")};
 `;
 
-export const Parent = styled.div``;
-
-class SectionAccordion extends Component {
-  state = { isOpen: true, height: "auto" };
-
-  handleAccordionToggle = () => this.setState({ isOpen: !this.state.isOpen });
-
-  render() {
-    const { children, title, titleName } = this.props;
-    const { isOpen } = this.state;
-
-    const addIsOpenToTitle = React.cloneElement(title, {
-      isOpen,
-    });
-
-    return (
-      <>
-        <Header>
-          <Title>
-            <Button
-              isOpen={isOpen}
-              onClick={this.handleAccordionToggle}
-              aria-expanded={isOpen}
-              aria-controls={`accordion-${titleName}`}
-              data-test={`accordion-${titleName}-button`}
-            >
-              {}
-            </Button>
-            <SectionTitle data-test={`accordion-${titleName}-title`}>
-              {addIsOpenToTitle}
-            </SectionTitle>
-          </Title>
-        </Header>
-        <Body
-          id={`accordion-${titleName}`}
-          data-test={`accordion-${titleName}-body`}
-          isOpen={isOpen}
-          aria-hidden={!isOpen}
-        >
-          <DisplayContent isOpen={isOpen}>{children}</DisplayContent>
-        </Body>
-      </>
-    );
-  }
-}
-
-SectionAccordion.propTypes = {
-  title: PropTypes.node.isRequired,
-  titleName: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+const propTypes = {
+  SectionAccordion: {
+    title: PropTypes.func.isRequired,
+    titleName: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+    identity: PropTypes.number,
+    handleChange: PropTypes.func,
+    isOpen: PropTypes.shape({ open: PropTypes.bool }).isRequired,
+  },
 };
+
+const SectionAccordion = props => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const {
+    children,
+    title,
+    titleName,
+    isOpen: isOpenProp,
+    handleChange,
+    identity,
+  } = props;
+
+  useEffect(() => {
+    setIsOpen(isOpenProp.open);
+  }, [isOpenProp]);
+
+  const handleClick = () => {
+    setIsOpen(isOpen => !isOpen);
+    handleChange({ isOpen: !isOpen, id: identity });
+  };
+
+  return (
+    <>
+      <Header>
+        <Title>
+          <Button
+            isOpen={isOpen}
+            onClick={() => handleClick()}
+            aria-expanded={isOpen}
+            aria-controls={`accordion-${titleName}`}
+            data-test={`accordion-${titleName}-button`}
+          />
+          <SectionTitle data-test={`accordion-${titleName}-title`}>
+            {title(isOpen)}
+          </SectionTitle>
+        </Title>
+      </Header>
+      <Body
+        id={`accordion-${titleName}`}
+        data-test={`accordion-${titleName}-body`}
+        isOpen={isOpen}
+        aria-hidden={!isOpen}
+      >
+        <DisplayContent isOpen={isOpen}>{children}</DisplayContent>
+      </Body>
+    </>
+  );
+};
+
+SectionAccordion.propTypes = propTypes.SectionAccordion;
 
 export default SectionAccordion;

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -6,7 +6,15 @@ import NavLink, {
 } from "../../App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js";
 
 describe("Section Accordion", () => {
-  let props;
+  const isOpen = { open: true };
+
+  let props, SectionTitleMock;
+
+  const SectionTitle = () => (
+    <>
+      <NavLink {...props}>section1</NavLink>
+    </>
+  );
 
   afterEach(async () => {
     await act(async () => {
@@ -15,6 +23,7 @@ describe("Section Accordion", () => {
   });
 
   beforeEach(() => {
+    SectionTitleMock = jest.fn(() => <SectionTitle />);
     props = {
       to: "q/QID1/section/section1/design",
       "data-test": "nav-section-link",
@@ -24,15 +33,15 @@ describe("Section Accordion", () => {
       isActive: () => true,
     };
   });
-
-  it("default should render accordion as expanded", async () => {
-    const SectionTitle = () => (
-      <>
-        <NavLink {...props}>section1</NavLink>
-      </>
-    );
+  it("default should render accordion as expanded", () => {
     const { getByTestId } = render(
-      <SectionAccordion title={<SectionTitle />} titleName="section1">
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section1"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel
       </SectionAccordion>
     );
@@ -41,21 +50,14 @@ describe("Section Accordion", () => {
   });
 
   it("should focus on a section when active", async () => {
-    const props = {
-      to: "q/QID1/section/section1/design",
-      "data-test": "nav-section-link",
-      title: "TestName",
-      icon: () => <svg />,
-      errorCount: 0,
-      isActive: () => true,
-    };
-    const SectionTitle = () => (
-      <>
-        <NavLink {...props}>section1</NavLink>
-      </>
-    );
     const { getByTestId } = render(
-      <SectionAccordion title={<SectionTitle />} titleName="section1">
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section1"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel
       </SectionAccordion>
     );
@@ -65,13 +67,14 @@ describe("Section Accordion", () => {
   });
 
   it("click on the arrow - it should open and close section accordion", async () => {
-    const SectionTitle = () => (
-      <>
-        <NavLink {...props}>section1</NavLink>
-      </>
-    );
     const { getByTestId } = render(
-      <SectionAccordion title={<SectionTitle />} titleName="section2">
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section2"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel2
       </SectionAccordion>
     );
@@ -88,13 +91,14 @@ describe("Section Accordion", () => {
   });
 
   it("click on the section title - it should not activate the accordion", async () => {
-    const SectionTitle = () => (
-      <>
-        <NavLink {...props}>section1</NavLink>
-      </>
-    );
     const { getByTestId } = render(
-      <SectionAccordion title={<SectionTitle />} titleName="section3">
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section3"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
         section accordion panel3
       </SectionAccordion>
     );

--- a/eq-publisher/yarn.lock
+++ b/eq-publisher/yarn.lock
@@ -520,10 +520,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/babel__core@^7.1.0":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
-  integrity sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==
+"@types/babel__core@^7.1.7":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.8.tgz#057f725aca3641f49fc11c7a87a9de5ec588a5d7"
+  integrity sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -3417,6 +3417,11 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -4241,10 +4246,10 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
-pino-http@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pino-http/-/pino-http-4.2.0.tgz#a2d2e2bca7d0ed17f6dd414952f15ff4dea7efab"
-  integrity sha512-yLOpH8fwnUJ3n++QmjS9HtxooJN8OKKcbbW+deRh7GqNHyY5+M9ehmH1X69pY+vuCxBY6hKGJGO2wmHG6OEmDQ==
+pino-http@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/pino-http/-/pino-http-5.2.0.tgz#d51da7981ab6ea7ca9f17c4db24a427e4ba9c546"
+  integrity sha512-uGmC6UbzLaCWu+sG9l2wTp2EoXMQ53GRSY9P1sgqNsq3JSh6HdoleMijyuGj2d02OOr1z3/JHcRUy6hYDYWe9Q==
   dependencies:
     fast-url-parser "^1.1.3"
     pino "^6.0.0"


### PR DESCRIPTION
### What is the context of this PR?

This is the combined EAR-235 and EAR-234 tickets that resolves merge conflicts
### How to review 

0.5 Open chrome dev tools and click this button in the top left
![Screenshot 2020-06-11 at 12 06 54](https://user-images.githubusercontent.com/22731314/84428855-0bf54680-abdc-11ea-8285-1f0aa116f07e.png)

It should open up tabs on the left like this
![Screenshot 2020-06-11 at 12 07 21](https://user-images.githubusercontent.com/22731314/84428894-1c0d2600-abdc-11ea-896a-9c64d3750de7.png)

The verbose tab at the bottom shows when certain actions are taking longer than expected

1. Open questionnaire
2. Create as many sections as you want but more than 1 (Try like 20 if you can)
3. Hit Open all
    - should change to close all
    - if individual section is opened, they should all change to the expected state instead of the opposite of the current state 
4. Adding a new section and see if that works
5. When all sections are open, the button should say 'Close all'
6. When one section is open, the button should say 'Open all'
7. When there are a lot of sections, you should be able to scroll down the nav and the open all button should be fixed under the add content button.
8. Each section when closed should have a red error circle at the end of it. This should disappear when opened. 
9. Hitting open all/close all should toggle the section error correctly