### PR TITLE
EAR 971 collapsible summary sections

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -114,6 +114,9 @@ const questionnaireVersionsSchema = new dynamoose.Schema(
     summary: {
       type: Boolean,
     },
+    collapsibleSummary: {
+      type: Boolean,
+    },
     sections: {
       type: Array,
       required: true,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -58,6 +58,7 @@ type Questionnaire {
   createdBy: User!
   sections: [Section]
   summary: Boolean
+  collapsibleSummary: Boolean
   questionnaireInfo: QuestionnaireInfo
   metadata: [Metadata!]!
   type: QuestionnaireType!
@@ -800,6 +801,7 @@ input UpdateQuestionnaireInput {
   navigation: Boolean
   surveyId: String
   summary: Boolean
+  collapsibleSummary: Boolean
   shortTitle: String
   editors: [ID!] 
   isPublic: Boolean

--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -347,6 +347,17 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
                 "kind": "Field",
                 "name": Object {
                   "kind": "Name",
+                  "value": "collapsibleSummary",
+                },
+                "selectionSet": undefined,
+              },
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
                   "value": "type",
                 },
                 "selectionSet": undefined,
@@ -1141,7 +1152,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 2001,
+        "end": 2022,
         "start": 0,
       },
     }

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -42,6 +42,7 @@ const moveSectionMock = {
         type: "Social",
         navigation: true,
         summary: "",
+        collapsibleSummary: false,
         displayName: "Display name",
         shortTitle: "Short tile",
         permission: WRITE,

--- a/eq-author/src/App/settings/SettingsPage.js
+++ b/eq-author/src/App/settings/SettingsPage.js
@@ -193,7 +193,13 @@ const SettingsPage = ({ questionnaire }) => {
               hideLabels={false}
               onChange={({ value }) =>
                 updateQuestionnaire({
-                  variables: { input: { id, summary: value } },
+                  variables: {
+                    input: {
+                      id,
+                      summary: value,
+                      collapsibleSummary: !summary && collapsibleSummary,
+                    },
+                  },
                 })
               }
               checked={summary}

--- a/eq-author/src/App/settings/SettingsPage.js
+++ b/eq-author/src/App/settings/SettingsPage.js
@@ -197,7 +197,7 @@ const SettingsPage = ({ questionnaire }) => {
                     input: {
                       id,
                       summary: value,
-                      collapsibleSummary: !summary && collapsibleSummary,
+                      collapsibleSummary: false,
                     },
                   },
                 })

--- a/eq-author/src/App/settings/SettingsPage.js
+++ b/eq-author/src/App/settings/SettingsPage.js
@@ -51,6 +51,11 @@ const VerticalSeparator = styled.div`
   margin-bottom: 0.4em;
 `;
 
+const CollapsibleWrapper = styled.div`
+  opacity: ${props => (props.disabled ? "0.6" : "1")};
+  pointer-events: ${props => (props.disabled ? "none" : "auto")};
+`;
+
 const InlineField = styled(Field)`
   display: flex;
   align-items: center;
@@ -86,7 +91,15 @@ Pill.propTypes = {
 };
 
 const SettingsPage = ({ questionnaire }) => {
-  const { title, shortTitle, type, id, navigation, summary } = questionnaire;
+  const {
+    title,
+    shortTitle,
+    type,
+    id,
+    navigation,
+    summary,
+    collapsibleSummary,
+  } = questionnaire;
 
   const [updateQuestionnaire] = useMutation(updateQuestionnaireMutation);
   const [questionnaireTitle, setQuestionnaireTitle] = useState(title);
@@ -165,6 +178,12 @@ const SettingsPage = ({ questionnaire }) => {
             the questionnaire.
           </InformationPanel>
           <HorizontalSeparator />
+          <Label>Summary page</Label>
+          <Caption>
+            Let respondents view and change their answers before submitting
+            them. You can set the list of sections to be collapsible, so
+            respondents can show and hide their answer for individual sections.
+          </Caption>
           <InlineField>
             <Label>Answers summary</Label>
             <VerticalSeparator />
@@ -180,10 +199,23 @@ const SettingsPage = ({ questionnaire }) => {
               checked={summary}
             />
           </InlineField>
-          <InformationPanel>
-            Let respondents check their answers before submitting their
-            questionnaire.
-          </InformationPanel>
+          <CollapsibleWrapper disabled={!summary}>
+            <InlineField>
+              <Label>Collapsible sections</Label>
+              <VerticalSeparator />
+              <ToggleSwitch
+                id="toggle-collapsible-summary"
+                name="toggle-collapsible-summary"
+                hideLabels={false}
+                onChange={({ value }) =>
+                  updateQuestionnaire({
+                    variables: { input: { id, collapsibleSummary: value } },
+                  })
+                }
+                checked={collapsibleSummary}
+              />
+            </InlineField>
+          </CollapsibleWrapper>
         </StyledPanel>
       </ScrollPane>
     </Container>

--- a/eq-author/src/App/settings/SettingsPage.test.js
+++ b/eq-author/src/App/settings/SettingsPage.test.js
@@ -170,6 +170,7 @@ describe("Settings page", () => {
             input: {
               id: mockQuestionnaire.id,
               summary: false,
+              collapsibleSummary: false,
             },
           },
         },
@@ -180,6 +181,30 @@ describe("Settings page", () => {
               updateQuestionnaire: {
                 ...mockQuestionnaire,
                 summary: false,
+                collapsibleSummary: false,
+                __typename: "Questionnaire",
+              },
+            },
+          };
+        },
+      },
+      {
+        request: {
+          query: updateQuestionnaireMutation,
+          variables: {
+            input: {
+              id: mockQuestionnaire.id,
+              collapsibleSummary: true,
+            },
+          },
+        },
+        result: () => {
+          queryWasCalled = true;
+          return {
+            data: {
+              updateQuestionnaire: {
+                ...mockQuestionnaire,
+                collapsibleSummary: true,
                 __typename: "Questionnaire",
               },
             },
@@ -367,6 +392,31 @@ describe("Settings page", () => {
       );
 
       const sectionNavigationToggle = getByTestId("toggle-answer-summary");
+
+      const toggle = Object.values(
+        sectionNavigationToggle.children
+      ).reduce(child => (child.type === "checkbox" ? child : null));
+
+      expect(queryWasCalled).toBeFalsy();
+
+      await act(async () => {
+        await fireEvent.click(toggle);
+        flushPromises();
+      });
+
+      expect(queryWasCalled).toBeTruthy();
+    });
+  });
+
+  describe("Collapsible summary toggle", () => {
+    it("Should enable/disable collapsible summaries when toggled", async () => {
+      const { getByTestId } = renderSettingsPage(
+        mockQuestionnaire,
+        user,
+        mocks
+      );
+
+      const sectionNavigationToggle = getByTestId("toggle-collapsible-summary");
 
       const toggle = Object.values(
         sectionNavigationToggle.children

--- a/eq-author/src/App/settings/SettingsPage.test.js
+++ b/eq-author/src/App/settings/SettingsPage.test.js
@@ -31,6 +31,7 @@ describe("Settings page", () => {
       id: "e3c3ecc4-87fb-4819-826b-ac696a4bc569",
       navigation: true,
       summary: true,
+      collapsibleSummary: false,
       description: "A questionnaire about a lovable, purple dragon",
       surveyId: "123",
       theme: "default",

--- a/eq-author/src/graphql/fragments/questionnaire.graphql
+++ b/eq-author/src/graphql/fragments/questionnaire.graphql
@@ -6,6 +6,7 @@ fragment Questionnaire on Questionnaire {
   theme
   navigation
   summary
+  collapsibleSummary
   type
   shortTitle
   displayName

--- a/eq-publisher/src/eq_schema/Questionnaire.js
+++ b/eq-publisher/src/eq_schema/Questionnaire.js
@@ -65,7 +65,10 @@ class Questionnaire {
       duration: 900,
     };
 
-    this.buildSummaryOrConfirmation(questionnaireJson.summary);
+    this.buildSummaryOrConfirmation(
+      questionnaireJson.summary,
+      questionnaireJson.collapsibleSummary
+    );
   }
 
   createContext(questionnaireJson) {
@@ -79,8 +82,10 @@ class Questionnaire {
     return sections.map(section => new Section(section, ctx));
   }
 
-  buildSummaryOrConfirmation(summary) {
-    const finalPage = summary ? new Summary() : new Confirmation();
+  buildSummaryOrConfirmation(summary, collapsible) {
+    const finalPage = summary
+      ? new Summary({ collapsible })
+      : new Confirmation();
     last(this.sections).groups.push(finalPage);
   }
 

--- a/eq-publisher/src/eq_schema/block-types/Summary.js
+++ b/eq-publisher/src/eq_schema/block-types/Summary.js
@@ -1,13 +1,17 @@
 class Summary {
-  constructor() {
+  constructor({ collapsible }) {
     this.id = "summary-group";
     this.title = "Summary";
-    this.blocks = [
-      {
-        type: "Summary",
-        id: "summary-block",
-      },
-    ];
+
+    const summaryBlock = {
+      type: "Summary",
+      id: "summary-block",
+    };
+    if (collapsible) {
+      summaryBlock.collapsible = true;
+    }
+
+    this.blocks = [summaryBlock];
   }
 }
 

--- a/eq-publisher/src/eq_schema/block-types/Summary.test.js
+++ b/eq-publisher/src/eq_schema/block-types/Summary.test.js
@@ -1,8 +1,8 @@
 const Summary = require("./Summary");
 
 describe("Summary", () => {
-  it("should build valid runner Summary", () => {
-    const summary = new Summary();
+  it("should build valid runner Summary - non collapsible sections", () => {
+    const summary = new Summary({ collapsible: false });
     expect(summary).toEqual({
       id: "summary-group",
       title: "Summary",
@@ -10,6 +10,20 @@ describe("Summary", () => {
         {
           type: "Summary",
           id: "summary-block",
+        },
+      ],
+    });
+  });
+  it("should build valid runner Summary - collapsible sections", () => {
+    const summary = new Summary({ collapsible: true });
+    expect(summary).toEqual({
+      id: "summary-group",
+      title: "Summary",
+      blocks: [
+        {
+          type: "Summary",
+          id: "summary-block",
+          collapsible: true,
         },
       ],
     });

--- a/eq-publisher/src/getQuestionnaire/queries.js
+++ b/eq-publisher/src/getQuestionnaire/queries.js
@@ -175,6 +175,7 @@ exports.getQuestionnaire = `
       navigation
       surveyId
       summary
+      collapsibleSummary
       metadata {
         ...metadataFragment
       }


### PR DESCRIPTION
### What is the context of this PR?

This re-designs the last section of the questionnaire Settings page in Author to match [Joe's prototype](https://overflow.io/s/HG5JQXVF?node=2bddfe0c&prototype), adding the ability for users to make the "summary" section(s) collapsible in Author with a new toggle switch. Previously this required manually editing the survey JSON. Worked on this jointly with Sam. 

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-971)

#### This PR:
- Modifies UI to match prototype - adds toggle switch, heading and descriptive text, removes old information panel.
- Updates typeDefs and clientside GraphQL - adds the `collapsibleSummary` attribute to the questionnaire object in Author.
- Updates DynamoDB schema to include `collapsibleSummary` attribute for `Questionnaire`
- Modifies Publisher v2 to output appropriate runner JSON dependent on the questionnaire JSON's `collapsibleSummary` attribute

### How to review 

#### Author

<img width="981" alt="Screenshot 2020-11-02 at 18 14 24" src="https://user-images.githubusercontent.com/60441612/97903654-456b5180-1d37-11eb-8fc6-71775b1183ca.png">

- Create/open a questionnaire in Author
- Go to the Settings page via left nav bar
- Toggle switch for "Collapsible sections" should be present.
- Toggle "Answers summary" on (if not already on)
- "Collapsible sections" toggle switch should become clickable
- Clicking toggle should switch it on/off
- Toggle "Answers summary" switch off
- "Collapsible sections" toggle should appear disabled and faded as per prototype
- "Collapsible sections" toggle should automatically change to "Off".

#### Publisher v2
- Open/edit existing questionnaire and enable "collapsible sections" as per above
- Use local instance of publisher v2 to get runner JSON from questionnaire ID
- Check that the `summary-block` in the runner JSON has `collapsible: true` present
- Disable "collapsible sections"
- Check that the `summary-block` in the runner JSON has no `collapsible` attribute.

#### Publisher v3
- Also kindly cast an eye over the [associated changes to publisher v3](https://github.com/ONSdigital/eq-publisher-v3/pull/13).

### What to do after everything is green

This adds a new attribute to the questionnaire object - but it is optional (if not present, behaviour should be unchanged from before). I'm guessing this means a migration isn't required for this?

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
