### PR TITLE
Update routing to not remove destination

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -208,15 +208,11 @@ const Resolvers = {
       );
       return questionnareComments.comments[id] || [];
     },
-    getAvailableAnswers: (
-      root,
-      { input: { pageId, includeSelf = true } },
-      ctx
-    ) =>
+    getAvailableAnswers: (root, { input }, ctx) =>
       getPreviousAnswersForPage(
         ctx.questionnaire,
-        pageId,
-        includeSelf,
+        input.pageId,
+        input.includeSelf,
         ROUTING_ANSWER_TYPES
       ),
   },

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -65,7 +65,7 @@ const updateMetadata = require("../../src/businessLogic/updateMetadata");
 const getPreviousAnswersForPage = require("../../src/businessLogic/getPreviousAnswersForPage");
 const getPreviousAnswersForSection = require("../../src/businessLogic/getPreviousAnswersForSection");
 const createOption = require("../../src/businessLogic/createOption");
-const onPageDeleted = require("../../src/businessLogic/onPageDeleted");
+const onSectionDeleted = require("../../src/businessLogic/onSectionDeleted");
 const addPrefix = require("../../utils/addPrefix");
 const { createQuestionPage } = require("./pages/questionPage");
 
@@ -208,13 +208,17 @@ const Resolvers = {
       );
       return questionnareComments.comments[id] || [];
     },
-    getAvailableAnswers: (root, { input: { pageId, includeSelf = true } }, ctx) => 
-    getPreviousAnswersForPage(
-      ctx.questionnaire,
-      pageId,
-      includeSelf,
-      ROUTING_ANSWER_TYPES
-    ),
+    getAvailableAnswers: (
+      root,
+      { input: { pageId, includeSelf = true } },
+      ctx
+    ) =>
+      getPreviousAnswersForPage(
+        ctx.questionnaire,
+        pageId,
+        includeSelf,
+        ROUTING_ANSWER_TYPES
+      ),
   },
 
   Subscription: {
@@ -353,9 +357,7 @@ const Resolvers = {
     deleteSection: createMutation((root, { input }, ctx) => {
       const section = find(ctx.questionnaire.sections, { id: input.id });
       const removedSection = first(remove(ctx.questionnaire.sections, section));
-      removedSection.pages.forEach(page => {
-        onPageDeleted(ctx, removedSection, page);
-      });
+      onSectionDeleted(ctx, removedSection);
       return ctx.questionnaire;
     }),
     moveSection: createMutation((_, { input }, ctx) => {

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -822,7 +822,6 @@ describe("routing", () => {
       await deleteSection(ctx, fourthSection.id);
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
-      // Only rule to exist after deletion of third page
       expect(firstPage.routing.else.sectionId).toBeNull();
     });
   });
@@ -918,7 +917,6 @@ describe("routing", () => {
       await deletePage(ctx, fourthPage.id);
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
-      // Only rule to exist after deletion of third page
       expect(firstPage.routing.else.pageId).toBeNull();
     });
   });

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -1,6 +1,5 @@
 const { buildContext } = require("../../tests/utils/contextBuilder");
 const { RADIO, NUMBER } = require("../../constants/answerTypes");
-const { NEXT_PAGE } = require("../../constants/logicalDestinations");
 
 const executeQuery = require("../../tests/utils/executeQuery");
 const {

--- a/eq-author-api/schema/tests/routing.test.js
+++ b/eq-author-api/schema/tests/routing.test.js
@@ -805,17 +805,12 @@ describe("routing", () => {
       await deleteSection(ctx, thirdSection.id);
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
-      // Only rule to exist after deletion of third page
-      expect(firstPage.routing.rules).toHaveLength(1);
-      expect(firstPage.routing.rules[0].destination.sectionId).toEqual(
-        secondSection.id
-      );
+      expect(firstPage.routing.rules).toHaveLength(2);
+      expect(firstPage.routing.rules[1].destination.sectionId).toBeNull();
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
       await deleteSection(ctx, secondSection.id);
-
-      // No routing after deletion of second page
-      expect(firstPage.routing).toBeNull();
+      expect(firstPage.routing.rules[0].destination.sectionId).toBeNull();
     });
 
     it("should change else destination if deleted section is the else destination", async () => {
@@ -829,8 +824,7 @@ describe("routing", () => {
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
       // Only rule to exist after deletion of third page
-      expect(firstPage.routing.else.pageId).toBeNull();
-      expect(firstPage.routing.else.logical).toEqual(NEXT_PAGE);
+      expect(firstPage.routing.else.sectionId).toBeNull();
     });
   });
 
@@ -907,17 +901,12 @@ describe("routing", () => {
       await deletePage(ctx, thirdPage.id);
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
-      // Only rule to exist after deletion of third page
-      expect(firstPage.routing.rules).toHaveLength(1);
-      expect(firstPage.routing.rules[0].destination.pageId).toEqual(
-        secondPage.id
-      );
+      expect(firstPage.routing.rules).toHaveLength(2);
+      expect(firstPage.routing.rules[1].destination.pageId).toBeNull();
       firstPage = ctx.questionnaire.sections[0].pages[0];
 
       await deletePage(ctx, secondPage.id);
-
-      // No routing after deletion of second page
-      expect(firstPage.routing).toBeNull();
+      expect(firstPage.routing.rules[0].destination.pageId).toBeNull();
     });
 
     it("should change else destination if deleted page is the else destination", async () => {
@@ -932,7 +921,6 @@ describe("routing", () => {
 
       // Only rule to exist after deletion of third page
       expect(firstPage.routing.else.pageId).toBeNull();
-      expect(firstPage.routing.else.logical).toEqual(NEXT_PAGE);
     });
   });
 });

--- a/eq-author-api/src/businessLogic/onPageDeleted.js
+++ b/eq-author-api/src/businessLogic/onPageDeleted.js
@@ -21,7 +21,7 @@ const onPageDeleted = (ctx, section, removedPage) => {
     }
 
     page.routing.rules.map(rule => {
-      if (rule.destination.pageId == removedPage.id) {
+      if (rule.destination.pageId === removedPage.id) {
         rule.destination.pageId = null;
       }
     });

--- a/eq-author-api/src/businessLogic/onPageDeleted.js
+++ b/eq-author-api/src/businessLogic/onPageDeleted.js
@@ -1,5 +1,4 @@
 const { getPages } = require("../../schema/resolvers/utils");
-const { NEXT_PAGE } = require("../../constants/logicalDestinations");
 const onAnswerDeleted = require("../../src/businessLogic/onAnswerDeleted");
 
 const onPageDeleted = (ctx, section, removedPage) => {
@@ -17,27 +16,15 @@ const onPageDeleted = (ctx, section, removedPage) => {
     }
 
     const elseRoute = page.routing.else;
-    if (
-      elseRoute.pageId === removedPage.id ||
-      elseRoute.sectionId === section.id
-    ) {
-      elseRoute.sectionId = null;
+    if (elseRoute.pageId === removedPage.id) {
       elseRoute.pageId = null;
-      elseRoute.logical = NEXT_PAGE;
     }
 
-    const validRules = page.routing.rules.filter(
-      rule =>
-        rule.destination &&
-        rule.destination.pageId !== removedPage.id &&
-        rule.destination.sectionId !== section.id
-    );
-
-    if (validRules.length) {
-      page.routing.rules = validRules;
-    } else {
-      page.routing = null;
-    }
+    page.routing.rules.map(rule => {
+      if (rule.destination.pageId == removedPage.id) {
+        rule.destination.pageId = null;
+      }
+    });
   });
 };
 

--- a/eq-author-api/src/businessLogic/onSectionDeleted.js
+++ b/eq-author-api/src/businessLogic/onSectionDeleted.js
@@ -16,7 +16,7 @@ const onSectionDeleted = (ctx, removedSection) => {
     }
 
     page.routing.rules.map(rule => {
-      if (rule.destination.sectionId == removedSection.id) {
+      if (rule.destination.sectionId === removedSection.id) {
         rule.destination.sectionId = null;
       }
     });

--- a/eq-author-api/src/businessLogic/onSectionDeleted.js
+++ b/eq-author-api/src/businessLogic/onSectionDeleted.js
@@ -1,0 +1,26 @@
+const onPageDeleted = require("../../src/businessLogic/onPageDeleted");
+const { getPages } = require("../../schema/resolvers/utils");
+
+const onSectionDeleted = (ctx, removedSection) => {
+  removedSection.pages.forEach(page => {
+    onPageDeleted(ctx, removedSection, page);
+  });
+  const allPages = getPages(ctx);
+  allPages.forEach(page => {
+    if (!page.routing) {
+      return;
+    }
+    const elseRoute = page.routing.else;
+    if (elseRoute.sectionId === removedSection.id) {
+      elseRoute.sectionId = null;
+    }
+
+    page.routing.rules.map(rule => {
+      if (rule.destination.sectionId == removedSection.id) {
+        rule.destination.sectionId = null;
+      }
+    });
+  });
+};
+
+module.exports = onSectionDeleted;

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
@@ -47,6 +47,9 @@ const getSelectedDisplayName = (
   loading,
   availableRoutingDestinations
 ) => {
+  if (!selected.page && !selected.section && !selected.logical) {
+    return "Select a destination";
+  }
   if (selected.logical) {
     return getLogicalDisplayName(
       selected.logical,


### PR DESCRIPTION
Update to not remove the destination when a page or section is deleted.

To Test,
Add a second question and route to it from the first question.
Delete second question and check first question routing shows select a destination.

Repeat by adding a second section, routing to it and deleting it.