### PR TITLE
Refactored routing and fixed add rule

### DIFF
--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -53,16 +53,6 @@ Resolvers.BinaryExpression2 = {
       return { ...answer, sideType: left.type };
     }
 
-    if (left.type === "Default") {
-      const answer = getAnswerById(ctx, left.answerId);
-      return {
-        ...answer,
-        sideType: left.type,
-        reason: "DefaultRouting",
-        displayName: "Select an answer",
-      };
-    }
-
     return { sideType: left.type, reason: left.nullReason };
   },
   right: async ({ right }) => {
@@ -262,6 +252,7 @@ Resolvers.Mutation = {
       answerId,
       type: "Answer",
     };
+    delete updatedLeftSide.nullReason;
 
     expression.left = updatedLeftSide;
     expression.right = null;

--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -4,23 +4,14 @@ const {
   flatMap,
   some,
   intersectionBy,
-  first,
   getOr,
   reject,
   map,
 } = require("lodash/fp");
 
-const {
-  createExpression,
-  createRightSide,
-} = require("../../../../src/businessLogic");
+const { createExpression } = require("../../../../src/businessLogic");
 
 const { createMutation } = require("../../createMutation");
-
-const {
-  NO_ROUTABLE_ANSWER_ON_PAGE,
-  NULL,
-} = require("../../../../constants/routingNoLeftSide");
 
 const {
   getPages,
@@ -139,43 +130,13 @@ Resolvers.Mutation = {
       flatMap(rule => rule.expressionGroup, rules)
     );
 
-    const page = find(page => {
-      if (
-        page.routing &&
-        some(rule => {
-          if (rule.expressionGroup.id === input.expressionGroupId) {
-            return true;
-          }
-        }, getOr([], "routing.rules", page))
-      ) {
-        return page;
-      }
-    }, pages);
-
-    const firstAnswer = first(getOr([], "answers", page));
-
-    const hasRoutableFirstAnswer =
-      firstAnswer &&
-      answerTypeToConditions.isAnswerTypeSupported(firstAnswer.type);
-    let condition;
-    if (hasRoutableFirstAnswer) {
-      condition = answerTypeToConditions.getDefault(firstAnswer.type);
-    }
-
-    const left = hasRoutableFirstAnswer
-      ? {
-          answerId: firstAnswer.id,
-          type: "Default",
-        }
-      : {
-          type: NULL,
-          nullReason: NO_ROUTABLE_ANSWER_ON_PAGE,
-        };
+    const left = {
+      type: "Null",
+      nullReason: "DefaultRouting",
+    };
 
     const expression = createExpression({
       left,
-      condition: condition || "Equal",
-      right: createRightSide(firstAnswer),
     });
 
     expressionGroup.expressions.push(expression);

--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -9,7 +9,10 @@ const {
   map,
 } = require("lodash/fp");
 
-const { createExpression } = require("../../../../src/businessLogic");
+const {
+  createExpression,
+  createLeftSide,
+} = require("../../../../src/businessLogic");
 
 const { createMutation } = require("../../createMutation");
 
@@ -130,13 +133,13 @@ Resolvers.Mutation = {
       flatMap(rule => rule.expressionGroup, rules)
     );
 
-    const left = {
+    const leftHandSide = {
       type: "Null",
       nullReason: "DefaultRouting",
     };
 
     const expression = createExpression({
-      left,
+      left: createLeftSide(leftHandSide),
     });
 
     expressionGroup.expressions.push(expression);

--- a/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/binaryExpression2/index.js
@@ -92,9 +92,6 @@ Resolvers.LeftSide2 = {
     if (sideType === "Null") {
       return "NoLeftSide";
     }
-    if (sideType === "Default") {
-      return "DefaultLeftSide";
-    }
   },
 };
 

--- a/eq-author-api/schema/resolvers/routing2/routing2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/routing2/index.js
@@ -1,4 +1,4 @@
-const { flatMap, find } = require("lodash/fp");
+const { find } = require("lodash/fp");
 
 const { createMutation } = require("../../createMutation");
 
@@ -12,7 +12,7 @@ const {
   createLeftSide,
 } = require("../../../../src/businessLogic");
 
-const { getPages, getPageById } = require("../../utils");
+const { getPages, getPageById, getRoutingById } = require("../../utils");
 
 const isMutuallyExclusiveDestination = isMutuallyExclusive([
   "sectionId",
@@ -75,9 +75,7 @@ Resolvers.Mutation = {
       throw new Error("Can only provide one destination.");
     }
 
-    const allRouting = flatMap(page => page.routing, getPages(ctx));
-
-    const routing = find({ id: input.id }, allRouting);
+    const routing = getRoutingById(ctx, input.id);
 
     routing.else = {
       id: routing.else.id,

--- a/eq-author-api/schema/resolvers/routing2/routingRule2/index.js
+++ b/eq-author-api/schema/resolvers/routing2/routingRule2/index.js
@@ -1,18 +1,8 @@
-const {
-  flatMap,
-  find,
-  some,
-  reject,
-  getOr,
-  pick,
-  first,
-} = require("lodash/fp");
+const { flatMap, find, some, reject, getOr, pick } = require("lodash/fp");
 
 const { createMutation } = require("../../createMutation");
 
 const isMutuallyExclusive = require("../../../../utils/isMutuallyExclusive");
-
-const conditions = require("../../../../constants/routingConditions");
 
 const {
   createDestination,
@@ -20,15 +10,9 @@ const {
   createExpressionGroup,
   createExpression,
   createLeftSide,
-  createRightSide,
 } = require("../../../../src/businessLogic");
 const availableRoutingDestinations = require("../../../../src/businessLogic/availableRoutingDestinations");
 const validateRoutingDestinations = require("../../../../src/businessLogic/validateRoutingDestination");
-const answerTypeToConditions = require("../../../../src/businessLogic/answerTypeToConditions");
-const {
-  NO_ROUTABLE_ANSWER_ON_PAGE,
-  NULL,
-} = require("../../../../constants/routingNoLeftSide");
 
 const { getPages } = require("../../utils");
 
@@ -66,33 +50,16 @@ Resolvers.Mutation = {
       }
     }, pages);
 
-    const firstAnswer = first(page.answers);
-
-    const hasRoutableFirstAnswer =
-      firstAnswer &&
-      answerTypeToConditions.isAnswerTypeSupported(firstAnswer.type);
-
-    let condition = conditions.EQUAL;
-    let leftHandSide = {
-      type: NULL,
-      nullReason: NO_ROUTABLE_ANSWER_ON_PAGE,
+    const leftHandSide = {
+      type: "Null",
+      nullReason: "DefaultRouting",
     };
-
-    if (hasRoutableFirstAnswer) {
-      condition = answerTypeToConditions.getDefault(firstAnswer.type);
-      leftHandSide = {
-        answerId: firstAnswer.id,
-        type: "Answer",
-      };
-    }
 
     const routingRule = createRoutingRule({
       expressionGroup: createExpressionGroup({
         expressions: [
           createExpression({
             left: createLeftSide(leftHandSide),
-            condition,
-            right: createRightSide(firstAnswer),
           }),
         ],
       }),

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -55,6 +55,21 @@ const getOptions = ctx =>
 
 const getOptionById = (ctx, id) => find(getOptions(ctx), { id });
 
+const getRouting = ctx => flatMap(filter(getPages(ctx), "routing"), "routing");
+
+const getRules = ctx => flatMap(filter(getRouting(ctx), "rules"), "rules");
+
+const getExpressionGroups = ctx =>
+  flatMap(filter(getRules(ctx), "expressionGroup"), "expressionGroup");
+
+const getExpressionGroupById = (ctx, id) =>
+  find(getExpressionGroups(ctx), { id });
+
+const getExpressions = ctx =>
+  flatMap(filter(getExpressionGroups(ctx), "expressions"), "expressions");
+
+const getExpressionById = (ctx, id) => find(getExpressions(ctx), { id });
+
 const getValidationById = (ctx, id) => {
   const answers = getAnswers(ctx);
   const answerValidations = flatMap(answers, answer =>
@@ -142,6 +157,13 @@ module.exports = {
 
   getOptions,
   getOptionById,
+
+  getRouting,
+  getRules,
+  getExpressionGroups,
+  getExpressionGroupById,
+  getExpressions,
+  getExpressionById,
 
   getConfirmations,
   getConfirmationById,

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -61,6 +61,8 @@ const getRoutingById = (ctx, id) => find(getRouting(ctx), { id });
 
 const getRules = ctx => flatMap(filter(getRouting(ctx), "rules"), "rules");
 
+const getRoutingRuleById = (ctx, id) => find(getRules(ctx), { id });
+
 const getExpressionGroups = ctx =>
   flatMap(filter(getRules(ctx), "expressionGroup"), "expressionGroup");
 
@@ -163,6 +165,7 @@ module.exports = {
   getRouting,
   getRoutingById,
   getRules,
+  getRoutingRuleById,
   getExpressionGroups,
   getExpressionGroupById,
   getExpressions,

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -57,6 +57,8 @@ const getOptionById = (ctx, id) => find(getOptions(ctx), { id });
 
 const getRouting = ctx => flatMap(filter(getPages(ctx), "routing"), "routing");
 
+const getRoutingById = (ctx, id) => find(getRouting(ctx), { id });
+
 const getRules = ctx => flatMap(filter(getRouting(ctx), "rules"), "rules");
 
 const getExpressionGroups = ctx =>
@@ -159,6 +161,7 @@ module.exports = {
   getOptionById,
 
   getRouting,
+  getRoutingById,
   getRules,
   getExpressionGroups,
   getExpressionGroupById,

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -26,7 +26,7 @@ const { deleteSection } = require("../../tests/utils/contextBuilder/section");
 
 describe("routing", () => {
   describe("A Routing", () => {
-    it("should create a full routing tree when creating a routing", async () => {
+    it("should create a default routing when creating a routing", async () => {
       let config = {
         metadata: [{}],
         sections: [
@@ -62,11 +62,8 @@ describe("routing", () => {
 
       const result = await queryPage(ctx, page.id);
       expect(
-        result.routing.rules[0].expressionGroup.expressions[0].left.id
-      ).toEqual(page.answers[0].id);
-      expect(
-        result.routing.rules[0].expressionGroup.expressions[0].right
-      ).toEqual({ options: [] });
+        result.routing.rules[0].expressionGroup.expressions[0].left.reason
+      ).toBe("DefaultRouting");
     });
 
     // Passes intermittently
@@ -403,8 +400,20 @@ describe("routing", () => {
       const ctx = await buildContext(config);
       const { questionnaire } = ctx;
       const firstPage = questionnaire.sections[0].pages[0];
+      const firstAnswer = questionnaire.sections[0].pages[0].answers[0];
       const expression =
         firstPage.routing.rules[0].expressionGroup.expressions[0];
+
+      await executeQuery(
+        updateLeftSideMutation,
+        {
+          input: {
+            expressionId: expression.id,
+            answerId: firstAnswer.id,
+          },
+        },
+        ctx
+      );
 
       await executeQuery(
         updateBinaryExpressionMutation,
@@ -548,21 +557,9 @@ describe("routing", () => {
                   },
                 ],
                 routing: {
-                  rules: [
-                    {
-                      expressionGroup: {
-                        expressions: [
-                          {
-                            right: {
-                              customValue: {
-                                number: 2,
-                              },
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
+                  routing: {
+                    rules: [{ expressionGroup: { expressions: [{}] } }],
+                  },
                 },
               },
             ],
@@ -572,9 +569,20 @@ describe("routing", () => {
       const ctx = await buildContext(config);
       const { questionnaire } = ctx;
       const firstPage = questionnaire.sections[0].pages[0];
+      const firstAnswer = questionnaire.sections[0].pages[0].answers[0];
       const expression =
         firstPage.routing.rules[0].expressionGroup.expressions[0];
 
+      await executeQuery(
+        updateLeftSideMutation,
+        {
+          input: {
+            expressionId: expression.id,
+            answerId: firstAnswer.id,
+          },
+        },
+        ctx
+      );
       await executeQuery(
         updateRightSideMutation,
         {
@@ -624,10 +632,21 @@ describe("routing", () => {
       const ctx = await buildContext(config);
       const { questionnaire } = ctx;
       const firstQuestionPage = questionnaire.sections[0].pages[0];
+      const firstAnswer = questionnaire.sections[0].pages[0].answers[0];
       const expression =
         firstQuestionPage.routing.rules[0].expressionGroup.expressions[0];
 
       const options = firstQuestionPage.answers[0].options;
+      await executeQuery(
+        updateLeftSideMutation,
+        {
+          input: {
+            expressionId: expression.id,
+            answerId: firstAnswer.id,
+          },
+        },
+        ctx
+      );
       await executeQuery(
         updateRightSideMutation,
         {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -520,13 +520,7 @@ type NoLeftSide {
   reason: NoLeftSideReason!
 }
 
-type DefaultLeftSide {
-  id: ID!
-  displayName: String!
-  reason: NoLeftSideReason!
-}
-
-union LeftSide2 = BasicAnswer | MultipleChoiceAnswer | NoLeftSide | DefaultLeftSide
+union LeftSide2 = BasicAnswer | MultipleChoiceAnswer | NoLeftSide
 
 union RightSide2 = SelectedOptions2 | CustomValue2
 

--- a/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
+++ b/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
@@ -92,9 +92,7 @@ const getPageQuery = `
                         id
                       }
                     }
-                    ... on DefaultLeftSide {
-                      id
-                      displayName
+                    ... on NoLeftSide {
                       reason
                     }
                   }

--- a/eq-author-api/tests/utils/contextBuilder/routing/createRouting.js
+++ b/eq-author-api/tests/utils/contextBuilder/routing/createRouting.js
@@ -18,9 +18,7 @@ mutation createRouting2($input: CreateRouting2Input!) {
               ... on MultipleChoiceAnswer {
                 id
               }
-              ... on DefaultLeftSide {
-                id
-                displayName
+              ... on NoLeftSide {
                 reason
               }
             }

--- a/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/fragment.graphql
+++ b/eq-author/src/App/page/Routing/RoutingPage/RoutingEditor/RuleEditor/BinaryExpressionEditor/fragment.graphql
@@ -23,11 +23,6 @@ fragment BinaryExpressionEditor on BinaryExpression2 {
     ... on NoLeftSide {
       reason
     }
-    ... on DefaultLeftSide {
-      id
-      displayName
-      reason
-    }
   }
   condition
   right {


### PR DESCRIPTION
Refactored routing

- The routing had redundant code that set the first answer. We are no longer doing this and so i removed the code.
- The default answer has been changed to a null answer and reason, this is so that we can use the null Reason for validation later on.
- When adding second rule it was still pre-populating with the current answer. This has been fixed to be a null answer.

Sanity check and feedback required.
