### PR TITLE
Remove 0 from date range duration

### DIFF
--- a/eq-author-api/schema/tests/validation.test.js
+++ b/eq-author-api/schema/tests/validation.test.js
@@ -402,7 +402,7 @@ describe("validation", () => {
           id: earliestId,
           enabled: false,
           offset: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
           relativePosition: "Before",
@@ -411,7 +411,7 @@ describe("validation", () => {
         latestDate: {
           id: latestId,
           offset: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
           relativePosition: "After",
@@ -686,7 +686,7 @@ describe("validation", () => {
           id: earliestId,
           enabled: false,
           offset: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
           relativePosition: "Before",
@@ -695,7 +695,7 @@ describe("validation", () => {
         latestDate: {
           id: latestId,
           offset: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
           relativePosition: "After",
@@ -719,7 +719,7 @@ describe("validation", () => {
           id: minimumId,
           enabled: false,
           duration: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
         },
@@ -727,7 +727,7 @@ describe("validation", () => {
           id: maximumId,
           enabled: false,
           duration: {
-            value: 0,
+            value: null,
             unit: "Days",
           },
         },

--- a/eq-author-api/utils/defaultAnswerValidations.js
+++ b/eq-author-api/utils/defaultAnswerValidations.js
@@ -21,7 +21,7 @@ const validationRuleMap = {
 };
 
 const duration = {
-  value: 0,
+  value: null,
   unit: "Days",
 };
 

--- a/eq-author/src/App/page/Design/Validation/DurationPreview.js
+++ b/eq-author/src/App/page/Design/Validation/DurationPreview.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const DurationPreview = ({ duration: { unit, value } }) => {
-  if (value === 0) {
+  if (!value) {
     return;
   }
   return (


### PR DESCRIPTION
### What is the context of this PR?

Remove 0 from date range durations

### How to review 

1. Create questionnaire
2. Add date range
3. Add min/max duration
4. Add earliest/latest date
4. 0 shouldn't default

**EDIT**
Turns out this completes EAR-773 as well

Might have to sit on this whilst we get the ticket to add validation to the value picker

Runner breaks if you don't default to 0