### PR TITLE
EAR 785 - Expand validation dot for double-digit numbers

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/NavLink.js
@@ -59,7 +59,6 @@ export const Badge = styled.span`
   line-height: 1;
   font-size: 0.9rem;
   pointer-events: none;
-  width: 20px;
   height: 20px;
 `;
 const SmallBadge = styled.span`


### PR DESCRIPTION
### What is the context of this PR?

Questions with double-digit validation errors caused a styling issue in the navigation bar - the number was misaligned with the red circle background.

This PR removes the fixed width of the Badge component (which renders the red dot with error count). Happily the red background remains circular for single-digit numbers but expands as needed to accommodate extra digits. See demo image.

[JIRA ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-785)

### How to review 

Create a questionnaire, add a question with ten or more validation errors. Check to see that the red background in the navigation bar expands appropriately.

<img width="342" alt="Screenshot 2020-10-14 at 15 42 09" src="https://user-images.githubusercontent.com/60441612/96006978-f451f700-0e35-11eb-8cfa-a0b432eca6f8.png">

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process