### PR TITLE
Require more than 1 answer for calculated summaries

### DIFF
--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -218,7 +218,7 @@
                   "calculatedSummaryUnitConsistency": {
                     "$data": "/sections"
                   },
-                  "minItems": 1,
+                  "minItems": 2,
                   "errorMessage": {
                     "minItems": "ERR_NO_ANSWERS"
                   }

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -74,6 +74,7 @@ const AnswerList = styled.ul`
 const AnswerListItem = styled.li`
   margin: 0 0 0.5em;
   width: 100%;
+  
   &:last-of-type {
     margin-bottom: 0em;
   }

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -196,9 +196,9 @@ export class UnwrappedAnswerSelector extends Component {
     let errorMsg;
 
     if (unit !== undefined) {
-      errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${unit}`, 20, 19);
+      errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${unit.toLowerCase()}`, 20, 19);
     } else {
-    errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${answers[0].type}`, 20, 19);
+    errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${answers[0].type.toLowerCase()}`, 20, 19);
     }
 
     const isInvalid = unitInconsistencyError || minOfTwoAnswersError;

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -76,7 +76,7 @@ const AnswerListItem = styled.li`
   width: 100%;
   
   &:last-of-type {
-    margin-bottom: 0em;
+    margin-bottom: 0;
   }
 `;
 
@@ -243,7 +243,6 @@ export class UnwrappedAnswerSelector extends Component {
                 ))}
               </AnswerList>
               {minOfTwoAnswersError && <ErrorInline>{errorMsg}</ErrorInline>}
-              {/* {unitInconsistencyError && <ErrorInline>{unitInconsistencyError}</ErrorInline>} */}
             </ErrorContext>
           </SectionListItem>
         </SectionList>

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -16,6 +16,7 @@ import ErrorInline from "components/ErrorInline";
 import {
   CALCSUM_ANSWER_NOT_SELECTED,
   CALCSUM_SUMMARY_ANSWERS_THE_SAME,
+  buildLabelError,
 } from "constants/validationMessages";
 
 import AnswerChip from "./AnswerChip";
@@ -73,6 +74,9 @@ const AnswerList = styled.ul`
 const AnswerListItem = styled.li`
   margin: 0 0 0.5em;
   width: 100%;
+  &:last-of-type {
+    margin-bottom: 0em;
+  }
 `;
 
 const SelectButton = styled(Button)`
@@ -129,7 +133,7 @@ export const ErrorContext = styled.div`
   ${props =>
     props.isInvalid &&
     css`
-      margin-bottom: 2em;
+      margin-bottom: 2.5em;
       border: 1px solid ${colors.red};
       padding: 1em;
     `}
@@ -175,13 +179,33 @@ export class UnwrappedAnswerSelector extends Component {
   };
 
   renderAnswers(answers, answerType) {
+
+    // console.log('not empty state props', this.props);
+
     const { section } = this.props.page;
-    const errorValidationMsg = this.props.getValidationError({
+
+    const unitInconsistencyError = this.props.getValidationError({
       field: "summaryAnswers",
       message: CALCSUM_SUMMARY_ANSWERS_THE_SAME,
     });
 
-    const isInvalid = Boolean(errorValidationMsg);
+    const minOfTwoAnswersError = this.props.getValidationError({
+      field: "summaryAnswers",
+      message: CALCSUM_ANSWER_NOT_SELECTED,
+    });
+
+    const unit = this.props.page.summaryAnswers[0].properties.unit;
+
+    let errorMsg;
+
+    if (unit !== undefined) {
+      errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${unit}`, 20, 19);
+    } else {
+    errorMsg = CALCSUM_ANSWER_NOT_SELECTED;
+    }
+
+    const isInvalid = Boolean(unitInconsistencyError) || Boolean(minOfTwoAnswersError);
+
     return (
       <div>
         <SectionList>
@@ -217,7 +241,8 @@ export class UnwrappedAnswerSelector extends Component {
                   </AnswerListItem>
                 ))}
               </AnswerList>
-              {isInvalid && <ErrorInline>{errorValidationMsg}</ErrorInline>}
+              {minOfTwoAnswersError && <ErrorInline>{errorMsg}</ErrorInline>}
+              {/* {unitInconsistencyError && <ErrorInline>{unitInconsistencyError}</ErrorInline>} */}
             </ErrorContext>
           </SectionListItem>
         </SectionList>
@@ -233,6 +258,7 @@ export class UnwrappedAnswerSelector extends Component {
   }
 
   renderEmptyState(availableSummaryAnswers) {
+
     const { getValidationError } = this.props;
     const isAvailableAnswers = availableSummaryAnswers.length > 0;
 

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector.js
@@ -180,11 +180,6 @@ export class UnwrappedAnswerSelector extends Component {
   };
 
   renderAnswers(answers, answerType) {
-
-    // console.log('not empty state props', this.props);
-
-    const { section } = this.props.page;
-
     const unitInconsistencyError = this.props.getValidationError({
       field: "summaryAnswers",
       message: CALCSUM_SUMMARY_ANSWERS_THE_SAME,
@@ -195,17 +190,18 @@ export class UnwrappedAnswerSelector extends Component {
       message: CALCSUM_ANSWER_NOT_SELECTED,
     });
 
-    const unit = this.props.page.summaryAnswers[0].properties.unit;
+    const { section } = this.props.page;
+    const unit = answers[0].properties.unit;
 
     let errorMsg;
 
     if (unit !== undefined) {
       errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${unit}`, 20, 19);
     } else {
-    errorMsg = CALCSUM_ANSWER_NOT_SELECTED;
+    errorMsg = buildLabelError(CALCSUM_ANSWER_NOT_SELECTED, `${answers[0].type}`, 20, 19);
     }
 
-    const isInvalid = Boolean(unitInconsistencyError) || Boolean(minOfTwoAnswersError);
+    const isInvalid = unitInconsistencyError || minOfTwoAnswersError;
 
     return (
       <div>

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -72,7 +72,7 @@ export const characterErrors = {
 export const QCODE_IS_NOT_UNIQUE = "Qcode must be unique";
 export const QCODE_REQUIRED = "Qcode required";
 export const QUESTION_ANSWER_NOT_SELECTED = "Answer required";
-export const CALCSUM_ANSWER_NOT_SELECTED = "Answer required";
+export const CALCSUM_ANSWER_NOT_SELECTED = "Select at least two answers to be calculated";
 export const CALCSUM_SUMMARY_ANSWERS_THE_SAME =
   "Select answers that are the same unit type";
 export const DATE_LABEL_REQUIRED = "Enter a date label";
@@ -165,5 +165,6 @@ export const buildLabelError = (mainString, insString, pos, pos2) => {
   ) {
     return "Label error";
   }
-  return mainString.slice(0, pos) + insString + mainString.slice(pos2);
+  const newLabelError = mainString.slice(0, pos) + insString + mainString.slice(pos2);
+  return newLabelError;
 };


### PR DESCRIPTION


### What is the context of this PR?

**_Acceptance criteria (user perspective)_**
Given I've added a calculated summary page
When I haven't chosen any answers
Then I see the error message Select at least two answers to be calculated

Given I've added a calculated summary page
When I've only chosen one answer to calculate
Then I see the error message Select at least two number answers to be calculated
Please note - The word number in the above message would change to percentage, currency etc depending on what answer type the user selected first

Given I've added a calculated summary page
When I've chosen two or more answers to calculate
Then I don't see any error messages


