### PR TITLE
set default message for then routing

### DIFF
--- a/eq-author-api/schema/resolvers/logic/routing2/routing2/index.js
+++ b/eq-author-api/schema/resolvers/logic/routing2/routing2/index.js
@@ -62,7 +62,7 @@ Resolvers.Mutation = {
               }),
             ],
           }),
-          destination: createDestination({ logical: "NextPage" }),
+          destination: createDestination({ logical: "Default" }),
         }),
       ],
     });
@@ -81,6 +81,7 @@ Resolvers.Mutation = {
       id: routing.else.id,
       ...input.else,
     };
+
     return routing;
   }),
 };

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -475,6 +475,7 @@ enum Language {
 }
 
 enum LogicalDestination2 {
+  Default
   NextPage
   EndOfQuestionnaire
 }

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
@@ -24,6 +24,10 @@ const getLogicalDisplayName = (
     return "Next page";
   }
 
+  if (logical === "Default") {
+    return "Select a destination";
+  }
+
   if (loading) {
     return "";
   }
@@ -50,6 +54,7 @@ const getSelectedDisplayName = (
   if (!selected.page && !selected.section && !selected.logical) {
     return "Select a destination";
   }
+  
   if (selected.logical) {
     return getLogicalDisplayName(
       selected.logical,

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.test.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.test.js
@@ -164,6 +164,16 @@ describe("RoutingDestinationContentPicker", () => {
       getByText("Next page");
     });
 
+    it("should correctly render logicalDestination Default", () => {
+      props.selected = {
+        logical: "Default",
+      };
+      const { getByText } = render(
+        <UnwrappedRoutingDestinationContentPicker {...props} />
+      );
+      getByText("Select a destination");
+    });
+
     it("should render with no display name if loading and next page selected", () => {
       props.loading = true;
       const { getByTestId } = render(


### PR DESCRIPTION

### What is the context of this PR?

https://collaborate2.ons.gov.uk/jira/browse/EAR-609

Acceptance criteria (user perspective) 
Given I am creating a routing logic rule
when I add the rule
and select an answer
then I am presented with an empty 'Then' destination box
text should say: "Select a destination"

_note: currently there will be NO validation on this - to be done in seperate ticket - EAR-918_ 
_note: 'Else  Go to' will stay as 'Next page' default.__

### How to review 

create 2 new questions
on question 1, create a routing rule within logic
you should see the 'then'  default selection to say 'Select a destination'
you should see the  'else' default selection to say 'Next page'
routing should work as normal

