### PR TITLE
Implement Skip Conditions Back End

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -14,10 +14,11 @@ const {
   first,
   some,
   concat,
+  reject,
 } = require("lodash");
 const GraphQLJSON = require("graphql-type-json");
 const { v4: uuidv4 } = require("uuid");
-const { withFilter } = require("apollo-server-express");
+const { withFilter, ApolloError } = require("apollo-server-express");
 const fetch = require("node-fetch");
 
 const {
@@ -37,6 +38,8 @@ const {
   getValidationEntity,
 } = require("../../src/businessLogic/createValidation");
 const { currentVersion } = require("../../migrations");
+
+const { createExpression, createLeftSide } = require("../../src/businessLogic");
 
 const {
   getSectionById,
@@ -865,6 +868,47 @@ const Resolvers = {
 
       return replies;
     },
+    createSkipCondition: createMutation((_, { input }, ctx) => {
+      let leftHandSide = {
+        type: "Null",
+        nullReason: "DefaultSkipCondition",
+      };
+      const defaultSkipCondition = {
+        id: uuidv4(),
+        expressions: [createExpression({ left: createLeftSide(leftHandSide) })],
+      };
+      const page = getPageById(ctx, input.pageId);
+
+      const skipConditions = page.skipConditions
+        ? [...page.skipConditions, defaultSkipCondition]
+        : [defaultSkipCondition];
+
+      merge(page, { skipConditions });
+      return defaultSkipCondition;
+    }),
+    deleteSkipCondition: createMutation((_, { input }, ctx) => {
+      const pages = getPages(ctx);
+
+      const page = find(pages, page => {
+        const { skipConditions } = page;
+        if (some(skipConditions, { id: input.id })) {
+          return page;
+        }
+      });
+
+      page.skipConditions = reject(page.skipConditions, { id: input.id });
+
+      if (!page.skipConditions.length) {
+        delete page.skipConditions;
+      }
+
+      return page;
+    }),
+    deleteSkipConditions: createMutation((_, { input }, ctx) => {
+      const page = getPageById(ctx, input.id);
+      delete page.skipConditions;
+      return page;
+    }),
   },
 
   Questionnaire: {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -18,7 +18,7 @@ const {
 } = require("lodash");
 const GraphQLJSON = require("graphql-type-json");
 const { v4: uuidv4 } = require("uuid");
-const { withFilter, ApolloError } = require("apollo-server-express");
+const { withFilter } = require("apollo-server-express");
 const fetch = require("node-fetch");
 
 const {

--- a/eq-author-api/schema/resolvers/index.js
+++ b/eq-author-api/schema/resolvers/index.js
@@ -1,6 +1,13 @@
 const base = require("./base");
-const routing2 = require("./routing2");
+const routing2 = require("./logic/routing2");
+const binaryExpression2 = require("./logic/binaryExpression2");
 const page = require("./pages");
 const questionnaireIntroduction = require("./questionnaireIntroduction");
 
-module.exports = [base, ...routing2, ...page, ...questionnaireIntroduction];
+module.exports = [
+  base,
+  ...routing2,
+  binaryExpression2,
+  ...page,
+  ...questionnaireIntroduction,
+];

--- a/eq-author-api/schema/resolvers/logic/routing2/expressionGroup2/index.js
+++ b/eq-author-api/schema/resolvers/logic/routing2/expressionGroup2/index.js
@@ -1,9 +1,9 @@
 const Resolvers = {};
 
 const { find, flatMap, get } = require("lodash/fp");
-const { createMutation } = require("../../createMutation");
+const { createMutation } = require("../../../createMutation");
 
-const { getPages } = require("../../utils");
+const { getPages } = require("../../../utils");
 
 Resolvers.ExpressionGroup2 = {
   expressions: expressionGroup => expressionGroup.expressions,

--- a/eq-author-api/schema/resolvers/logic/routing2/index.js
+++ b/eq-author-api/schema/resolvers/logic/routing2/index.js
@@ -23,5 +23,4 @@ module.exports = [
   require("./routing2"),
   require("./routingRule2"),
   require("./expressionGroup2"),
-  require("./binaryExpression2"),
 ];

--- a/eq-author-api/schema/resolvers/logic/routing2/routing2/index.js
+++ b/eq-author-api/schema/resolvers/logic/routing2/routing2/index.js
@@ -1,8 +1,8 @@
 const { find } = require("lodash/fp");
 
-const { createMutation } = require("../../createMutation");
+const { createMutation } = require("../../../createMutation");
 
-const isMutuallyExclusive = require("../../../../utils/isMutuallyExclusive");
+const isMutuallyExclusive = require("../../../../../utils/isMutuallyExclusive");
 const {
   createRouting,
   createDestination,
@@ -10,9 +10,9 @@ const {
   createExpressionGroup,
   createExpression,
   createLeftSide,
-} = require("../../../../src/businessLogic");
+} = require("../../../../../src/businessLogic");
 
-const { getPages, getPageById, getRoutingById } = require("../../utils");
+const { getPages, getPageById, getRoutingById } = require("../../../utils");
 
 const isMutuallyExclusiveDestination = isMutuallyExclusive([
   "sectionId",

--- a/eq-author-api/schema/resolvers/logic/routing2/routingRule2/index.js
+++ b/eq-author-api/schema/resolvers/logic/routing2/routingRule2/index.js
@@ -1,8 +1,8 @@
 const { flatMap, find, some, reject, pick } = require("lodash/fp");
 
-const { createMutation } = require("../../createMutation");
+const { createMutation } = require("../../../createMutation");
 
-const isMutuallyExclusive = require("../../../../utils/isMutuallyExclusive");
+const isMutuallyExclusive = require("../../../../../utils/isMutuallyExclusive");
 
 const {
   createDestination,
@@ -10,11 +10,15 @@ const {
   createExpressionGroup,
   createExpression,
   createLeftSide,
-} = require("../../../../src/businessLogic");
-const availableRoutingDestinations = require("../../../../src/businessLogic/availableRoutingDestinations");
-const validateRoutingDestinations = require("../../../../src/businessLogic/validateRoutingDestination");
+} = require("../../../../../src/businessLogic");
+const availableRoutingDestinations = require("../../../../../src/businessLogic/availableRoutingDestinations");
+const validateRoutingDestinations = require("../../../../../src/businessLogic/validateRoutingDestination");
 
-const { getPages, getRoutingById, getRoutingRuleById } = require("../../utils");
+const {
+  getPages,
+  getRoutingById,
+  getRoutingRuleById,
+} = require("../../../utils");
 
 const isMutuallyExclusiveDestination = isMutuallyExclusive([
   "sectionId",

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -63,14 +63,32 @@ const getRules = ctx => flatMap(filter(getRouting(ctx), "rules"), "rules");
 
 const getRoutingRuleById = (ctx, id) => find(getRules(ctx), { id });
 
+const getSkipConditions = ctx =>
+  flatMap(filter(getPages(ctx), "skipConditions"), "skipConditions");
+
+const getSkipConditionById = (ctx, id) => {
+  const skipConditions = getSkipConditions(ctx);
+  return find(skipConditions, { id });
+};
+
 const getExpressionGroups = ctx =>
   flatMap(filter(getRules(ctx), "expressionGroup"), "expressionGroup");
 
 const getExpressionGroupById = (ctx, id) =>
   find(getExpressionGroups(ctx), { id });
 
-const getExpressions = ctx =>
-  flatMap(filter(getExpressionGroups(ctx), "expressions"), "expressions");
+const getExpressions = ctx => {
+  const routingExpressions = flatMap(
+    filter(getExpressionGroups(ctx), "expressions"),
+    "expressions"
+  );
+  const skipConditionExpressions = flatMap(
+    filter(getSkipConditions(ctx), "expressions"),
+    "expressions"
+  );
+
+  return [...routingExpressions, ...skipConditionExpressions];
+};
 
 const getExpressionById = (ctx, id) => find(getExpressions(ctx), { id });
 
@@ -180,4 +198,7 @@ module.exports = {
   getAvailableMetadataForValidation,
 
   remapAllNestedIds,
+
+  getSkipConditionById,
+  getSkipConditions,
 };

--- a/eq-author-api/schema/tests/skipConditions.test.js
+++ b/eq-author-api/schema/tests/skipConditions.test.js
@@ -1,0 +1,91 @@
+const { buildContext } = require("../../tests/utils/contextBuilder");
+const { RADIO } = require("../../constants/answerTypes");
+const {
+  createSkipCondition,
+  deleteSkipCondition,
+  deleteSkipConditions,
+} = require("../../tests/utils/contextBuilder/skipConditions");
+const {
+  createBinaryExpression,
+} = require("../../tests/utils/contextBuilder/routing");
+
+const { queryPage } = require("../../tests/utils/contextBuilder/page");
+
+const config = {
+  metadata: [{}],
+  sections: [
+    {
+      title: "title-1",
+      alias: "alias-1",
+      position: 0,
+      pages: [
+        {
+          title: "page-1",
+          parentSection: "title-1",
+          answers: [
+            {
+              type: RADIO,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("skip conditions", () => {
+  describe("expression group", () => {
+    it("should create an expression group and default expresiion", async () => {
+      const ctx = await buildContext(config);
+      const { questionnaire } = ctx;
+      const page = questionnaire.sections[0].pages[0];
+
+      createSkipCondition(ctx, page);
+      const result = await queryPage(ctx, page.id);
+      expect(result.skipConditions[0].expressions[0].left.reason).toBe(
+        "DefaultSkipCondition"
+      );
+    });
+
+    it("should delete an existing expression group", async () => {
+      const ctx = await buildContext(config);
+      const { questionnaire } = ctx;
+      const page = questionnaire.sections[0].pages[0];
+      const { id } = await createSkipCondition(ctx, page);
+
+      expect(page.skipConditions.length).toBe(1);
+      await deleteSkipCondition(ctx, id);
+      const result = await queryPage(ctx, page.id);
+      expect(result.skipConditions).toBeNull();
+    });
+
+    it("should delete all existing expression groups on a page", async () => {
+      const ctx = await buildContext(config);
+      const { questionnaire } = ctx;
+      const page = questionnaire.sections[0].pages[0];
+      createSkipCondition(ctx, page);
+      createSkipCondition(ctx, page);
+
+      expect(page.skipConditions.length).toBe(2);
+      await deleteSkipConditions(ctx, page);
+      const result = await queryPage(ctx, page.id);
+      expect(result.skipConditions).toBeNull();
+    });
+  });
+  describe("binary Expression", () => {
+    it("should add a binary exporession to an existing expression group", async () => {
+      const ctx = await buildContext(config);
+      const { questionnaire } = ctx;
+      const page = questionnaire.sections[0].pages[0];
+
+      await createSkipCondition(ctx, page);
+      const expressionGroup =
+        ctx.questionnaire.sections[0].pages[0].skipConditions[0];
+      await createBinaryExpression(ctx, expressionGroup);
+      const result = await queryPage(ctx, page.id);
+      expect(result.skipConditions[0].expressions[0].left.reason).toBe(
+        "DefaultSkipCondition"
+      );
+    });
+  });
+});

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -151,6 +151,7 @@ type QuestionPage implements Page {
   availableRoutingDestinations: AvailableRoutingDestinations!
   confirmation: QuestionConfirmation
   routing: Routing2
+  skipConditions: [ExpressionGroup2]
   totalValidation: TotalValidationRule
   validationErrorInfo: ValidationErrorInfo
 }
@@ -506,7 +507,7 @@ union Expression2 = BinaryExpression2 | ExpressionGroup2
 
 type ExpressionGroup2 {
   id: ID!
-  operator: RoutingOperator2!
+  operator: RoutingOperator2
   expressions: [Expression2!]!
 }
 
@@ -514,6 +515,7 @@ enum NoLeftSideReason {
   SelectedAnswerDeleted
   NoRoutableAnswerOnPage
   DefaultRouting
+  DefaultSkipCondition
 }
 
 type NoLeftSide {
@@ -532,7 +534,7 @@ type SelectedOptions2 {
   options: [Option!]!
 }
 
-enum RoutingCondition2 {
+enum LogicCondition {
   Equal
   NotEqual
   GreaterThan
@@ -549,10 +551,10 @@ enum RoutingCondition2 {
 
 type BinaryExpression2 {
   id: ID!
-  left: LeftSide2!
-  condition: RoutingCondition2!
+  left: LeftSide2
+  condition: LogicCondition
   right: RightSide2
-  expressionGroup: ExpressionGroup2!
+  expressionGroup: ExpressionGroup2
 }
 
 enum LegalBasis {
@@ -625,6 +627,19 @@ input QueryInput {
   optionId: ID
 }
 
+input CreateSkipConditionInput {
+  pageId: ID!
+}
+
+input DeleteSkipConditionInput {
+  id: ID!
+}
+
+input DeleteSkipConditionsInput {
+  id: ID!
+}
+
+
 type Mutation {
   createQuestionnaire(input: CreateQuestionnaireInput!): Questionnaire
   updateQuestionnaire(input: UpdateQuestionnaireInput!): Questionnaire
@@ -688,6 +703,9 @@ type Mutation {
   deleteCollapsible(input: DeleteCollapsibleInput!): QuestionnaireIntroduction!
   triggerPublish(input: PublishQuestionnaireInput!): Questionnaire!
   reviewQuestionnaire(input: ReviewQuestionnaireInput!): Questionnaire!
+  createSkipCondition(input: CreateSkipConditionInput!): ExpressionGroup2!
+  deleteSkipCondition(input: DeleteSkipConditionInput!): QuestionPage
+  deleteSkipConditions(input: DeleteSkipConditionsInput!): QuestionPage
 }
 
 input CreateRouting2Input {
@@ -729,7 +747,7 @@ input CreateBinaryExpression2Input {
 
 input UpdateBinaryExpression2Input {
   id: ID!
-  condition: RoutingCondition2!
+  condition: LogicCondition!
 }
 
 input UpdateLeftSide2Input {

--- a/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
+++ b/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
@@ -119,6 +119,43 @@ const getPageQuery = `
             ...destination2Fragment
           }
         }
+        skipConditions {
+          expressions {
+            ... on BinaryExpression2 {
+              id
+              left {
+                ... on BasicAnswer {
+                  id
+                  type
+                  label
+                }
+                ... on MultipleChoiceAnswer {
+                  id
+                  type
+                  options {
+                    id
+                  }
+                }
+                ... on NoLeftSide {
+                  reason
+                }
+              }
+              condition
+              right {
+                ... on CustomValue2 {
+                  number
+                }
+                ... on SelectedOptions2 {
+                  options {
+                    id
+                    label
+                  }
+                }
+              }
+            }
+          }
+          id
+        }
         totalValidation {
           id
           enabled

--- a/eq-author-api/tests/utils/contextBuilder/skipConditions/createSkipCondition.js
+++ b/eq-author-api/tests/utils/contextBuilder/skipConditions/createSkipCondition.js
@@ -1,0 +1,27 @@
+const executeQuery = require("../../executeQuery");
+
+const createSkipConditionMutation = `
+mutation createSkipCondition($input: CreateSkipConditionInput!) {
+  createSkipCondition(input: $input) {
+    id
+  }
+}`;
+
+const createSkipCondition = async (ctx, page) => {
+  const input = {
+    pageId: page.id,
+  };
+  const result = await executeQuery(
+    createSkipConditionMutation,
+    {
+      input,
+    },
+    ctx
+  );
+  return result.data.createSkipCondition;
+};
+
+module.exports = {
+  createSkipConditionMutation,
+  createSkipCondition,
+};

--- a/eq-author-api/tests/utils/contextBuilder/skipConditions/deleteSkipCondition.js
+++ b/eq-author-api/tests/utils/contextBuilder/skipConditions/deleteSkipCondition.js
@@ -1,0 +1,27 @@
+const executeQuery = require("../../executeQuery");
+
+const deleteSkipConditionMutation = `
+mutation deleteSkipCondition($input: DeleteSkipConditionInput!) {
+  deleteSkipCondition(input: $input) {
+    id
+  }
+}`;
+
+const deleteSkipCondition = async (ctx, id) => {
+  const input = {
+    id: id,
+  };
+  const result = await executeQuery(
+    deleteSkipConditionMutation,
+    {
+      input,
+    },
+    ctx
+  );
+  return result.data.deleteSkipCondition;
+};
+
+module.exports = {
+  deleteSkipConditionMutation,
+  deleteSkipCondition,
+};

--- a/eq-author-api/tests/utils/contextBuilder/skipConditions/deleteSkipConditions.js
+++ b/eq-author-api/tests/utils/contextBuilder/skipConditions/deleteSkipConditions.js
@@ -1,0 +1,27 @@
+const executeQuery = require("../../executeQuery");
+
+const deleteSkipConditionsMutation = `
+mutation deleteSkipConditions($input: DeleteSkipConditionsInput!) {
+  deleteSkipConditions(input: $input) {
+    id
+  }
+}`;
+
+const deleteSkipConditions = async (ctx, page) => {
+  const input = {
+    id: page.id,
+  };
+  const result = await executeQuery(
+    deleteSkipConditionsMutation,
+    {
+      input,
+    },
+    ctx
+  );
+  return result.data.deleteSkipConditions;
+};
+
+module.exports = {
+  deleteSkipConditionsMutation,
+  deleteSkipConditions,
+};

--- a/eq-author-api/tests/utils/contextBuilder/skipConditions/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/skipConditions/index.js
@@ -1,0 +1,23 @@
+const {
+  createSkipCondition,
+  createSkipConditionMutation,
+} = require("./createSkipCondition");
+
+const {
+  deleteSkipCondition,
+  deleteSkipConditionMutation,
+} = require("./deleteSkipCondition");
+
+const {
+  deleteSkipConditions,
+  deleteSkipConditionsMutation,
+} = require("./deleteSkipConditions");
+
+module.exports = {
+  createSkipCondition,
+  createSkipConditionMutation,
+  deleteSkipCondition,
+  deleteSkipConditionMutation,
+  deleteSkipConditions,
+  deleteSkipConditionsMutation,
+};


### PR DESCRIPTION
### Context

This pull request introduces the back end functionality for supporting Skip Conditions. Utilising what already exists for Routing, where possible, types and resolvers have been reused to ensure that A) the schema used in both are identical and B) the front end content picker maintains the same interface when talking to the API via resolvers.

This **does not** include publisher changes for translating between Author and EqRunner.

### How to test

Firstly, ensure the code looks OK and that Routing remains unchanged in functionality.

Some notes regarding the Skip Conditions schema:

- `skipConditions` is an array of objects, each defining a condition whereby the question on which the aforementioned field appears should be skipped. Multiple skip conditions are evaluated as OR rules (if any of the conditions evaluate to true, then the question is skipped).
- `expressions` is an array of objects, each defining a unique rule that must be satisfied in order to cause the condition they are part of to evaluate as true and consequently cause the question to be skipped. Multiple expressions are evaluated as AND rules. Each expression is a `BinaryExpression2` identical to what is found in Routing.

Then, boot up your prefered tool for sending API requests (e.g. Altair and Postman) and test out the following mutations:

**Note** - Skip conditions live on the question that they will cause to be skipped if evaluated to true.

- `createSkipCondition` - it should accept a single input, `pageId`, which is the identifier for the page to enable skip conditons on. If adding a skip condition for the first time, it should introduce the `skipConditions` property onto the Page's JSON blob and initialise an empty, default, skip conditon containing an empty, default expression. It should return the skip condition blob it created.

- `deleteSkipCondition` - it should accept a single input, `id`, which is the identifier for the condition you want to delete. If deleting the only skip condition on the page, the entire `skipConditions` property should be removed from the page JSON blob. It should return the page it removed the skip condition from.

- `createBinaryExpression2` - it should accept a single input, `expressionGroupId`, which is the identifier for the skip condition you created. It should create an empty, default expression within the `expressions` array in the JSON blob for the target skip condition.

- `deleteBinaryExpression` - it should accept a single input, `id`, which is the identifier for the skip condition you want to delete. It should delete the expression from the `expressions` array on the parent skip condition. If it is the only skip condition in the array, `expressions` should be empty.

- `updateBinaryExpression2` - it should accept two inputs, `id` and `condition`, which are the identifier for the expression you wish to update and the logical condition (e.g. Equals, NotEquals, Unanswered) to update on the expression, respectively. It is known that the name of this mutation is weird and a note has been made to consider renaming it when we refactor Routing. When called, it should update the condition on the target expression, return an error if the condition is not allowed for the answer type on the left of the expression or an error if there is no left side of the expression.

- `updateLeftSide2` - it should accept two inputs, `expressionId` and `answerId`, which are the identifiers for the expression you wish to update the left side of and the answer to use as the new left side. 

- `updateRightSide2` - it should accept two inputs, `expressionId` and `selectedOptions` OR `customValue` (depending on the left hand side of the expression), which is an identifier for the expression to update and the value to use when evaluating if the page should be skipped. If you give it both `customValue` and `selectedOption` it  should return an error.

You can test these in any order. However, to build a valid Skip Condition, you could call them like this:

**Prerequesite** - Build a question that is a multiple choice answer and a second one which is of any type. The first question will be used as the answer to evaluate whether the second question should be skipped.

1. `createSkipCondition`
2. `createBinaryExpression2`
3. `updateLeftSide2`
4. `updateBinaryExpression2`
5. `updateRightSide2`
