### PR TITLE
EAR-998 break-word in multiple preview places

### DIFF
--- a/eq-author/src/App/introduction/Preview/index.js
+++ b/eq-author/src/App/introduction/Preview/index.js
@@ -16,7 +16,7 @@ import iconChevron from "./icon-chevron.svg";
 
 const Container = styled.div`
   padding: 0 2em 2em;
-  max-width: 40em;
+  word-break: break-word;
   font-size: 1.1em;
   p {
     margin: 0 0 1em;

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -17,7 +17,6 @@ import CalculatedSummaryPageEditor from "../Design/CalculatedSummaryPageEditor";
 
 const Container = styled.div`
   padding: 2em;
-  max-width: 35em;
   font-size: 1.1em;
   p {
     margin: 0 0 1em;
@@ -52,6 +51,7 @@ const SummaryItem = styled.div`
 
 const SummaryLabel = styled.div`
   font-weight: normal;
+  word-break: break-word;
 `;
 
 const SummaryValue = styled.div`
@@ -78,6 +78,7 @@ const SummaryTotal = styled(SummaryItem)`
 
 const SummaryTotalLabel = styled.div`
   font-weight: bold;
+  word-break: break-word;
 `;
 
 const CalculatedSummaryPagePreview = ({ page }) => {

--- a/eq-author/src/App/page/Preview/QuestionPagePreview.js
+++ b/eq-author/src/App/page/Preview/QuestionPagePreview.js
@@ -20,7 +20,6 @@ import Panel from "components/Panel";
 
 const Container = styled.div`
   padding: 2em;
-  max-width: 40em;
   font-size: 1.1em;
   p {
     margin: 0 0 1em;
@@ -43,10 +42,12 @@ const Container = styled.div`
 
 export const Description = styled.div`
   margin-bottom: 1em;
+  word-wrap: break-word;
 `;
 
 const Guidance = styled.div`
   margin-bottom: 2em;
+  word-wrap: break-word;
 `;
 
 const Box = styled.div`
@@ -68,6 +69,7 @@ export const DetailsTitle = styled.div`
   align-items: center;
   color: ${colors.primary};
   margin-bottom: 0.5em;
+  word-wrap: break-word;
 
   &::before {
     width: 32px;
@@ -83,6 +85,7 @@ export const DetailsContent = styled.div`
   border-left: 2px solid #999;
   margin-left: 6px;
   padding: 0.2em 0 0.2em 1em;
+  word-wrap: break-word;
 `;
 
 const QuestionPagePreview = ({ page }) => {

--- a/eq-author/src/App/questionConfirmation/Preview/index.js
+++ b/eq-author/src/App/questionConfirmation/Preview/index.js
@@ -48,7 +48,6 @@ const Container = styled.div`
 const Replay = styled.div`
   background-color: ${colors.darkBlue};
   color: ${colors.white};
-  width: auto;
   min-width: 20em;
   width: 100%;
   word-break: break-word;

--- a/eq-author/src/App/questionConfirmation/Preview/index.js
+++ b/eq-author/src/App/questionConfirmation/Preview/index.js
@@ -24,7 +24,6 @@ import ValidationErrorInfoFragment from "graphql/fragments/validationErrorInfo.g
 
 const Container = styled.div`
   padding: 2em;
-  max-width: 40em;
   font-size: 1.1em;
   p {
     margin: 0 0 1em;
@@ -51,6 +50,8 @@ const Replay = styled.div`
   color: ${colors.white};
   width: auto;
   min-width: 20em;
+  width: 100%;
+  word-break: break-word;
   display: inline-block;
   overflow: hidden;
   margin-top: 0;

--- a/eq-author/src/App/questionConfirmation/Preview/index.js
+++ b/eq-author/src/App/questionConfirmation/Preview/index.js
@@ -55,6 +55,7 @@ const Replay = styled.div`
   overflow: hidden;
   margin-top: 0;
   margin-bottom: 1em;
+  padding-right: 1em;
 `;
 
 export const UnwrappedPreviewConfirmationRoute = ({ loading, data }) => {

--- a/eq-author/src/App/section/Preview/SectionIntroPreview.js
+++ b/eq-author/src/App/section/Preview/SectionIntroPreview.js
@@ -9,7 +9,6 @@ import { propType } from "graphql-anywhere";
 
 const Wrapper = styled.div`
   padding: 2em;
-  max-width: 40em;
   p {
     margin: 0 0 1em;
   }
@@ -34,11 +33,13 @@ const ContentBlock = styled.div`
     font-size: 1em;
     font-weight: normal;
   }
+  word-break: break-word;
 `;
 
 const TitleBlock = styled.h1`
   font-size: 1.4em;
   margin: 0 0 1em;
+  word-break: break-word;
 `;
 
 const SectionIntroPreview = ({

--- a/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
+++ b/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
@@ -66,12 +66,13 @@ export const OptionItem = styled.div`
   background: #fff;
   border: 1px solid ${colors.grey};
   border-radius: 0.2em;
-  width: auto;
+  width: 100%;
   min-width: 20em;
   display: inline-block;
   overflow: hidden;
   position: relative;
   margin-bottom: 0.25em;
+  word-wrap: break-word;
 
   ${props => props.error && optionItemError};
 `;

--- a/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -138,7 +138,7 @@ exports[`MultipleChoiceAnswer should render OptionItem 1`] = `
         "rules": Array [
           "font-size:1em;background:#fff;border:1px solid ",
           "#999999",
-          ";border-radius:0.2em;width:auto;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;",
+          ";border-radius:0.2em;width:100%;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
           [Function],
           ";",
         ],
@@ -170,7 +170,7 @@ exports[`MultipleChoiceAnswer should render OptionItem with error 1`] = `
         "rules": Array [
           "font-size:1em;background:#fff;border:1px solid ",
           "#999999",
-          ";border-radius:0.2em;width:auto;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;",
+          ";border-radius:0.2em;width:100%;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
           [Function],
           ";",
         ],

--- a/eq-author/src/components/preview/Answers/elements/Label.js
+++ b/eq-author/src/components/preview/Answers/elements/Label.js
@@ -9,6 +9,7 @@ const Description = styled.div`
   line-height: 1.4;
   margin-top: 0.2em;
   display: block;
+  word-wrap: break-word;
 `;
 
 const Wrapper = styled.label`
@@ -17,6 +18,7 @@ const Wrapper = styled.label`
   font-weight: 600;
   font-size: 1em;
   line-height: 1.4;
+  word-wrap: break-word;
 `;
 
 const Label = ({ description, children }) => (

--- a/eq-author/src/components/preview/Answers/index.js
+++ b/eq-author/src/components/preview/Answers/index.js
@@ -41,6 +41,7 @@ export const answerComponents = {
 
 const AnswerWrapper = styled.div`
   margin-bottom: 1em;
+  word-wrap: break-word;
 `;
 
 export const Answer = ({ answer }) => {

--- a/eq-author/src/components/preview/elements/PageTitle.js
+++ b/eq-author/src/components/preview/elements/PageTitle.js
@@ -7,6 +7,7 @@ import Error from "components/preview/Error";
 const Title = styled.h1`
   font-size: 1.4em;
   margin: 0 0 1em;
+  word-wrap: break-word;
 `;
 
 const PageTitle = ({ title, missingText = "Missing Page Title" }) => {


### PR DESCRIPTION

### What is the context of this PR?

Error occurs in multiple places.

**Introduction preview** - all editible content boxes

**Section Preview** - Section title and section intro titles

**Question Preview** - all different answer types - title, labels and descriptions, and optional checkboxes and radios 

**Question confirmation preview** - Question, +ve and -ve titles and descriptions

This happens in the Preview tab.

If text is really long it probably should be truncated so it doesn't expand out the side of the container

### How to review
Create very long words for titles etc in all of the above places and test that they now word-break as required