### PR TITLE
EAR 883 - Add validation for empty include/exclude section in question editor

### DIFF
--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -111,6 +111,36 @@ describe("schema validation", () => {
         type: "page",
       });
     });
+
+    it("should validate that include/exclude guidance has been filled in when enabled", () => {
+      const page = questionnaire.sections[0].pages[0];
+      page.guidanceEnabled = true;
+      page.guidance = "";
+
+      const validationPageErrors = validation(questionnaire);
+
+      expect(validationPageErrors[0]).toMatchObject({
+        errorCode: "ERR_VALID_REQUIRED",
+        field: "guidance",
+        id: uuidRejex,
+        type: "page",
+      });
+    });
+
+    it("should validate that include/exclude guidance is not null", () => {
+      const page = questionnaire.sections[0].pages[0];
+      page.guidanceEnabled = true;
+      page.guidance = null;
+
+      const validationPageErrors = validation(questionnaire);
+
+      expect(validationPageErrors[0]).toMatchObject({
+        errorCode: "ERR_VALID_REQUIRED",
+        field: "guidance",
+        id: uuidRejex,
+        type: "page",
+      });
+    });
   });
 
   describe("Confirmation Question validation", () => {

--- a/eq-author-api/src/validation/schemas/definitions.json
+++ b/eq-author-api/src/validation/schemas/definitions.json
@@ -4,9 +4,7 @@
     "populatedString": {
       "type": "string",
       "pattern": "\\w+",
-      "errorMessage": {
-        "pattern": "ERR_VALID_REQUIRED"
-      }
+      "errorMessage": "ERR_VALID_REQUIRED"
     }
   }
 }

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -132,6 +132,22 @@
         {
           "if": {
             "properties": {
+              "guidanceEnabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "guidance": {
+                "$ref": "definitions.json#/definitions/populatedString"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
               "pageType": {
                 "enum": ["QuestionPage"]
               }

--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
@@ -56,6 +56,7 @@ const {
   QUESTION_TITLE_NOT_ENTERED,
   PIPING_TITLE_MOVED,
   PIPING_TITLE_DELETED,
+  INCLUDE_EXCLUDE_NOT_ENTERED,
 } = richTextEditorErrors;
 
 const {
@@ -76,6 +77,10 @@ const situations = {
   definitionContent: {
     [DEFINITION_CONTENT_NOT_ENTERED.errorCode]:
       DEFINITION_CONTENT_NOT_ENTERED.message,
+  },
+  guidance: {
+    [INCLUDE_EXCLUDE_NOT_ENTERED.errorCode]:
+      INCLUDE_EXCLUDE_NOT_ENTERED.message,
   },
 };
 
@@ -195,6 +200,7 @@ export class StatelessMetaEditor extends React.Component {
                 fetchAnswers={fetchAnswers}
                 metadata={get(page, "section.questionnaire.metadata", [])}
                 testSelector="txt-question-guidance"
+                errorValidationMsg={this.errorMsg("guidance")}
               />
             </AnswerTransition>
           )}

--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.test.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.test.js
@@ -83,6 +83,17 @@ describe("MetaEditor", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("should display the correct error message when the includes/excludes content is missing", async () => {
+    props.page.validationErrorInfo.errors[0] = {
+      errorCode: "ERR_VALID_REQUIRED",
+      field: "guidance",
+      id: "1",
+      type: "pages",
+    };
+    const wrapper = shallow(<StatelessMetaEditor {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("should display the correct error message when piping answer in title is deleted", async () => {
     props.page.validationErrorInfo.errors[0] = {
       errorCode: "PIPING_TITLE_DELETED",

--- a/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -128,6 +128,7 @@ exports[`MetaEditor should display the correct error message when piping answer 
           }
         }
         disabled={false}
+        errorValidationMsg={null}
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"
@@ -273,6 +274,7 @@ exports[`MetaEditor should display the correct error message when piping answer 
           }
         }
         disabled={false}
+        errorValidationMsg={null}
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"
@@ -418,6 +420,7 @@ exports[`MetaEditor should display the correct error message when the definition
           }
         }
         disabled={false}
+        errorValidationMsg={null}
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"
@@ -563,6 +566,153 @@ exports[`MetaEditor should display the correct error message when the definition
           }
         }
         disabled={false}
+        errorValidationMsg={null}
+        fetchAnswers={[MockFunction]}
+        id="question-guidance"
+        label="Include/exclude"
+        maxHeight={12}
+        metadata={Array []}
+        multiline={true}
+        name="guidance"
+        onUpdate={[MockFunction]}
+        placeholder=""
+        testSelector="txt-question-guidance"
+        value="<p>Guidance</p>"
+      />
+    </AnswerTransition>
+  </TransitionGroup>
+</div>
+`;
+
+exports[`MetaEditor should display the correct error message when the includes/excludes content is missing 1`] = `
+<div>
+  <RichTextEditor
+    autoFocus={false}
+    controls={
+      Object {
+        "emphasis": true,
+        "piping": true,
+      }
+    }
+    disabled={false}
+    errorValidationMsg={null}
+    fetchAnswers={[MockFunction]}
+    id="question-title"
+    label="Question"
+    maxHeight={12}
+    metadata={Array []}
+    multiline={false}
+    name="title"
+    onUpdate={[MockFunction]}
+    placeholder=""
+    size="large"
+    testSelector="txt-question-title"
+    value="<p>Hello world</p>"
+  />
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
+  >
+    <AnswerTransition
+      key="question-description"
+      onEntered={[Function]}
+      timeout={200}
+    >
+      <RichTextEditor
+        autoFocus={false}
+        controls={
+          Object {
+            "emphasis": true,
+            "piping": true,
+          }
+        }
+        disabled={false}
+        fetchAnswers={[MockFunction]}
+        id="question-description"
+        label="Question description"
+        maxHeight={12}
+        metadata={Array []}
+        multiline={true}
+        name="description"
+        onUpdate={[MockFunction]}
+        placeholder=""
+        testSelector="txt-question-description"
+        value="<p>Description</p>"
+      />
+    </AnswerTransition>
+    <AnswerTransition
+      key="definition"
+      onEntered={[Function]}
+      timeout={200}
+    >
+      <MultipleFieldEditor
+        id="definition"
+        label="Question definition"
+      >
+        <MetaEditor__Paragraph>
+          Only to be used to define word(s) or acronym(s) within the question.
+        </MetaEditor__Paragraph>
+        <Field
+          disabled={false}
+          last={false}
+        >
+          <Label
+            bold={true}
+            htmlFor="definition-label"
+          >
+            Label
+          </Label>
+          <withChangeHandler(WrappingInput)
+            bold={true}
+            data-test="txt-question-definition-label"
+            errorValidationMsg={null}
+            id="definition-label"
+            name="definitionLabel"
+            onBlur={[MockFunction]}
+            onChange={[MockFunction]}
+            value="<p>Definition Label</p>"
+          />
+        </Field>
+        <RichTextEditor
+          autoFocus={false}
+          controls={
+            Object {
+              "bold": true,
+              "emphasis": true,
+              "list": true,
+            }
+          }
+          disabled={false}
+          errorValidationMsg={null}
+          fetchAnswers={[MockFunction]}
+          id="definition-content"
+          label="Content"
+          maxHeight={12}
+          metadata={Array []}
+          multiline={true}
+          name="definitionContent"
+          onUpdate={[MockFunction]}
+          placeholder=""
+          testSelector="txt-question-definition-content"
+          value="<p>Definition Content</p>"
+        />
+      </MultipleFieldEditor>
+    </AnswerTransition>
+    <AnswerTransition
+      key="question-guidance"
+      onEntered={[Function]}
+      timeout={200}
+    >
+      <RichTextEditor
+        autoFocus={false}
+        controls={
+          Object {
+            "bold": true,
+            "list": true,
+          }
+        }
+        disabled={false}
+        errorValidationMsg="Enter include/exclude content"
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"
@@ -708,6 +858,7 @@ exports[`MetaEditor should display the correct error message when the title is m
           }
         }
         disabled={false}
+        errorValidationMsg={null}
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"
@@ -853,6 +1004,7 @@ exports[`MetaEditor should render 1`] = `
           }
         }
         disabled={false}
+        errorValidationMsg={null}
         fetchAnswers={[MockFunction]}
         id="question-guidance"
         label="Include/exclude"

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -24,6 +24,10 @@ export const richTextEditorErrors = {
     errorCode: "PIPING_TITLE_DELETED",
     message: "The answer being piped has been deleted",
   },
+  INCLUDE_EXCLUDE_NOT_ENTERED: {
+    errorCode: "ERR_VALID_REQUIRED",
+    message: "Enter include/exclude content",
+  },
 };
 
 export const questionDefinitionErrors = {


### PR DESCRIPTION
### What is the context of this PR?

Previously there were no validation errors associated with enabling the "include/exclude" optional question field and leaving it blank - see [the JIRA ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-883).

This PR adds validation via the AJV schema for the includes/excludes field and updates the front-end to display the appropriate message as per the ticket.

<img width="1399" alt="Screenshot 2020-10-19 at 13 36 29" src="https://user-images.githubusercontent.com/60441612/96452351-d1965880-1210-11eb-972d-65398c0ddc95.png">

### How to review 

> Add to the list below as appropriate, including screenshots when necessary

Open a questionnaire in author. Enable the "include/exclude" optional field and leave it blank - the validation message should appear. Enter text and de-focus the element and the validation message should disappear.

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
