### PR TITLE
EAR 1081 - Fix language / region metadata types

### DIFF
--- a/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
@@ -11,7 +11,7 @@ const Select = ({ name, options, value, onChange, onUpdate }) => {
   return (
     <TableSelect name={name} value={value} onChange={handleUpdate}>
       {map(options, (option, index) => (
-        <option key={index} value={option.type}>
+        <option key={index} value={option.value}>
           {option.label}
         </option>
       ))}

--- a/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
@@ -20,7 +20,12 @@ const Select = ({ name, options, value, onChange, onUpdate }) => {
 };
 
 Select.propTypes = {
-  options: PropTypes.arrayOf(PropTypes.oneOf(Object.values(metadataTypes))),
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ),
   name: PropTypes.string.isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,

--- a/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/Select.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import React from "react";
 import { flip, map, partial } from "lodash";
 
-import * as metadataTypes from "constants/metadata-types";
 import { TableSelect } from "components/datatable/Controls";
 
 const Select = ({ name, options, value, onChange, onUpdate }) => {

--- a/eq-author/src/App/metadata/MetadataTable/Controls/Select.test.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/Select.test.js
@@ -12,15 +12,15 @@ describe("Select", () => {
       options: [
         {
           label: "Option A",
-          type: "opt_a",
+          value: "opt_a",
         },
         {
           label: "Option B",
-          type: "opt_b",
+          value: "opt_b",
         },
         {
           label: "Option C",
-          type: "opt_c",
+          value: "opt_c",
         },
       ],
       name: "test",

--- a/eq-author/src/App/metadata/MetadataTable/Row.js
+++ b/eq-author/src/App/metadata/MetadataTable/Row.js
@@ -68,7 +68,7 @@ export class StatelessRow extends Component {
           />
         </TableColumn>
         <TableColumn>
-          {(type === TEXT.type || type === TEXT_OPTIONAL.type) && (
+          {(type === TEXT.value || type === TEXT_OPTIONAL.value) && (
             <TableInput
               onChange={onChange}
               onBlur={onUpdate}
@@ -76,7 +76,7 @@ export class StatelessRow extends Component {
               name="textValue"
             />
           )}
-          {type === DATE.type && (
+          {type === DATE.value && (
             <TableInputDate
               onChange={onChange}
               onBlur={onUpdate}
@@ -85,7 +85,7 @@ export class StatelessRow extends Component {
               type="date"
             />
           )}
-          {type === REGION.type && (
+          {type === REGION.value && (
             <Select
               onChange={onChange}
               onUpdate={onUpdate}
@@ -94,7 +94,7 @@ export class StatelessRow extends Component {
               name="regionValue"
             />
           )}
-          {type === LANGUAGE.type && (
+          {type === LANGUAGE.value && (
             <Select
               onChange={onChange}
               onUpdate={onUpdate}

--- a/eq-author/src/App/metadata/MetadataTable/__snapshots__/Row.test.js.snap
+++ b/eq-author/src/App/metadata/MetadataTable/__snapshots__/Row.test.js.snap
@@ -30,23 +30,23 @@ exports[`MetadataTable should correctly render different types of metadata 1`] =
         Array [
           Object {
             "label": "Text",
-            "type": "Text",
+            "value": "Text",
           },
           Object {
             "label": "Text (Optional)",
-            "type": "Text_Optional",
+            "value": "Text_Optional",
           },
           Object {
             "label": "Date",
-            "type": "Date",
+            "value": "Date",
           },
           Object {
             "label": "Language",
-            "type": "Language",
+            "value": "Language",
           },
           Object {
             "label": "Region",
-            "type": "Region",
+            "value": "Region",
           },
         ]
       }
@@ -101,23 +101,23 @@ exports[`MetadataTable should correctly render different types of metadata 2`] =
         Array [
           Object {
             "label": "Text",
-            "type": "Text",
+            "value": "Text",
           },
           Object {
             "label": "Text (Optional)",
-            "type": "Text_Optional",
+            "value": "Text_Optional",
           },
           Object {
             "label": "Date",
-            "type": "Date",
+            "value": "Date",
           },
           Object {
             "label": "Language",
-            "type": "Language",
+            "value": "Language",
           },
           Object {
             "label": "Region",
-            "type": "Region",
+            "value": "Region",
           },
         ]
       }
@@ -173,23 +173,23 @@ exports[`MetadataTable should correctly render different types of metadata 3`] =
         Array [
           Object {
             "label": "Text",
-            "type": "Text",
+            "value": "Text",
           },
           Object {
             "label": "Text (Optional)",
-            "type": "Text_Optional",
+            "value": "Text_Optional",
           },
           Object {
             "label": "Date",
-            "type": "Date",
+            "value": "Date",
           },
           Object {
             "label": "Language",
-            "type": "Language",
+            "value": "Language",
           },
           Object {
             "label": "Region",
-            "type": "Region",
+            "value": "Region",
           },
         ]
       }
@@ -203,11 +203,26 @@ exports[`MetadataTable should correctly render different types of metadata 3`] =
       onUpdate={[MockFunction]}
       options={
         Array [
-          "GB_ENG",
-          "GB_GBN",
-          "GB_NIR",
-          "GB_SCT",
-          "GB_WLS",
+          Object {
+            "label": "GB_ENG",
+            "value": "GB_ENG",
+          },
+          Object {
+            "label": "GB_GBN",
+            "value": "GB_GBN",
+          },
+          Object {
+            "label": "GB_NIR",
+            "value": "GB_NIR",
+          },
+          Object {
+            "label": "GB_SCT",
+            "value": "GB_SCT",
+          },
+          Object {
+            "label": "GB_WLS",
+            "value": "GB_WLS",
+          },
         ]
       }
       value="GB_ENG"
@@ -253,23 +268,23 @@ exports[`MetadataTable should correctly render different types of metadata 4`] =
         Array [
           Object {
             "label": "Text",
-            "type": "Text",
+            "value": "Text",
           },
           Object {
             "label": "Text (Optional)",
-            "type": "Text_Optional",
+            "value": "Text_Optional",
           },
           Object {
             "label": "Date",
-            "type": "Date",
+            "value": "Date",
           },
           Object {
             "label": "Language",
-            "type": "Language",
+            "value": "Language",
           },
           Object {
             "label": "Region",
-            "type": "Region",
+            "value": "Region",
           },
         ]
       }
@@ -283,8 +298,14 @@ exports[`MetadataTable should correctly render different types of metadata 4`] =
       onUpdate={[MockFunction]}
       options={
         Array [
-          "en",
-          "cy",
+          Object {
+            "label": "en",
+            "value": "en",
+          },
+          Object {
+            "label": "cy",
+            "value": "cy",
+          },
         ]
       }
       value="cy"
@@ -330,23 +351,23 @@ exports[`MetadataTable should render 1`] = `
         Array [
           Object {
             "label": "Text",
-            "type": "Text",
+            "value": "Text",
           },
           Object {
             "label": "Text (Optional)",
-            "type": "Text_Optional",
+            "value": "Text_Optional",
           },
           Object {
             "label": "Date",
-            "type": "Date",
+            "value": "Date",
           },
           Object {
             "label": "Language",
-            "type": "Language",
+            "value": "Language",
           },
           Object {
             "label": "Region",
-            "type": "Region",
+            "value": "Region",
           },
         ]
       }

--- a/eq-author/src/constants/languages.js
+++ b/eq-author/src/constants/languages.js
@@ -1,2 +1,9 @@
-export const EN = "en";
-export const CY = "cy";
+export const EN = {
+  label: "en",
+  value: "en",
+};
+
+export const CY = {
+  label: "cy",
+  value: "cy",
+};

--- a/eq-author/src/constants/metadata-types.js
+++ b/eq-author/src/constants/metadata-types.js
@@ -1,26 +1,26 @@
 const DATE = {
   label: "Date",
-  type: "Date",
+  value: "Date",
 };
 
 const TEXT = {
   label: "Text",
-  type: "Text",
+  value: "Text",
 };
 
 const TEXT_OPTIONAL = {
   label: "Text (Optional)",
-  type: "Text_Optional",
+  value: "Text_Optional",
 };
 
 const LANGUAGE = {
   label: "Language",
-  type: "Language",
+  value: "Language",
 };
 
 const REGION = {
   label: "Region",
-  type: "Region",
+  value: "Region",
 };
 
 export { DATE, TEXT, TEXT_OPTIONAL, LANGUAGE, REGION };

--- a/eq-author/src/constants/regions.js
+++ b/eq-author/src/constants/regions.js
@@ -1,5 +1,24 @@
-export const GB_ENG = "GB_ENG";
-export const GB_GBN = "GB_GBN";
-export const GB_NIR = "GB_NIR";
-export const GB_SCT = "GB_SCT";
-export const GB_WLS = "GB_WLS";
+export const GB_ENG = {
+  label: "GB_ENG",
+  value: "GB_ENG",
+};
+
+export const GB_GBN = {
+  label: "GB_GBN",
+  value: "GB_GBN",
+};
+
+export const GB_NIR = {
+  label: "GB_NIR",
+  value: "GB_NIR",
+};
+
+export const GB_SCT = {
+  label: "GB_SCT",
+  value: "GB_SCT",
+};
+
+export const GB_WLS = {
+  label: "GB_WLS",
+  value: "GB_WLS",
+};

--- a/eq-author/src/custom-prop-types/index.js
+++ b/eq-author/src/custom-prop-types/index.js
@@ -20,7 +20,7 @@ const CustomPropTypes = {
     id: PropTypes.string.isRequired,
     alias: PropTypes.string,
     key: PropTypes.string,
-    type: PropTypes.oneOf(Object.values(metadataTypes).map(type => type.type)),
+    type: PropTypes.oneOf(Object.values(metadataTypes).map(type => type.value)),
     languageValue: PropTypes.string,
     regionValue: PropTypes.string,
     textValue: PropTypes.string,


### PR DESCRIPTION
### What is the context of this PR?

Choosing language / region metadata types in Author (staging / pre-prod) broke the UI, showing an empty drop-down menu for value selection. Choosing one of these blank options broke the API.

This was a consequence of a previous change I made for adding the `Text (Optional)` type - labels are now de-coupled from the back-end recognised values in the `Select` element but I neglected to update the region / language constants files accordingly.

This PR fixes the issue (NB - we have the option now of changing the labels for the constant types to more human readable wants if we want - e.g. `GB_ENG` could become "England" without affecting the back-end code. I've left it how it is for now though).

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1081)

### How to review

- Open the metadata editor
- Choose a "Region" or "Language" type metadata item
- Should be able to set its value to one of the pre-defined values

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
