### PR TITLE
Err msg now displays correctly on smaller screens

### DIFF
--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/index.test.js
@@ -158,7 +158,7 @@ describe("BinaryExpressionEditor", () => {
 
     expect(
       screen.getByText(
-        "Select an answer that is not later on, in the questionnaire"
+        "Select an answer that is not later on in the questionnaire"
       )
     ).toBeTruthy();
   });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/index.js
@@ -28,7 +28,6 @@ import { destinationErrors } from "constants/validationMessages";
 const RepositionedValidationError = styled(ValidationError)`
   justify-content: unset;
   padding-left: 36.5%;
-  line-height: 0;
   margin-top: 0;
 `;
 


### PR DESCRIPTION
### What is the context of this PR?

Jordan noticed that the error message for deleting a page used as the destination in a routing rule (and related error messages) were styled weirdly. This PR fixes that.

### How to review 

Set up a routing rule that goes to an absolute destination and then delete the page used as the destination. An error message should pop up. Reduce the screen size and the message should break onto two lines, instead of being overlaped which is what it was before.

* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
