### PR TITLE
EAR 973 - Fix Radio/Checkbox label validation in UI

### DIFF
--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -52,6 +52,7 @@ export const StatelessBasicAnswer = ({
           bold
           errorValidationMsg={getValidationError({
             field: "label",
+            type: "answer",
             label: errorLabel,
             requiredMsg: errorMsg,
           })}

--- a/eq-author/src/enhancers/withValidationError.js
+++ b/eq-author/src/enhancers/withValidationError.js
@@ -17,7 +17,7 @@ const withValidationError = entityPropName => WrappedComponent => {
 
     static fragments = WrappedComponent.fragments;
 
-    getValidationError = ({ field, ...options }) => {
+    getValidationError = ({ field, type, ...options }) => {
       const {
         [entityPropName]: { validationErrorInfo },
       } = this.props;
@@ -28,7 +28,9 @@ const withValidationError = entityPropName => WrappedComponent => {
         return null;
       }
 
-      const fieldMessage = messages.find(m => m.field === field);
+      const fieldMessage = messages.find(
+        m => m.field === field && m.type === (type ?? m.type)
+      );
 
       if (!fieldMessage) {
         return null;


### PR DESCRIPTION
### What is the context of this PR?

Implementing the QCode validation changes last week caused `Label` and `Radio` answer types to incorrectly display a validation error message for their optional labels. 

This was due the addition of `validationErrorInfo` on the parent question and the UI code misinterpreting validation errors on `label` fields of `option`s as also applicable to the parent question label.

This PR adds the ability to filter error messages returned by `getValidationError` (for those components that use it, e.g `BasicAnswer`) by type. This is used to ensure that `BasicAnswer` only reports errors on the label for the `answer` itself and not its children.

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-973)

### How to review 

- Create a questionnaire
- Add a checkbox question
- Check there's no validation error for the empty (marked 'optional') answer label
- Add a radio question
- Check there's no validation error for the empty (marked 'optional') answer label

Should appear as below:

<img width="463" alt="Screenshot 2020-10-29 at 11 14 04" src="https://user-images.githubusercontent.com/60441612/97563658-43be2880-19db-11eb-87e9-bd1ad3f11104.png">

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
