### PR TITLE
Publisher now correctly handles 'unanswered' logic condition in mutully exclusive

### DIFF
--- a/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
+++ b/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
@@ -44,8 +44,6 @@ const convertExpressionGroup = (expressionGroup, ctx) => {
       accum = accum.concat(translateBinaryExpression(expression));
     }
 
-    console.log(expression);
-
     if (
       mutallyExclusiveAnswer &&
       expression.left &&

--- a/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
+++ b/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
@@ -35,17 +35,17 @@ const convertCheckboxExpression = expression => {
 
 const convertExpressionGroup = (expressionGroup, ctx) => {
   return expressionGroup.expressions.reduce((accum, expression) => {
-    const mutallyExclusiveAnswer = getMutallyExclusiveAnswer(
+    const mutuallyExclusiveAnswer = getMutallyExclusiveAnswer(
       expression.left.id,
       ctx
     );
 
-    if (!mutallyExclusiveAnswer) {
+    if (!mutuallyExclusiveAnswer) {
       accum = accum.concat(translateBinaryExpression(expression));
     }
 
     if (
-      mutallyExclusiveAnswer &&
+      mutuallyExclusiveAnswer &&
       expression.left &&
       expression.right &&
       some(expression.left.options, option =>
@@ -58,9 +58,9 @@ const convertExpressionGroup = (expressionGroup, ctx) => {
     }
 
     if (
-      mutallyExclusiveAnswer &&
+      mutuallyExclusiveAnswer &&
       expression.right &&
-      some(expression.right.options, { id: mutallyExclusiveAnswer.id })
+      some(expression.right.options, { id: mutuallyExclusiveAnswer.id })
     ) {
       accum = accum.concat([
         translateBinaryExpression(

--- a/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
+++ b/eq-publisher/src/eq_schema/builders/expressionGroup/index.js
@@ -44,8 +44,12 @@ const convertExpressionGroup = (expressionGroup, ctx) => {
       accum = accum.concat(translateBinaryExpression(expression));
     }
 
+    console.log(expression);
+
     if (
       mutallyExclusiveAnswer &&
+      expression.left &&
+      expression.right &&
       some(expression.left.options, option =>
         some(expression.right.options, { id: option.id })
       )
@@ -57,6 +61,7 @@ const convertExpressionGroup = (expressionGroup, ctx) => {
 
     if (
       mutallyExclusiveAnswer &&
+      expression.right &&
       some(expression.right.options, { id: mutallyExclusiveAnswer.id })
     ) {
       accum = accum.concat([


### PR DESCRIPTION
### What is the context of this PR?

If you have a skip condition like this:

![image](https://user-images.githubusercontent.com/15129656/99552210-a4c29600-29b4-11eb-9919-9f85e7403955.png)

Publisher throws a wobbly because the code didn't account for the unanswered logic condition alongside a mutually exclusive. This PR introduces a check to ensure the `right` part of the rule is populated before doing things with it (which is unpopulated if the condition is unanswered)

### How to review 

* Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
    * ensure it can be opened in Author;
    * then, ensure it can be viewed in Runner by pressing the **view survey** button
* Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. * [ ] Bring this branch up-to-date with Origin/Master
2. * [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. * [ ] Click the **Merge** button on this pull request
4. * [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. * [ ] Move the Jira ticket for this task into the next stage of the process
