### PR TITLE
Add correct duration error message

### DIFF
--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.js
@@ -19,6 +19,7 @@ import DurationPreview from "./DurationPreview";
 import {
   EARLIEST_BEFORE_LATEST_DATE,
   MAX_GREATER_THAN_MIN,
+  DURATION_ERROR_MESSAGE,
   MIN_INCLUSIVE_TEXT,
   MAX_INCLUSIVE_TEXT,
 } from "constants/validationMessages";
@@ -277,7 +278,7 @@ class AnswerValidation extends React.PureComponent {
 
       const durationError = this.renderPropertyError(
         validationErrors.dateRange.duration.length > 1,
-        MAX_GREATER_THAN_MIN,
+        DURATION_ERROR_MESSAGE,
         "duration-error"
       );
 

--- a/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
+++ b/eq-author/src/App/page/Design/Validation/AnswerValidation.test.js
@@ -21,6 +21,7 @@ import AnswerValidation, {
 import {
   MIN_INCLUSIVE_TEXT,
   MAX_INCLUSIVE_TEXT,
+  DURATION_ERROR_MESSAGE,
   MAX_GREATER_THAN_MIN,
   EARLIEST_BEFORE_LATEST_DATE,
 } from "constants/validationMessages";
@@ -343,7 +344,7 @@ describe("AnswerValidation", () => {
 
       const { getByText } = rtlRender(<AnswerValidation {...props} />);
 
-      expect(getByText(MAX_GREATER_THAN_MIN)).toBeTruthy();
+      expect(getByText(DURATION_ERROR_MESSAGE)).toBeTruthy();
     });
   });
 });

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
@@ -72,10 +72,6 @@ describe("BasicAnswer", () => {
     expect(buildLabelError(MISSING_LABEL, 8, 7)).toEqual("Label error");
   });
 
-  it("shows default label error if missing buildLabelError mainString props", () => {
-    expect(buildLabelError(MISSING_LABEL, 8, 7)).toEqual("Label error");
-  });
-
   describe("event handling behaviour", () => {
     let wrapper;
 


### PR DESCRIPTION
### What is the context of this PR?
Error message for duration validation was using max/min value instead of duration.
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2020-07-15 at 11 56 27](https://user-images.githubusercontent.com/22731314/87537320-57df5380-c692-11ea-8f40-fc44dbebd02b.png)  | ![Screenshot 2020-07-15 at 11 56 11](https://user-images.githubusercontent.com/22731314/87537378-67f73300-c692-11ea-8f3a-fc12f407d340.png)  |


### How to review 

- Create questionnaire
- Add date range answer
- Enter a larger value in the min duration field
- Enter a small value in the max duration field
- Check error message matches above screenshot
- Change min to be lower and check it goes away