### PR TITLE
Enabled toggle labels

### DIFF
--- a/eq-author/src/App/page/Design/Validation/ValidationView.js
+++ b/eq-author/src/App/page/Design/Validation/ValidationView.js
@@ -6,7 +6,7 @@ import { uniqueId } from "lodash";
 
 import FadeTransition from "components/transitions/FadeTransition";
 import ToggleSwitch from "components/buttons/ToggleSwitch";
-import { Label, Field } from "components/Forms";
+import { Field } from "components/Forms";
 
 const InlineField = styled(Field)`
   display: flex;

--- a/eq-author/src/App/page/Design/Validation/ValidationView.js
+++ b/eq-author/src/App/page/Design/Validation/ValidationView.js
@@ -42,10 +42,8 @@ class ValidationView extends Component {
             name={id}
             onChange={onToggleChange}
             checked={enabled}
+            hideLabels={false}
           />
-          <Label inline htmlFor={id}>
-            On
-          </Label>
         </InlineField>
 
         <TransitionGroup>

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/ValidationView.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/ValidationView.test.js.snap
@@ -7,18 +7,11 @@ exports[`ValidationView should render children when enabled 1`] = `
   >
     <ToggleSwitch
       checked={true}
-      hideLabels={true}
+      hideLabels={false}
       id="ValidationView1"
       name="ValidationView1"
       onChange={[MockFunction]}
     />
-    <Label
-      bold={true}
-      htmlFor="ValidationView1"
-      inline={true}
-    >
-      On
-    </Label>
   </ValidationView__InlineField>
   <TransitionGroup
     childFactory={[Function]}
@@ -48,18 +41,11 @@ exports[`ValidationView should render disabled messaged when disabled 1`] = `
   >
     <ToggleSwitch
       checked={false}
-      hideLabels={true}
+      hideLabels={false}
       id="ValidationView2"
       name="ValidationView2"
       onChange={[MockFunction]}
     />
-    <Label
-      bold={true}
-      htmlFor="ValidationView2"
-      inline={true}
-    >
-      On
-    </Label>
   </ValidationView__InlineField>
   <TransitionGroup
     childFactory={[Function]}


### PR DESCRIPTION
### What is the context of this PR?

When changing the properties of a answer, e.g. max or min value for number answers, regardless of if that property was enabled or disabled the toggle would still show "on". 

This PR enabled the standard toggle labels which fixes this.

### How to review 

Take a look at the various modals for changing the properties and make sure it's all OK.

* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
