### PR TITLE
Added createdAt to duplicateQuestionnaire call

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -293,6 +293,7 @@ const Resolvers = {
         shortTitle: addPrefix(questionnaire.shortTitle),
         id: uuidv4(),
         createdBy: ctx.user.id,
+        createdAt: new Date(),
         editors: [],
         publishStatus: UNPUBLISHED,
         surveyVersion: 1,

--- a/eq-author-api/schema/tests/duplication.test.js
+++ b/eq-author-api/schema/tests/duplication.test.js
@@ -185,6 +185,7 @@ describe("Duplication", () => {
         "shortTitle",
         "displayName",
         "createdBy",
+        "createdAt",
       ];
       expect(omit(questionnaireCopy, ignoredFields)).toEqual(
         omit(queriedQuestionnaire, ignoredFields)
@@ -202,6 +203,12 @@ describe("Duplication", () => {
       expect(questionnaireCopy.shortTitle).toEqual(
         `Copy of ${queriedQuestionnaire.shortTitle}`
       );
+    });
+
+    it("should have createdAt greater than original", () => {
+      const copyDate = Date.parse(questionnaireCopy.createdAt);
+      const queriedDate = Date.parse(queriedQuestionnaire.createdAt);
+      expect(copyDate).toBeGreaterThan(queriedDate);
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?

> When you duplicate a questionnaire the Created date used the original date, the call to duplicate now passes in the current date in the same way as when creating a new questionnaire so uses the current date.
>
> 
### How to review 

> Add to the list below as appropriate, including screenshots when necessary

* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Copy an existing questionnaire and check the Created date is the current date.

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Trello card for this task into the next stage of the process
