### PR TITLE
Ear 954 remove employment date default metadata

### DIFF
--- a/eq-author-api/migrations/addBusinessQuestionnaireIntroduction.test.js
+++ b/eq-author-api/migrations/addBusinessQuestionnaireIntroduction.test.js
@@ -51,7 +51,6 @@ describe("addBusinessQuestionnaireIntroduction", () => {
       "period_id",
       "ref_p_start_date",
       "ref_p_end_date",
-      "employment_date",
     ]);
   });
 });

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -92,7 +92,7 @@ describe("questionnaire", () => {
         ...config,
         type: BUSINESS,
       });
-      expect(questionnaire.metadata).toHaveLength(6);
+      expect(questionnaire.metadata).toHaveLength(5);
     });
 
     it("should create a questionnaire introduction for business surveys", async () => {

--- a/eq-author-api/utils/defaultMetadata.js
+++ b/eq-author-api/utils/defaultMetadata.js
@@ -98,14 +98,7 @@ const defaultValues = [
 
 const DEFAULT_BUSINESS_SURVEY_METADATA = filter(defaultValues, ({ key }) =>
   includes(
-    [
-      "ru_name",
-      "trad_as",
-      "ref_p_start_date",
-      "ref_p_end_date",
-      "period_id",
-      "employment_date",
-    ],
+    ["ru_name", "trad_as", "ref_p_start_date", "ref_p_end_date", "period_id"],
     key
   )
 );


### PR DESCRIPTION
### What is the context of this PR?

Previously `employment_date` was included as default metadata for all business surveys despite this not being required for all, leading to extra manual editing of JSON files prior to remove it. This PR removes `employment_date` from the default metadata populated when creating a new survey.

### How to review 

From [JIRA ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-954): 

Given I've created a survey
when I go to the Metadata screen
then there is no employment_date row

Given I've created a survey
when I deploy that survey to staging
then there is no employment_date included

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
