### PR TITLE
remove right side when answer deleted

### DIFF
--- a/eq-author-api/src/businessLogic/onAnswerDeleted.js
+++ b/eq-author-api/src/businessLogic/onAnswerDeleted.js
@@ -18,6 +18,7 @@ const removeAnswerFromExpressions = (ctx, answer) => {
     expression.left.answerId = undefined;
     expression.left.type = NULL;
     expression.left.nullReason = SELECTED_ANSWER_DELETED;
+    delete expression.right;
   }, expressions);
 };
 


### PR DESCRIPTION
### What is the context of this PR?

Deleting an answer that is used in routing, should remove any right hand side errors that were in that routing rule

### How to review 

Create a new questionnaire
Create a question with a numeric, checkbox or radio answer
Create a 2nd Question with and add a routing rule using the answer as a condition
DO NOT enter any details for the right side (else) rule - IE there should be a right hand side error!
Delete the answer
Go back to the routing tab
The errors badges show 2 (left nav) and 1 (routing logic tab)