### PR TITLE
Add warning error for empty right expression

### DIFF
--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
@@ -26,8 +26,6 @@ const MultipleChoiceAnswerOptions = styled.div`
   flex-flow: row wrap;
   display: flex;
   width: 100%;
-  /* margin-top: 0.75em; */
-  /* margin-bottom: 1em; */
   margin-top: 1em;
   margin-bottom: 0.5em;
   padding: 0.5em;

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
@@ -23,11 +23,13 @@ const answerConditions = {
 
 const MultipleChoiceAnswerOptions = styled.div`
   align-items: center;
-  display: inline-flex;
   flex-flow: row wrap;
+  display: flex;
   width: 100%;
-  margin-top: 0.75em;
-  margin-bottom: 1em;
+  /* margin-top: 0.75em; */
+  /* margin-bottom: 1em; */
+  margin-top: 1em;
+  margin-bottom: 0.5em;
   padding: 0.5em;
   border-radius: 4px;
   border: 2px solid ${colors.lighterGrey};

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/NumberAnswerSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/NumberAnswerSelector.js
@@ -34,6 +34,8 @@ const NumberAnswerRoutingSelector = styled.div`
   align-items: center;
   border: 1px solid ${colors.lightGrey};
   margin: 1em 0;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
   border-radius: ${radius};
   padding: 1em;
 `;

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/__snapshots__/index.test.js.snap
@@ -94,26 +94,30 @@ exports[`BinaryExpressionEditor should render consistently 1`] = `
               key="answer"
               timeout={200}
             >
-              <MultipleChoiceAnswerOptionsSelector
-                expression={
-                  Object {
-                    "condition": "Equal",
-                    "id": "1",
-                    "left": Object {
-                      "id": "2",
-                      "type": "Radio",
-                    },
-                    "right": null,
-                    "validationErrorInfo": Object {
-                      "errors": Array [],
-                      "id": "6dd",
-                      "totalCount": 0,
-                    },
+              <BinaryExpressionEditor__ErrorWrapper
+                hasError={false}
+              >
+                <MultipleChoiceAnswerOptionsSelector
+                  expression={
+                    Object {
+                      "condition": "Equal",
+                      "id": "1",
+                      "left": Object {
+                        "id": "2",
+                        "type": "Radio",
+                      },
+                      "right": null,
+                      "validationErrorInfo": Object {
+                        "errors": Array [],
+                        "id": "6dd",
+                        "totalCount": 0,
+                      },
+                    }
                   }
-                }
-                onConditionChange={[Function]}
-                onRightChange={[Function]}
-              />
+                  onConditionChange={[Function]}
+                  onRightChange={[Function]}
+                />
+              </BinaryExpressionEditor__ErrorWrapper>
             </Transition__RoutingComponentTransition>
           </TransitionGroup>
         </BinaryExpressionEditor__StyledTransition>

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.js
@@ -26,7 +26,8 @@ import {
 
 import {
   ERR_ANSWER_NOT_SELECTED,
-  ERR_NO_RIGHT_VALUE,
+  ERR_NO_RIGHT_VALUE_NUMBER,
+  ERR_NO_RIGHT_VALUE_OPTION,
 } from "constants/validationMessages";
 
 import IconText from "components/IconText";
@@ -155,7 +156,6 @@ const StyledTransition = styled.div`
 const PropertiesError = styled(IconText)`
   color: ${colors.red};
   justify-content: flex-end;
-  padding-top: 0.5em;
   width: ${props => (props.right ? "100%" : "80%")};
 `;
 
@@ -226,10 +226,34 @@ const ERROR_SITUATIONS = {
         some(
           { errorCode: "ERR_NO_RIGHT_VALUE" },
           props.expression.validationErrorInfo.errors
-        ),
+        ) && props.expression.left.type === NUMBER,
       message: () => (
         <PropertiesError right icon={WarningIcon}>
-          {ERR_NO_RIGHT_VALUE}
+          {ERR_NO_RIGHT_VALUE_NUMBER}
+        </PropertiesError>
+      ),
+    },
+    {
+      condition: props =>
+        some(
+          { errorCode: "ERR_NO_RIGHT_VALUE" },
+          props.expression.validationErrorInfo.errors
+        ) && props.expression.left.type === CHECKBOX,
+      message: () => (
+        <PropertiesError right icon={WarningIcon}>
+          {ERR_NO_RIGHT_VALUE_OPTION}
+        </PropertiesError>
+      ),
+    },
+    {
+      condition: props =>
+        some(
+          { errorCode: "ERR_NO_RIGHT_VALUE" },
+          props.expression.validationErrorInfo.errors
+        ) && props.expression.left.type === RADIO,
+      message: () => (
+        <PropertiesError right icon={WarningIcon}>
+          {ERR_NO_RIGHT_VALUE_OPTION}
         </PropertiesError>
       ),
     },

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.js
@@ -226,7 +226,11 @@ const ERROR_SITUATIONS = {
         some(
           { errorCode: "ERR_NO_RIGHT_VALUE" },
           props.expression.validationErrorInfo.errors
-        ) && props.expression.left.type === NUMBER,
+        ) &&
+        (props.expression.left.type === NUMBER ||
+          props.expression.left.type === CURRENCY ||
+          props.expression.left.type === PERCENTAGE ||
+          props.expression.left.type === UNIT),
       message: () => (
         <PropertiesError right icon={WarningIcon}>
           {ERR_NO_RIGHT_VALUE_NUMBER}
@@ -339,6 +343,7 @@ export class UnwrappedBinaryExpressionEditor extends React.Component {
 
   renderEditor() {
     const { LEFT_ERRORS, RIGHT_ERRORS } = ERROR_SITUATIONS;
+
     if (
       this.props.expression.left.reason === DEFAULT_ROUTING ||
       this.props.expression.left.reason === DEFAULT_SKIP_CONDITION ||

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
@@ -3,6 +3,14 @@ import { shallow } from "enzyme";
 import { render, flushPromises, act } from "tests/utils/rtl";
 
 import { RADIO, CURRENCY, NUMBER, PERCENTAGE } from "constants/answer-types";
+
+import { colors } from "constants/theme";
+
+import {
+  ERR_ANSWER_NOT_SELECTED,
+  ERR_NO_RIGHT_VALUE,
+} from "constants/validationMessages";
+
 import {
   NO_ROUTABLE_ANSWER_ON_PAGE,
   SELECTED_ANSWER_DELETED,
@@ -227,7 +235,7 @@ describe("BinaryExpressionEditor", () => {
     expect(options).toBeFalsy();
   });
 
-  it("should provide validation message when errors are present", async () => {
+  it("should provide validation message for the left side when errors are present", async () => {
     defaultProps.expression.validationErrorInfo.totalCount = 1;
     defaultProps.expression.validationErrorInfo.errors[0] = {
       errorCode: "ERR_ANSWER_NOT_SELECTED",
@@ -236,12 +244,33 @@ describe("BinaryExpressionEditor", () => {
       type: "expressions",
     };
 
-    const wrapper = shallow(<BinaryExpressionEditor {...defaultProps} />);
+    const { getByTestId, getByText } = render(
+      <BinaryExpressionEditor {...defaultProps} />
+    );
 
-    expect(
-      wrapper
-        .find("BinaryExpressionEditor__PropertiesError")
-        .contains("Answer required")
-    ).toBeTruthy();
+    expect(getByText(ERR_ANSWER_NOT_SELECTED)).toBeTruthy();
+    expect(getByTestId("routing-answer-picker")).toHaveStyleRule(
+      "border-color",
+      `${colors.red}`
+    );
+  });
+
+  it("should provide validation message for the right side when errors are present", async () => {
+    defaultProps.expression.validationErrorInfo.totalCount = 1;
+    defaultProps.expression.validationErrorInfo.errors[0] = {
+      errorCode: "ERR_NO_RIGHT_VALUE",
+      field: "right",
+      id: "expression-routing-1-right",
+      type: "expressions",
+    };
+
+    const { getByText } = render(<BinaryExpressionEditor {...defaultProps} />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(getByText(ERR_NO_RIGHT_VALUE)).toBeTruthy();
+    expect(getByText(ERR_NO_RIGHT_VALUE)).toHaveStyleRule("width", "100%");
   });
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
@@ -8,7 +8,8 @@ import { colors } from "constants/theme";
 
 import {
   ERR_ANSWER_NOT_SELECTED,
-  ERR_NO_RIGHT_VALUE,
+  ERR_NO_RIGHT_VALUE_NUMBER,
+  ERR_NO_RIGHT_VALUE_OPTION,
 } from "constants/validationMessages";
 
 import {
@@ -255,7 +256,7 @@ describe("BinaryExpressionEditor", () => {
     );
   });
 
-  it("should provide validation message for the right side when errors are present", async () => {
+  it("should provide validation message for the right side of Radio answers when errors are present", async () => {
     defaultProps.expression.validationErrorInfo.totalCount = 1;
     defaultProps.expression.validationErrorInfo.errors[0] = {
       errorCode: "ERR_NO_RIGHT_VALUE",
@@ -270,7 +271,33 @@ describe("BinaryExpressionEditor", () => {
       await flushPromises();
     });
 
-    expect(getByText(ERR_NO_RIGHT_VALUE)).toBeTruthy();
-    expect(getByText(ERR_NO_RIGHT_VALUE)).toHaveStyleRule("width", "100%");
+    expect(getByText(ERR_NO_RIGHT_VALUE_OPTION)).toBeTruthy();
+    expect(getByText(ERR_NO_RIGHT_VALUE_OPTION)).toHaveStyleRule(
+      "width",
+      "100%"
+    );
+  });
+
+  it("should provide validation message for the right side of Number answers when errors are present", async () => {
+    defaultProps.expression.left.type = NUMBER;
+    defaultProps.expression.validationErrorInfo.totalCount = 1;
+    defaultProps.expression.validationErrorInfo.errors[0] = {
+      errorCode: "ERR_NO_RIGHT_VALUE",
+      field: "right",
+      id: "expression-routing-1-right",
+      type: "expressions",
+    };
+
+    const { getByText } = render(<BinaryExpressionEditor {...defaultProps} />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(getByText(ERR_NO_RIGHT_VALUE_NUMBER)).toBeTruthy();
+    expect(getByText(ERR_NO_RIGHT_VALUE_NUMBER)).toHaveStyleRule(
+      "width",
+      "100%"
+    );
   });
 });

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -7,4 +7,6 @@ export default {
 };
 
 export const ERR_ANSWER_NOT_SELECTED = "Answer required";
-export const ERR_NO_RIGHT_VALUE = "Right value invalid";
+// export const ERR_NO_RIGHT_VALUE = "Right value invalid";
+export const ERR_NO_RIGHT_VALUE_NUMBER = "Enter a number";
+export const ERR_NO_RIGHT_VALUE_OPTION = "Select at least one option";


### PR DESCRIPTION
### What is the context of this PR?

Adds warning error and message to number, checkbox and radio answers when the right hand side is empty

### How to review 

1. Create questionnaire
2. Add three questions of types number, checkbox and radio
3. Go to each logic tab for each and add routing and skip condition using each answer type
4. Red border should surround the answer picker with either Enter a number (number) or Select at least one option
(radio, checkbox)
