### PR TITLE
Fix dates breaking when changing relative position

### DIFF
--- a/eq-author/src/App/page/Design/Validation/DateValidation/PositionPicker.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/PositionPicker.js
@@ -2,9 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { RelativePositionSelect } from "./components";
 
-const RELATIVE_POSITIONS = ["before", "after"];
+const RELATIVE_POSITIONS = ["Before", "After"];
 
-const PositionPicker = ({value, onChange, onUpdate}) =>
+const PositionPicker = ({ value, onChange, onUpdate }) => (
   <RelativePositionSelect
     name="relativePosition"
     value={value}
@@ -14,15 +14,16 @@ const PositionPicker = ({value, onChange, onUpdate}) =>
   >
     {RELATIVE_POSITIONS.map(position => (
       <option key={position} value={position}>
-        {position}
+        {position.toLowerCase()}
       </option>
     ))}
-  </RelativePositionSelect>;
+  </RelativePositionSelect>
+);
 
 PositionPicker.propTypes = {
-    value: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired,
-    onUpdate: PropTypes.func.isRequired
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };
 
 export default PositionPicker;

--- a/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/PositionPicker.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/PositionPicker.test.js.snap
@@ -9,14 +9,14 @@ exports[`Date Position Picker Should render 1`] = `
   value="before"
 >
   <option
-    key="before"
-    value="before"
+    key="Before"
+    value="Before"
   >
     before
   </option>
   <option
-    key="after"
-    value="after"
+    key="After"
+    value="After"
   >
     after
   </option>


### PR DESCRIPTION
### What is the context of this PR?

The position picker for date answers was recently refactored. When re-adding the relative positions we forgot to capitalise them.

This caused the backend to break as it was expecting a capital.

### How to review

1 - Create a questionnaire
2 - Write a question
3 - Add an answer of type Date
4 - Add answer label
5 - On the right sidebar, select either Set earliest date or Set latest date
6 - Switch on the date validation
7 - Change the before value to after
8 - This shouldn't break anything now