### PR TITLE
Error now shows only when answer is used at least once in expression group

### DIFF
--- a/eq-author-api/src/validation/customKeywords/validateExpression.js
+++ b/eq-author-api/src/validation/customKeywords/validateExpression.js
@@ -42,6 +42,18 @@ module.exports = function(ajv) {
         entityData.right &&
         entityData.right.optionIds
       ) {
+        const { condition, left } = entityData;
+
+        const leftAnswerId = left.answerId;
+
+        const numOfOccurancesOfLeft = expressionsWithoutNullLeft.filter(
+          ({ left }) => left.answerId === leftAnswerId
+        );
+
+        if (numOfOccurancesOfLeft.length === 1) {
+          return true;
+        }
+
         const selectedOptions = entityData.right.optionIds.map(optionId =>
           getOptionById({ questionnaire }, optionId)
         );
@@ -52,8 +64,6 @@ module.exports = function(ajv) {
 
         const selectionContainsOnlyMutuallyExclusive =
           selectedOptions.length === 1 && selectedOptions[0].mutuallyExclusive;
-
-        const { condition } = entityData;
 
         if (
           expressionsWithoutNullLeft.length > 0 &&


### PR DESCRIPTION
### What is the context of this PR?

> We're aware of an issue where you need to reload the page to have the actual error message show/hide (the dot works as expected). This is being fixed in another ticket.

One of our users found that on the BICS survey, they were unable to create a rule that was:

Match ALL OF the following:

WHEN <Answer 1> is < Mutually exclusive option > AND < Answer 2 > is < anything >

This fixes that. The error message now only shows when the question containing a mutually exclusive is used more than once in the set.

### How to review 

* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
