### PR TITLE
accesibility for section accordions

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu.js
@@ -51,6 +51,11 @@ const AddButton = styled(Button).attrs({
   width: 100%;
   padding: 0.7em 2.1em;
   z-index: 15;
+
+  &:focus {
+    outline: 3px solid #fdbd56;
+    outline-offset: -3px;
+  }
 `;
 
 const StyledIconText = styled(IconText)`

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/SectionNavItem.js
@@ -88,7 +88,7 @@ export const UnwrappedSectionNavItem = props => {
           data-test="nav-section-link"
           title={section.displayName}
           icon={SectionIcon}
-          id="sectionName"
+          id={section.displayName}
           errorCount={section.validationErrorInfo.totalCount}
           sectionTotalErrors={questionErrorCount}
           isSection

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -48,6 +48,11 @@ const AccordionGroupToggle = styled(Button).attrs({
   padding: 0.5em;
   align-self: baseline;
   font-size: 0.9em;
+
+  &:focus {
+    outline: 3px solid #fdbd56;
+    outline-offset: -3px;
+  }
 `;
 
 const proptypes = {

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -126,7 +126,10 @@ const SectionAccordion = props => {
   return (
     <>
       <Header>
-        <Title onKeyUp={event => onEnterUp(event)}>
+        <Title
+          onKeyUp={event => onEnterUp(event)}
+          data-test={`accordion-${titleName}-titleContainer`}
+        >
           <Button
             role="button"
             id={`${titleName}-btn`}

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -116,16 +116,34 @@ const SectionAccordion = props => {
     handleChange({ isOpen: !isOpen, id: identity });
   };
 
+  const onEnterUp = event => {
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      setIsOpen(isOpen => !isOpen);
+      handleChange({ isOpen: !isOpen, id: identity });
+    }
+    if (isOpen && event.keyCode === 37) {
+      setIsOpen(isOpen => !isOpen);
+      handleChange({ isOpen: !isOpen, id: identity });
+    }
+    if (!isOpen && event.keyCode === 39) {
+      setIsOpen(isOpen => !isOpen);
+      handleChange({ isOpen: !isOpen, id: identity });
+    }
+  };
+
   return (
     <>
       <Header>
-        <Title>
+        <Title onKeyUp={event => onEnterUp(event)}>
           <Button
+            role="button"
+            id={`${titleName}-title`}
             isOpen={isOpen}
             onClick={() => handleClick()}
             aria-expanded={isOpen}
-            aria-controls={`accordion-${titleName}`}
+            aria-controls={`accordionBody-${titleName}`}
             data-test={`accordion-${titleName}-button`}
+            tabIndex={-1}
           />
           <SectionTitle data-test={`accordion-${titleName}-title`}>
             {title(isOpen)}
@@ -133,10 +151,13 @@ const SectionAccordion = props => {
         </Title>
       </Header>
       <Body
-        id={`accordion-${titleName}`}
+        id={`accordionBody-${titleName}`}
         data-test={`accordion-${titleName}-body`}
         isOpen={isOpen}
         aria-hidden={!isOpen}
+        hidden={!isOpen}
+        role="region"
+        aria-labelledby={`${titleName}-title`}
       >
         <DisplayContent isOpen={isOpen}>{children}</DisplayContent>
       </Body>

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -129,6 +129,10 @@ const SectionAccordion = props => {
       setIsOpen(isOpen => !isOpen);
       handleChange({ isOpen: !isOpen, id: identity });
     }
+    if (event.keyCode === 38) {
+      focusRef.current.focus();
+      console.log("focusRef", focusRef.current);
+    }
   };
 
   return (
@@ -137,7 +141,7 @@ const SectionAccordion = props => {
         <Title onKeyUp={event => onEnterUp(event)}>
           <Button
             role="button"
-            id={`${titleName}-title`}
+            id={`${titleName}-btn`}
             isOpen={isOpen}
             onClick={() => handleClick()}
             aria-expanded={isOpen}
@@ -151,12 +155,12 @@ const SectionAccordion = props => {
         </Title>
       </Header>
       <Body
+        role="region"
         id={`accordionBody-${titleName}`}
         data-test={`accordion-${titleName}-body`}
         isOpen={isOpen}
         aria-hidden={!isOpen}
         hidden={!isOpen}
-        role="region"
         aria-labelledby={`${titleName}-title`}
       >
         <DisplayContent isOpen={isOpen}>{children}</DisplayContent>

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -129,10 +129,6 @@ const SectionAccordion = props => {
       setIsOpen(isOpen => !isOpen);
       handleChange({ isOpen: !isOpen, id: identity });
     }
-    if (event.keyCode === 38) {
-      focusRef.current.focus();
-      console.log("focusRef", focusRef.current);
-    }
   };
 
   return (

--- a/eq-author/src/components/AccordionSectionsNav/index.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.js
@@ -121,14 +121,6 @@ const SectionAccordion = props => {
       setIsOpen(isOpen => !isOpen);
       handleChange({ isOpen: !isOpen, id: identity });
     }
-    if (isOpen && event.keyCode === 37) {
-      setIsOpen(isOpen => !isOpen);
-      handleChange({ isOpen: !isOpen, id: identity });
-    }
-    if (!isOpen && event.keyCode === 39) {
-      setIsOpen(isOpen => !isOpen);
-      handleChange({ isOpen: !isOpen, id: identity });
-    }
   };
 
   return (

--- a/eq-author/src/components/AccordionSectionsNav/index.test.js
+++ b/eq-author/src/components/AccordionSectionsNav/index.test.js
@@ -110,4 +110,88 @@ describe("Section Accordion", () => {
     });
     expect(getByTestId("accordion-section3-body")).toBeVisible();
   });
+
+  it("click on the space-bar when section is in focus - it should open section accordion", async () => {
+    const { getByTestId } = render(
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section2"
+        isOpen={{ open: false }}
+        identity={0}
+        handleChange={jest.fn()}
+      >
+        section accordion panel2
+      </SectionAccordion>
+    );
+
+    await act(async () => {
+      await fireEvent.keyUp(getByTestId("accordion-section2-titleContainer"), {
+        keyCode: 32,
+      });
+    });
+    expect(getByTestId("accordion-section2-body")).toBeVisible();
+  });
+
+  it("click on the space-bar when section is in focus - it should close section accordion", async () => {
+    const { getByTestId } = render(
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section2"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
+        section accordion panel2
+      </SectionAccordion>
+    );
+
+    await act(async () => {
+      await fireEvent.keyUp(getByTestId("accordion-section2-titleContainer"), {
+        keyCode: 32,
+      });
+    });
+    expect(getByTestId("accordion-section2-body")).not.toBeVisible();
+  });
+
+  it("click on enter when section is in focus - it should open section accordion", async () => {
+    const { getByTestId } = render(
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section2"
+        isOpen={{ open: false }}
+        identity={0}
+        handleChange={jest.fn()}
+      >
+        section accordion panel2
+      </SectionAccordion>
+    );
+
+    await act(async () => {
+      await fireEvent.keyUp(getByTestId("accordion-section2-titleContainer"), {
+        keyCode: 13,
+      });
+    });
+    expect(getByTestId("accordion-section2-body")).toBeVisible();
+  });
+
+  it("click on enter when section is in focus - it should close section accordion", async () => {
+    const { getByTestId } = render(
+      <SectionAccordion
+        title={SectionTitleMock}
+        titleName="section2"
+        isOpen={isOpen}
+        identity={0}
+        handleChange={jest.fn()}
+      >
+        section accordion panel2
+      </SectionAccordion>
+    );
+
+    await act(async () => {
+      await fireEvent.keyUp(getByTestId("accordion-section2-titleContainer"), {
+        keyCode: 13,
+      });
+    });
+    expect(getByTestId("accordion-section2-body")).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
### **What is the context of this PR?**

**_Using the tab key to navigate_**
GIVEN I'm focussed on a collapsed section
WHEN I press the tab key
THEN the next section is focussed

GIVEN I'm focussed on a expanded section
WHEN I press the tab key
THEN the first question in that section is focussed

GIVEN I'm focussed on a collapsed section
WHEN I press the shift and tab keys on a collapsed section
THEN the previous section/question is focussed

_**Using the space key to navigate**_
GIVEN I'm focussed on a expanded section
WHEN I press the space key
THEN the section closes AND active state does not change

GIVEN I'm focussed on a closed section
WHEN I press the space key
THEN the section opens AND active state does not change

_**Using the enter key to navigate**_
GIVEN I'm focussed on a expanded section
WHEN I press the enter key
THEN the section closes AND that section becomes active

GIVEN I'm focussed on a closed section
WHEN I press the enter key
THEN the section opens AND that section becomes active

I've also included focus for close/open all accordion btn and add new content btn so now tabs correctly in this area!

**### How to review**
Add multiple sections and questions to your questionnaire and make sure the AC above is met