### PR TITLE
Add scrollpane to storybook

### DIFF
--- a/eq-author/.storybook/main.js
+++ b/eq-author/.storybook/main.js
@@ -1,10 +1,8 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
     "@storybook/addon-links",
-    "@storybook/addon-essentials"
-  ]
-}
+    "@storybook/addon-essentials",
+    "@storybook/addon-controls",
+  ],
+};

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -2054,7 +2054,7 @@ exports[`QuestionnaireDesignPage should render 1`] = `
       }
     }
   >
-    <StyledScrollPane>
+    <ScrollPane>
       <GetContext
         title={[Function]}
       >
@@ -2221,7 +2221,7 @@ exports[`QuestionnaireDesignPage should render 1`] = `
           </Column>
         </Grid>
       </GetContext>
-    </StyledScrollPane>
+    </ScrollPane>
   </BaseLayout>
 </ContextProvider>
 `;

--- a/eq-author/src/components/EditorLayout/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/EditorLayout/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ exports[`Editor Layout should render 1`] = `
         preview={false}
       />
     </Component>
-    <StyledScrollPane
+    <ScrollPane
       scrollToTop={true}
     >
       <EditorLayout__StyledGrid
@@ -47,7 +47,7 @@ exports[`Editor Layout should render 1`] = `
           />
         </Column>
       </EditorLayout__StyledGrid>
-    </StyledScrollPane>
+    </ScrollPane>
   </EditorLayout__Container>
 </GetContext>
 `;

--- a/eq-author/src/components/ScrollPane/index.js
+++ b/eq-author/src/components/ScrollPane/index.js
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import { useHistory } from "react-router-dom";
 
-const ScrollPane = styled.div`
+const StyledScrollPane = styled.div`
   width: 100%;
   height: 100%;
   overflow-y: auto;
   position: relative;
 `;
 
-const StyledScrollPane = ({ children, scrollToTop = false, ...otherProps }) => {
+const ScrollPane = ({ children, scrollToTop = false, ...otherProps }) => {
   const history = useHistory();
   const ref = useRef();
 
@@ -24,16 +24,17 @@ const StyledScrollPane = ({ children, scrollToTop = false, ...otherProps }) => {
       });
     }
   });
+
   return (
-    <ScrollPane ref={ref} {...otherProps}>
+    <StyledScrollPane ref={ref} {...otherProps}>
       {children}
-    </ScrollPane>
+    </StyledScrollPane>
   );
 };
 
-StyledScrollPane.propTypes = {
+ScrollPane.propTypes = {
   children: PropTypes.node,
   scrollToTop: PropTypes.bool,
 };
 
-export default StyledScrollPane;
+export default ScrollPane;

--- a/eq-author/src/storybook/Components/ScrollPane.stories.mdx
+++ b/eq-author/src/storybook/Components/ScrollPane.stories.mdx
@@ -36,7 +36,7 @@ This resets the content to the top of the scroll pane after a user clicks a link
 
 <Canvas>
   <Story
-    name="Primary"
+    name="Default"
     args={{ children: exampleText }}
     parameters={{ actions: { disabled: true } }}
   >
@@ -48,6 +48,8 @@ This resets the content to the top of the scroll pane after a user clicks a link
 
 Use this pattern sparingly. We have tried to limit the amount of scroll panes present within the Author application.
 
+Having multiple scroll panes can frustrate and confuse users (Mouse wheel behaviour).
+
 Note: The black border surrounding the scroll pane is for example purposes only. It's used to highlight where the content begins scrolling.
 
 ## When not to use this component
@@ -57,14 +59,13 @@ Do not use this component if there are other ways to obscure content from the us
 Alternative methods to obscure content:
 
 - Truncation
-- Progressive disclosure
-- Sub-categorization
+- Accordions
+- [Progressive disclosure](https://www.interaction-design.org/literature/topics/progressive-disclosure#:~:text=Progressive%20disclosure%20is%20an%20interaction,overwhelmed%20by%20what%20they%20encounter.)
+- [Sub-categorization](https://baymard.com/blog/sub-sub-categories)
 
 ## How to use this component
 
-The scroll pane component needs to be wrapped in a container that has a limited height and width.
-
-This will enable scrolling within itself.
+The scroll pane component needs to be wrapped in a container that has a set height and width to enable scrolling within itself.
 
 ## Variants
 
@@ -78,7 +79,7 @@ A link has been added to show case the functionality.
 
 <Canvas>
   <Story
-    name="Secondary"
+    name="Scroll to top"
     args={{ children: exampleText, scrollToTop: true }}
     parameters={{ actions: { disabled: true } }}
   >
@@ -97,15 +98,7 @@ A link has been added to show case the functionality.
 
 ## Accessibility
 
-TODO
-
-## Research
-
-### Nielsen group advice on scrollbars (2005).
-
-https://www.nngroup.com/articles/scrolling-and-scrollbars/
-
-Key points from above link:
+### Nielsen Norman group advice on scrollbars (2005).
 
 - The additional action that scrolling requires can be difficult for users with motor skill impairments.
 - Low-literacy users can't easily reacquire their position in the text after it moves.
@@ -113,12 +106,23 @@ Key points from above link:
 
 ### Baymard UX research article (2014).
 
-https://baymard.com/blog/inline-scroll-areas
-
-Key points from above link:
-
 - Lack of overview
+  - Users need to memorize content that is out of view
 - Scroll hijacking
+  - Additional scroll panes can 'hijack' the main scroll pane
+  - When a user has reached the end of an inner scroll pane, the whole page begins scrolling again
+  - Frustrates users due to requirement of constant awareness of mouse cursor.
+  - Causes problems with touch devices
 - Invisible content & scroll bars
+   - Apple devices have scroll bars hidden by default, surprising users when content is scrollable
 - Overly sensitive scroll bars
+  - Some users click and drag the scroll panes which can causes them to miss certain options.
 - “Activation” of scroll areas
+  - Some users click nested scroll panes to "activate" them and instead end up clicking a hyperlink instead.
+
+## Research
+
+- [Nielsen Norman group (2005)](https://www.nngroup.com/articles/scrolling-and-scrollbars/)
+- [Baymard institute UX research article (2014)](https://baymard.com/blog/inline-scroll-areas)
+
+

--- a/eq-author/src/storybook/Components/ScrollPane.stories.mdx
+++ b/eq-author/src/storybook/Components/ScrollPane.stories.mdx
@@ -1,0 +1,124 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+
+import ScrollPane from "components/ScrollPane";
+import { NavLink } from "react-router-dom";
+const exampleText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id`;
+
+<Meta
+  title="Components/ScrollPane"
+  component={ScrollPane}
+  decorators={[
+    (Story) => (
+      <div
+        style={{
+          height: "150px",
+          width: "300px",
+          border: "2px solid #e1e4e8",
+          borderRadius: "6px",
+          padding: "50px",
+        }}
+      >
+        {Story()}
+      </div>
+    ),
+  ]}
+/>
+
+# Scroll Pane
+
+Hides overflowing content and makes it scrollable.
+
+There is an optional property that the component accepts `scrollToTop`
+
+This resets the content to the top of the scroll pane after a user clicks a link.
+
+## Example
+
+<Canvas>
+  <Story
+    name="Primary"
+    args={{ children: exampleText }}
+    parameters={{ actions: { disabled: true } }}
+  >
+    {(args) => <ScrollPane {...args} />}
+  </Story>
+</Canvas>
+
+## When to use this component
+
+Use this pattern sparingly. We have tried to limit the amount of scroll panes present within the Author application.
+
+Note: The black border surrounding the scroll pane is for example purposes only. It's used to highlight where the content begins scrolling.
+
+## When not to use this component
+
+Do not use this component if there are other ways to obscure content from the user
+
+Alternative methods to obscure content:
+
+- Truncation
+- Progressive disclosure
+- Sub-categorization
+
+## How to use this component
+
+The scroll pane component needs to be wrapped in a container that has a limited height and width.
+
+This will enable scrolling within itself.
+
+## Variants
+
+### ScrollToTop
+
+This variant makes use of the `scrollToTop` property.
+
+When a user clicks on a link, this will return the scroll pane to the top of it's content.
+
+A link has been added to show case the functionality.
+
+<Canvas>
+  <Story
+    name="Secondary"
+    args={{ children: exampleText, scrollToTop: true }}
+    parameters={{ actions: { disabled: true } }}
+  >
+    {(args) => {
+      return (
+        <>
+          <ScrollPane {...args} style={{ marginBottom: "10px" }} />
+          <NavLink to={"#"} title={"Hello"} data-test="nav-link">
+            Return to top of content
+          </NavLink>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Accessibility
+
+TODO
+
+## Research
+
+### Nielsen group advice on scrollbars (2005).
+
+https://www.nngroup.com/articles/scrolling-and-scrollbars/
+
+Key points from above link:
+
+- The additional action that scrolling requires can be difficult for users with motor skill impairments.
+- Low-literacy users can't easily reacquire their position in the text after it moves.
+- Elderly users often have trouble getting to the right spot in scrolling menus and other small scrolling items.
+
+### Baymard UX research article (2014).
+
+https://baymard.com/blog/inline-scroll-areas
+
+Key points from above link:
+
+- Lack of overview
+- Scroll hijacking
+- Invisible content & scroll bars
+- Overly sensitive scroll bars
+- “Activation” of scroll areas

--- a/eq-author/src/storybook/Components/ScrollPane.stories.mdx
+++ b/eq-author/src/storybook/Components/ScrollPane.stories.mdx
@@ -28,7 +28,7 @@ const exampleText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, se
 
 Hides overflowing content and makes it scrollable.
 
-There is an optional property that the component accepts `scrollToTop`
+There is an optional property that the component accepts `scrollToTop`.
 
 This resets the content to the top of the scroll pane after a user clicks a link.
 
@@ -48,13 +48,13 @@ This resets the content to the top of the scroll pane after a user clicks a link
 
 Use this pattern sparingly. We have tried to limit the amount of scroll panes present within the Author application.
 
-Having multiple scroll panes can frustrate and confuse users (Mouse wheel behaviour).
+Having multiple scroll panes can frustrate and confuse users (mouse wheel behaviour).
 
 Note: The black border surrounding the scroll pane is for example purposes only. It's used to highlight where the content begins scrolling.
 
 ## When not to use this component
 
-Do not use this component if there are other ways to obscure content from the user
+Do not use this component if there are other ways to obscure content from the user.
 
 Alternative methods to obscure content:
 
@@ -124,5 +124,4 @@ A link has been added to show case the functionality.
 
 - [Nielsen Norman group (2005)](https://www.nngroup.com/articles/scrolling-and-scrollbars/)
 - [Baymard institute UX research article (2014)](https://baymard.com/blog/inline-scroll-areas)
-
 


### PR DESCRIPTION
### What is the context of this PR?

Adds the scroll pane component to Storybook

Run into a few issues with the `.mdx` format whilst working on this ticket. Working with storybook is pretty cool though.

Getting a `.mdx` syntax highlighter is a really good idea, otherwise it gets hard to identify the `jsx` in the code.

Not sure if it's just my set up, but `prettier` doesn't work for me with `.mdx`. It apparently does support the file type but errors in the VScode terminal.

There is an issue with `.mdx` right now where viewing the source code in storybook prints out decorators and other bits. At the moment, the `Template.bind({})` doesn't work. I've left the decorator as is, even though it outputs more to the source.

I've made it so the text of the scroll pane is editable within storybook itself.

I've also added a few divs to style the scroll pane so it doesn't look crazy

Also also renamed the ScrollPane from StyledScrollPane because that was the name of the component in the Storybook source code.

| Weird sb bug  |  
| ------------- | 
|<img width="997" alt="Screenshot 2020-09-23 at 14 47 14" src="https://user-images.githubusercontent.com/22731314/94073150-d69bef80-fdab-11ea-84c1-1c5155285314.png">| 


Issue being discussed here
https://github.com/storybookjs/storybook/issues/11542


### How to review 

1. Run `yarn storybook`
2. Check out the scrollpane component
3. I've removed actions from the stories (it shouldn't appear in the tab next to controls)
4. Review the documentation under the `Docs` tab
5. Check the source code under `Show code` in the docs tab
