### PR TITLE
Fix scrollPane after for main content

### DIFF
--- a/eq-author/src/components/EditorLayout/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/EditorLayout/__snapshots__/index.test.js.snap
@@ -11,7 +11,9 @@ exports[`Editor Layout should render 1`] = `
         preview={false}
       />
     </Component>
-    <StyledScrollPane>
+    <StyledScrollPane
+      scrollToTop={true}
+    >
       <EditorLayout__StyledGrid
         align="top"
         fillHeight={true}

--- a/eq-author/src/components/EditorLayout/index.js
+++ b/eq-author/src/components/EditorLayout/index.js
@@ -43,7 +43,7 @@ const PanelWrapper = styled.div`
 `;
 
 const StyledGrid = styled(Grid)`
-height: auto;
+  height: auto;
 `;
 
 const EditorLayout = ({
@@ -59,47 +59,47 @@ const EditorLayout = ({
   validationErrorInfo,
   ...otherProps
 }) => (
-    <Titled title={existingTitle => `${existingTitle} - ${title}`}>
-      <Container>
-        <Header title={title}>
-          <Tabs
-            design={design}
-            preview={preview}
-            logic={logic}
-            validationErrorInfo={validationErrorInfo}
-          />
-        </Header>
-        <ScrollPane>
-          <StyledGrid {...otherProps}>
-            <Column cols={singleColumnLayout ? 12 : 9} gutters={false}>
-              <Margin>
-                <MainCanvas maxWidth={mainCanvasMaxWidth}>{children}</MainCanvas>
-              </Margin>
-              {onAddQuestionPage && (
-                <Centered>
-                  <Button
-                    variant="tertiary"
-                    small
-                    onClick={onAddQuestionPage}
-                    data-test="btn-add-page"
-                  >
-                    <IconText icon={AddPage}>Add question page</IconText>
-                  </Button>
-                </Centered>
-              )}
-            </Column>
-            {singleColumnLayout ? null : (
-              <Column cols={3} gutters={false}>
-                <PanelWrapper data-test="right-hand-panel">
-                  {renderPanel ? renderPanel() : null}
-                </PanelWrapper>
-              </Column>
+  <Titled title={existingTitle => `${existingTitle} - ${title}`}>
+    <Container>
+      <Header title={title}>
+        <Tabs
+          design={design}
+          preview={preview}
+          logic={logic}
+          validationErrorInfo={validationErrorInfo}
+        />
+      </Header>
+      <ScrollPane scrollToTop>
+        <StyledGrid {...otherProps}>
+          <Column cols={singleColumnLayout ? 12 : 9} gutters={false}>
+            <Margin>
+              <MainCanvas maxWidth={mainCanvasMaxWidth}>{children}</MainCanvas>
+            </Margin>
+            {onAddQuestionPage && (
+              <Centered>
+                <Button
+                  variant="tertiary"
+                  small
+                  onClick={onAddQuestionPage}
+                  data-test="btn-add-page"
+                >
+                  <IconText icon={AddPage}>Add question page</IconText>
+                </Button>
+              </Centered>
             )}
-          </StyledGrid>
-        </ScrollPane>
-      </Container>
-    </Titled>
-  );
+          </Column>
+          {singleColumnLayout ? null : (
+            <Column cols={3} gutters={false}>
+              <PanelWrapper data-test="right-hand-panel">
+                {renderPanel ? renderPanel() : null}
+              </PanelWrapper>
+            </Column>
+          )}
+        </StyledGrid>
+      </ScrollPane>
+    </Container>
+  </Titled>
+);
 
 EditorLayout.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
### What is the context of this PR?

The scrollPane that was sending the panels back to the top was removed. Have re-added it to editor layout to replicate the same functionality.

### How to review

1. Create questionnaire
2. Add a bunch of sections and questions 
3. Switch pages
4. Left nav should stay and main and right should go to the top 

