### PR TITLE
Fix adding qcode to dates

### DIFF
--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -67,6 +67,7 @@ const buildOptionRow = (option, questionType, secondary = false) => {
       label={label}
       qCode={qCode}
       secondary={secondary}
+      properties={option.properties}
     />
   );
 };


### PR DESCRIPTION
Fixes date qcodes not saving if they are the second + question on a page

To test

- create questionnaire
- make a question page with two date answers
- make sure both qcodes save