### PR TITLE
coverage test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,12 +9,6 @@ coverage:
         flags: publisher
   patch: false
 
-  range:
-    70..90 # First number represents red, and second represents green
-    # (default is 70..100)
-  round: down # up, down, or nearest
-  precision: 2 # Number of decimal places, between 0 and 5
-
 flags:
   author:
     paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,5 +18,4 @@ flags:
   publisher:
     paths:
       - eq-publisher/
-
-comment: off
+# comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,13 @@ coverage:
         flags: api
       publisher:
         flags: publisher
+  patch: false
+
+  range:
+    70..90 # First number represents red, and second represents green
+    # (default is 70..100)
+  round: down # up, down, or nearest
+  precision: 2 # Number of decimal places, between 0 and 5
 
 flags:
   author:
@@ -19,3 +26,5 @@ flags:
     paths:
       - eq-publisher/
 # comment: off
+comment:
+layout: diff, files # accepted in any order: reach, diff, flags, and/or files

--- a/eq-author/src/components/EditorLayout/Tabs/__snapshots__/tabs.test.js.snap
+++ b/eq-author/src/components/EditorLayout/Tabs/__snapshots__/tabs.test.js.snap
@@ -36,6 +36,9 @@ exports[`Tabs should render a confirmation link when provided 1`] = `
       <Tabs__SmallBadge
         data-test="small-badge"
       />
+      <Tabs__SmallBadge
+        data-test="small-badge-codeCovTest"
+      />
       Design
     </Tabs__Tab>
     <Tabs__DisabledTab
@@ -68,37 +71,8 @@ exports[`Tabs should render link to section if params are for a section 1`] = `
       <Tabs__SmallBadge
         data-test="small-badge"
       />
-      Design
-    </Tabs__Tab>
-    <Tabs__DisabledTab
-      data-test="preview"
-      key="preview"
-    >
-      Preview
-    </Tabs__DisabledTab>
-    <Tabs__DisabledTab
-      data-test="logic"
-      key="logic"
-    >
-      Logic
-    </Tabs__DisabledTab>
-  </Tabs__TabsContainer>
-</div>
-`;
-
-exports[`Tabs should render with design tab enabled by default 1`] = `
-<div>
-  <Tabs__TabsContainer
-    data-test="tabs-nav"
-  >
-    <Tabs__Tab
-      activeClassName="active"
-      data-test="design"
-      key="design"
-      to="/q/1/page/3/design"
-    >
       <Tabs__SmallBadge
-        data-test="small-badge"
+        data-test="small-badge-codeCovTest"
       />
       Design
     </Tabs__Tab>

--- a/eq-author/src/components/EditorLayout/Tabs/index.js
+++ b/eq-author/src/components/EditorLayout/Tabs/index.js
@@ -98,6 +98,9 @@ export const UnwrappedTabs = props => {
               pageErrors > 0 ? (
                 <SmallBadge data-test="small-badge" />
               ) : null}
+              {key === "design" && pageErrors === 1 ? (
+                <SmallBadge data-test="small-badge-codeCovTest" />
+              ) : null}
               {children}
             </Component>
           );

--- a/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
+++ b/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
@@ -57,13 +57,13 @@ describe("Tabs", () => {
     });
   });
 
-  it("should provide the validation error dot for the design tab if design page has error", async () => {
-    const { getByTestId } = render(<UnwrappedTabs {...props} logic preview />);
+  // it("should provide the validation error dot for the design tab if design page has error", async () => {
+  //   const { getByTestId } = render(<UnwrappedTabs {...props} logic preview />);
 
-    await act(async () => {
-      await flushPromises();
-    });
+  //   await act(async () => {
+  //     await flushPromises();
+  //   });
 
-    expect(getByTestId("small-badge")).toBeTruthy();
-  });
+  //   expect(getByTestId("small-badge")).toBeTruthy();
+  // });
 });

--- a/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
+++ b/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { UnwrappedTabs, Tab, activeClassName } from "./";
-import { render, flushPromises, act } from "tests/utils/rtl";
+// import { render, flushPromises, act } from "tests/utils/rtl";
 
 describe("Tabs", () => {
   let props;

--- a/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
+++ b/eq-author/src/components/EditorLayout/Tabs/tabs.test.js
@@ -23,10 +23,10 @@ describe("Tabs", () => {
     };
   });
 
-  it("should render with design tab enabled by default", () => {
-    const wrapper = shallow(<UnwrappedTabs {...props} />);
-    expect(wrapper).toMatchSnapshot();
-  });
+  // it("should render with design tab enabled by default", () => {
+  //   const wrapper = shallow(<UnwrappedTabs {...props} />);
+  //   expect(wrapper).toMatchSnapshot();
+  // });
 
   it("should render link to section if params are for a section", () => {
     delete props.match.params.pageId;


### PR DESCRIPTION
### What is the context of this PR?

Simple changes to tabs file to see the effect of codecov

In my first commit (coverage test) I've removed a test that tests for a baisc render - Codecov reports GREEN.
This test appears irrelevant to codecov 

In commit no. 5 (woops - linter - shows importance of) we see the linter spring nicelyinto action as I forgot to remove unused definitions
More importantly I've removed a test that hits both if statements in the tabs file.....
_YET - Codecov passes this pull request at this stage - Expected to fail_ 
Are you guys seeing the same???

Unless I've missed something, this is showing Codecov as being naughty!

Other commits were just experimenting with codecov.yaml settings to see if I could get the first commit to trigger RED

### How to review 

N/A