### PR TITLE
Fix for question title

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { propType } from "graphql-anywhere";
 import styled from "styled-components";
-import { get, flowRight, some } from "lodash";
+import { get, flowRight, some, filter } from "lodash";
 import { TransitionGroup } from "react-transition-group";
 
 import WrappingInput from "components/Forms/WrappingInput";
@@ -84,17 +84,20 @@ export class StatelessMetaEditor extends React.Component {
   description = React.createRef();
   guidance = React.createRef();
 
-  ErrorMsg = () => {
+  ErrorMsg = titleErrors => {
     for (let i = 0; i < ERROR_SITUATIONS.length; ++i) {
       const { condition, message } = ERROR_SITUATIONS[i];
-      if (condition(this.props.page.validationErrorInfo.errors)) {
-        return message(this.props.page.validationErrorInfo.errors);
+      if (condition(titleErrors)) {
+        return message(titleErrors);
       }
     }
   };
 
   render() {
-    const ErrorMsg = this.ErrorMsg();
+    const titleErrors = filter(this.props.page.validationErrorInfo.errors, {
+      field: "title",
+    });
+    const ErrorMsg = this.ErrorMsg(titleErrors);
     const {
       page,
       onChange,

--- a/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -440,7 +440,6 @@ exports[`MetaEditor should render 1`] = `
       }
     }
     disabled={false}
-    errorValidationMsg="Enter a question title"
     fetchAnswers={[MockFunction]}
     id="question-title"
     label="Question"


### PR DESCRIPTION
add a question and answer. Make sure title has correct error message and styling.
Currently, an error in an answer also adds error to question title.
