### PR TITLE
EAR 1014 - 🛠 Remove qCode validation on Radio answer's nested additionalAnswer

### DIFF
--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -1160,7 +1160,22 @@
           "$ref": "definitions.json#/definitions/populatedString"
         },
         "additionalAnswer": {
-          "$ref": "entities.json#/definitions/basicAnswer"
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "label": {
+              "$ref": "definitions.json#/definitions/populatedString"
+            },
+            "properties": {
+              "$ref": "entities.json#/definitions/properties"
+            }
+          },
+          "required": [
+            "id",
+            "label"
+          ]
         },
         "qCode": {
           "$ref": "definitions.json#/definitions/populatedString"


### PR DESCRIPTION
### What is the context of this PR?
Those radio / checkbox answers which provide an embedded `TextField` answer ("Other" options) were erroneously showing qCode validation errors for the embedded `TextField` when its qCode was null.

This commit removes checking for qCodes from nested `additionalAnswers` inside Radio / Checkbox answers' options. Fixes issue with BICS wave 18 survey - only the radio answer itself or the individual `option`s of a checkbox answer should have qCodes.

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1014)

### How to review 

Copy & import locally the questionnaire from https://author.ons.gov.uk/#/q/7a12c69c-d886-4ca3-a7eb-c6e5adcea116 (BICS wave 18).

Check that the error reported in the JIRA ticket is no more (e.g. no qCode errors shown where qCode entered for the affected radio answer - question 6a).

Screenshot:

<img width="1288" alt="Screenshot 2020-11-12 at 07 14 24" src="https://user-images.githubusercontent.com/60441612/98908369-39f6f380-24b8-11eb-8743-8ac43ae9b4ca.png">

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
