### PR TITLE
Move last question in section, does not automatically create a new question

### DIFF
--- a/eq-author/src/App/page/Design/withMovePage.js
+++ b/eq-author/src/App/page/Design/withMovePage.js
@@ -54,27 +54,10 @@ const getCachedSection = (client, id) =>
     fragment,
   });
 
-const handleMove = (
-  {
-    // history,
-    onAddQuestionPage,
-    // match: {
-    // params: { questionnaireId },
-    // },
-  },
-  section
-  // nextPage
-) => {
+const handleMove = ({ onAddQuestionPage }, section) => {
   if (section.pages.length === 0) {
     return onAddQuestionPage(section.id);
   }
-
-  // history.push(
-  // buildPagePath({
-  // questionnaireId,
-  // pageId: nextPage.id,
-  // })
-  // );
 };
 
 export const mapMutateToProps = ({ ownProps, mutate }) => ({
@@ -102,9 +85,7 @@ export const mapMutateToProps = ({ ownProps, mutate }) => ({
       .then(() => redirect(ownProps, { from, to }))
       .then(() => {
         const cachedSection = getCachedSection(client, page.section.id);
-        // const nextPage = getNextPage(cachedSection.pages, ownProps.page.id);
         handleMove(ownProps, cachedSection);
-        // handleMove(ownProps, cachedSection, nextPage)
       })
       .then(() => mutation);
   },

--- a/eq-author/src/App/page/Design/withMovePage.js
+++ b/eq-author/src/App/page/Design/withMovePage.js
@@ -3,7 +3,6 @@ import movePageMutation from "graphql/movePage.graphql";
 import fragment from "graphql/fragments/movePage.graphql";
 import { buildPagePath } from "utils/UrlUtils";
 import { remove } from "lodash";
-// import getNextPage from "utils/getNextOnDelete";
 
 export const createUpdater = ({ from, to }) => (proxy, result) => {
   result = result.data.movePage;
@@ -62,7 +61,6 @@ const handleMove = ({ onAddQuestionPage }, section) => {
 
 export const mapMutateToProps = ({ ownProps, mutate }) => ({
   onMovePage({ from, to }) {
-    const { client, page } = ownProps;
     const optimisticResponse = {
       movePage: {
         id: to.id,
@@ -84,7 +82,10 @@ export const mapMutateToProps = ({ ownProps, mutate }) => ({
     return mutation
       .then(() => redirect(ownProps, { from, to }))
       .then(() => {
-        const cachedSection = getCachedSection(client, page.section.id);
+        const cachedSection = getCachedSection(
+          ownProps.client,
+          ownProps.page.section.id
+        );
         handleMove(ownProps, cachedSection);
       })
       .then(() => mutation);

--- a/eq-author/src/App/page/Design/withMovePage.test.js
+++ b/eq-author/src/App/page/Design/withMovePage.test.js
@@ -10,18 +10,18 @@ describe("withMovePage", () => {
     mutate,
     args,
     result,
-    // movedPage,
-    beforeMoveSection;
-  // handleMove;
+    movedPage,
+    beforeMoveSection,
+    onAddQuestionPage;
 
   beforeEach(() => {
-    // movedPage = {
-    //   id: "2",
-    //   section: {
-    //     id: "section1Id",
-    //   },
-    //   position: 1,
-    // };
+    movedPage = {
+      id: "2",
+      section: {
+        id: "section1Id",
+      },
+      position: 0,
+    };
 
     match = {
       params: {
@@ -35,8 +35,10 @@ describe("withMovePage", () => {
 
     beforeMoveSection = {
       id: "section1Id",
-      pages: [{ id: "3", position: 1 }],
+      pages: [],
     };
+
+    onAddQuestionPage = jest.fn(() => Promise.resolve());
 
     ownProps = {
       history,
@@ -45,6 +47,7 @@ describe("withMovePage", () => {
       client: {
         readFragment: jest.fn().mockReturnValueOnce(beforeMoveSection),
       },
+      onAddQuestionPage,
     };
 
     args = {
@@ -105,17 +108,11 @@ describe("withMovePage", () => {
         return expect(props.onMovePage(args)).resolves.toBe(result);
       });
 
-      // it("should create a page if you move the last page in a section", () => {
-      //   // result.data.deletePage.pages = [];
-      //   // ownProps.client.readFragment = jest.fn().mockReturnValueOnce({
-      //   // ...beforeMoveSection,
-      //   // pages: [movedPage],
-      //   // });
-
-      //   return props.onMovePage(args).then(() => {
-      //     expect(handleMove).toHaveBeenCalledWith(ownProps, movedPage.section.id);
-      //   });
-      // });
+      it("should create a page if you move the last page in a section", () => {
+        return props.onMovePage(args).then(() => {
+          expect(onAddQuestionPage).toHaveBeenCalledWith("section1Id");
+        });
+      });
 
       it("should redirect if the section id has changed", () => {
         const expected = buildPagePath({

--- a/eq-author/src/App/page/Design/withMovePage.test.js
+++ b/eq-author/src/App/page/Design/withMovePage.test.js
@@ -10,18 +10,18 @@ describe("withMovePage", () => {
     mutate,
     args,
     result,
-    movedPage,
-    beforeMoveSection,
-    handleMove;
+    // movedPage,
+    beforeMoveSection;
+  // handleMove;
 
   beforeEach(() => {
-    movedPage = {
-      id: "2",
-      section: {
-        id: "section1Id",
-      },
-      position: 1,
-    };
+    // movedPage = {
+    //   id: "2",
+    //   section: {
+    //     id: "section1Id",
+    //   },
+    //   position: 1,
+    // };
 
     match = {
       params: {
@@ -78,7 +78,7 @@ describe("withMovePage", () => {
   describe("mapMutateToProps", () => {
     beforeEach(() => {
       mutate = jest.fn(() => Promise.resolve(result));
-      handleMove = jest.fn(() => Promise.resolve());
+      // handleMove = jest.fn(() => Promise.resolve());
       props = mapMutateToProps({ ownProps, mutate });
     });
 

--- a/eq-author/src/App/page/Design/withMovePage.test.js
+++ b/eq-author/src/App/page/Design/withMovePage.test.js
@@ -12,7 +12,7 @@ describe("withMovePage", () => {
     result,
     movedPage,
     beforeMoveSection,
-    onAddQuestionPage;
+    handleMove;
 
   beforeEach(() => {
     movedPage = {
@@ -73,12 +73,12 @@ describe("withMovePage", () => {
         },
       },
     };
-    onAddQuestionPage = jest.fn(() => Promise.resolve());
   });
 
   describe("mapMutateToProps", () => {
     beforeEach(() => {
       mutate = jest.fn(() => Promise.resolve(result));
+      handleMove = jest.fn(() => Promise.resolve());
       props = mapMutateToProps({ ownProps, mutate });
     });
 
@@ -105,17 +105,17 @@ describe("withMovePage", () => {
         return expect(props.onMovePage(args)).resolves.toBe(result);
       });
 
-      it("should create a page if you move the last page in a section", () => {
-        // result.data.deletePage.pages = [];
-        // ownProps.client.readFragment = jest.fn().mockReturnValueOnce({
-        // ...beforeMoveSection,
-        // pages: [movedPage],
-        // });
+      // it("should create a page if you move the last page in a section", () => {
+      //   // result.data.deletePage.pages = [];
+      //   // ownProps.client.readFragment = jest.fn().mockReturnValueOnce({
+      //   // ...beforeMoveSection,
+      //   // pages: [movedPage],
+      //   // });
 
-        return props.onMovePage(args).then(() => {
-          expect(onAddQuestionPage).toHaveBeenCalledWith(movedPage.section.id);
-        });
-      });
+      //   return props.onMovePage(args).then(() => {
+      //     expect(handleMove).toHaveBeenCalledWith(ownProps, movedPage.section.id);
+      //   });
+      // });
 
       it("should redirect if the section id has changed", () => {
         const expected = buildPagePath({

--- a/eq-author/src/App/page/Design/withMovePage.test.js
+++ b/eq-author/src/App/page/Design/withMovePage.test.js
@@ -10,19 +10,10 @@ describe("withMovePage", () => {
     mutate,
     args,
     result,
-    movedPage,
     beforeMoveSection,
     onAddQuestionPage;
 
   beforeEach(() => {
-    movedPage = {
-      id: "2",
-      section: {
-        id: "section1Id",
-      },
-      position: 0,
-    };
-
     match = {
       params: {
         questionnaireId: "1",

--- a/eq-author/src/App/page/Design/withMovePage.test.js
+++ b/eq-author/src/App/page/Design/withMovePage.test.js
@@ -72,7 +72,6 @@ describe("withMovePage", () => {
   describe("mapMutateToProps", () => {
     beforeEach(() => {
       mutate = jest.fn(() => Promise.resolve(result));
-      // handleMove = jest.fn(() => Promise.resolve());
       props = mapMutateToProps({ ownProps, mutate });
     });
 


### PR DESCRIPTION
### What is the context of this PR?

If a section has only one question and that question is moved to a previous section - No new question is automatically created. 
this creates issues as sections are expected to have at least one question

This ticket is to fix that

### How to review 

Create 2 sections, A and B
move the only question from section B to section A
Section B should automatically create a new question so that the section is not left without a question

Codacy quality review does not like my destructing statement on line 65 of withMovePage.js
any ideas?