### PR TITLE
Update legal notice to use sentence casing

### DIFF
--- a/eq-author/src/App/introduction/Design/IntroductionEditor/LegalBasisField.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/LegalBasisField.js
@@ -84,8 +84,7 @@ const LegalLabel = styled.label`
 const LegalTitle = styled.span`
   font-size: 0.85em;
   font-weight: bold;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0;
   margin: 0 0 1em;
   color: ${colors.text};
 `;


### PR DESCRIPTION
### What is the context of this PR?

Changes legal basis titles to use sentence case. Also reduces the `letter-spacing`.

EDIT: **The title looks really small now, need to double check if it should be increased**

### How to review 

- Check introduction pages are now using sentence case in the legal notice title.

| Before  | After |
| ------------- | ------------- |
| <img width="847" alt="Screenshot 2020-06-25 at 09 46 30" src="https://user-images.githubusercontent.com/22731314/85762643-c8fd9d80-b6c8-11ea-96f7-800c9545340c.png"> | <img width="835" alt="Screenshot 2020-06-25 at 09 37 00" src="https://user-images.githubusercontent.com/22731314/85762479-9f447680-b6c8-11ea-8a54-0224ec90226a.png">  |

