### PR TITLE
Remove default 0

### DIFF
--- a/eq-author/src/components/Forms/Number/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/Forms/Number/__snapshots__/index.test.js.snap
@@ -35,7 +35,7 @@ exports[`Number should render correctly 1`] = `
     aria-labelledby="unit-number"
     aria-live="assertive"
     data-test="number-input"
-    default={0}
+    default={null}
     id="number"
     max={10}
     min={-10}
@@ -45,7 +45,7 @@ exports[`Number should render correctly 1`] = `
     role="alert"
     step={1}
     type="number"
-    value={0}
+    value={null}
   />
 </Number__StyledDiv>
 `;

--- a/eq-author/src/components/Forms/Number/index.js
+++ b/eq-author/src/components/Forms/Number/index.js
@@ -68,7 +68,6 @@ const Number = props => {
       isNaN(enteredValue) || Object.is(enteredValue, -0)
         ? props.default
         : enteredValue;
-
     onChange({ name: name || id, value: newValue });
   };
 
@@ -122,7 +121,7 @@ const Number = props => {
 Number.defaultProps = {
   min: 0,
   step: 1,
-  default: 0,
+  default: null,
   "data-test": "number-input",
 };
 

--- a/eq-author/src/components/Forms/Number/index.test.js
+++ b/eq-author/src/components/Forms/Number/index.test.js
@@ -7,7 +7,7 @@ import { CENTIMETRES } from "constants/unit-types";
 
 import Number from "./";
 
-const defaultValue = 0;
+const defaultValue = null;
 
 describe("Number", () => {
   jest.useFakeTimers();
@@ -65,7 +65,7 @@ describe("Number", () => {
     jest.runAllTimers();
     expect(handleChange).toHaveBeenCalledWith({
       name: "numberName",
-      value: 0,
+      value: null,
     });
   });
 
@@ -119,7 +119,7 @@ describe("Number", () => {
       numberWithMinMax.find("[data-test='number-input']").simulate("blur");
       expect(handleChange).toBeCalledWith({
         name: "number",
-        value: 0,
+        value: null,
       });
     });
 


### PR DESCRIPTION


### What is the context of this PR?

Remove default 0 from number validation answer types
### How to review 

1. Create questionnaire
2. Add number answer
3. Add min/max value
4. Hopefully 0 doesn't pop up when you don't enter any values