### PR TITLE
EAR 643 - 🛠 Bug fix - only validate AND operator

### DIFF
--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -1216,7 +1216,7 @@
                 "type": "null"
               },
               {
-                "const:": "And"
+                "const": "And"
               }
             ]
           }


### PR DESCRIPTION
### What is the context of this PR?

Syntax error in entities.json was causing bug where OR conditions were
being validated as AND rules.

### How to review 

- Add two routing rules with the "Any of" operator choice (OR)
- Add two rules which would not be valid if the operator were AND (e.g. = 3 and = 2)
- Shouldn't get an AND-related validation error

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
