### PR TITLE
EAR 981 - fix confirmation page validation

### DIFF
--- a/eq-author-api/schema/resolvers/pages/questionPage.js
+++ b/eq-author-api/schema/resolvers/pages/questionPage.js
@@ -74,7 +74,7 @@ Resolvers.QuestionPage = {
   },
   validationErrorInfo: ({ id }, args, ctx) => {
     const pageErrors = ctx.validationErrorInfo.filter(
-      ({ pageId }) => id === pageId
+      ({ pageId, type }) => id === pageId && !type.startsWith("confirmation")
     );
     //remove qcode errors from total here - important as Qcode errors don't count to total
     // otherwise error totals get confusing for users!!!!!!

--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -316,19 +316,20 @@
           "type": "object",
           "properties": {
             "label": {
-              "allOf": [
-                {
-                  "$ref": "definitions.json#/definitions/populatedString"
+              "if": {
+                "$ref": "definitions.json#/definitions/populatedString"
+              },
+              "then": {
+                "not": {
+                  "const": {
+                    "$data": "2/negative/label"
+                  }
                 },
-                {
-                  "not": {
-                    "const": {
-                      "$data": "2/negative/label"
-                    }
-                  },
-                  "errorMessage": "ERR_UNIQUE_REQUIRED"
-                }
-              ]
+                "errorMessage": "ERR_UNIQUE_REQUIRED"
+              },
+              "else": {
+                "$ref": "definitions.json#/definitions/populatedString"
+              }
             }
           },
           "required": [
@@ -339,19 +340,20 @@
           "type": "object",
           "properties": {
             "label": {
-              "allOf": [
-                {
-                  "$ref": "definitions.json#/definitions/populatedString"
+              "if": {
+                "$ref": "definitions.json#/definitions/populatedString"
+              },
+              "then": {
+                "not": {
+                  "const": {
+                    "$data": "2/positive/label"
+                  }
                 },
-                {
-                  "not": {
-                    "const": {
-                      "$data": "2/positive/label"
-                    }
-                  },
-                  "errorMessage": "ERR_UNIQUE_REQUIRED"
-                }
-              ]
+                "errorMessage": "ERR_UNIQUE_REQUIRED"
+              },
+              "else": {
+                "$ref": "definitions.json#/definitions/populatedString"
+              }
             }
           },
           "required": [


### PR DESCRIPTION
### What is the context of this PR?

Confirmation pages were reporting an incorrect amount of errors and propagating these errors into the parent question, causing inappropriate errors in the parent. See [JIRA ticket ](https://collaborate2.ons.gov.uk/jira/browse/EAR-981)for a screenshot.

This PR:

- Re-jigs the AJV validation of the `confirmationPage` labels so that the labels are only checked for duplication **if they are not empty**. Previously two errors were generated for each empty label: one for 'label required' and one for 'duplicated value', giving a confusing error count in the nav pane.
- Adjusts the resolver for `questionPage` to stop confirmation page errors being included inside their parent question's `validationErrorInfo`. This is necessary due to the design of confirmation pages as "part" of the parent page rather than an independent page in their own right.

### How to review 

- Create or open a questionnaire
- Create a question or open an existing question
- Add a confirmation page for the question
- Check that the red 'error dot' in the navigation bar is accurate for the question & the confirmation page based on errors visible on the respective pages
- Check that duplicated labels and missing labels on confirmation page are still reported appropriately as errors

<img width="182" alt="Screenshot 2020-10-29 at 15 58 14" src="https://user-images.githubusercontent.com/60441612/97599154-96a9d700-19ff-11eb-9246-5e0f2ae76033.png">


### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
