### PR TITLE
added Questionaire to AnswerSelector return

### DIFF
--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -306,6 +306,13 @@ UnwrappedAnswerSelector.fragments = {
       section {
         id
         displayName
+        questionnaire {
+          id
+          metadata {
+            id
+            displayName
+          }
+        }
       }
       summaryAnswers {
         id


### PR DESCRIPTION
### What is the context of this PR?
When returning to a calcsum page - the piped metadata in the title was showing as deleted
this was because the props.page.section.questionnaire.metaData was missing from the props for the Richtexteditor so it was defaulting to "Deleted metadata"


### How to review 

1. Set up calculated summary page
2. Pipe metadata into the title
3. Swap to another section and back
4. Metadata to still be there
5. View the survey and make sure the correct metadat is still appearing in the calc sum title