### PR TITLE
Reduced btn font size to match rest of nav

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -47,6 +47,7 @@ const AccordionGroupToggle = styled(Button).attrs({
   top: 1px; /* adjust for misalignment caused by PopoutContainer */
   padding: 0.5em;
   align-self: baseline;
+  font-size: 0.9em;
 `;
 
 const proptypes = {


### PR DESCRIPTION
### What is the context of this PR?

Joe has asked that the font size on the Open all / Close all button is reduced so that it matches the rest of the nav.

![image](https://user-images.githubusercontent.com/15129656/84743130-66f6b700-afa9-11ea-848d-95e72524b95d.png)

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
