### PR TITLE
Ear 297 long question titles cut off

### DIFF
--- a/eq-author/src/components/EditorLayout/Header/PageTitle.js
+++ b/eq-author/src/components/EditorLayout/Header/PageTitle.js
@@ -17,7 +17,9 @@ const Title = styled.h1`
   margin: 0;
   width: 100%;
   line-height: 1.3;
-  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const PageTitle = ({ children }) => (

--- a/eq-author/src/components/EditorLayout/Header/PageTitle.js
+++ b/eq-author/src/components/EditorLayout/Header/PageTitle.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 
 import styled from "styled-components";
 import { colors } from "constants/theme";
-import Truncated from "components/Truncated";
 
 const Wrapper = styled.div`
   display: flex;

--- a/eq-author/src/components/EditorLayout/Header/PageTitle.js
+++ b/eq-author/src/components/EditorLayout/Header/PageTitle.js
@@ -8,8 +8,6 @@ import Truncated from "components/Truncated";
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  overflow: hidden;
-  white-space: pre;
   color: ${colors.white};
   padding: 0 1.5em 1em;
 `;
@@ -20,13 +18,12 @@ const Title = styled.h1`
   margin: 0;
   width: 100%;
   line-height: 1.3;
+  word-break: break-word;
 `;
 
 const PageTitle = ({ children }) => (
   <Wrapper>
-    <Truncated>
       <Title data-test="questionnaire-title">{children}&nbsp;</Title>
-    </Truncated>
   </Wrapper>
 );
 

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -14241,7 +14241,7 @@ react-router@latest:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-sizeme@^2.6.7:
+react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
   integrity sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==


### PR DESCRIPTION
### What is the context of this PR?

Long question titles get cut off in the blue bar at the top of the page.
This is for Questions, sections, Confirmation pages and Calc summary pages
Also for both design and preview

I've taken out the 'truncated' class and added a simple ellipsis, after chatting with Joe

### How to review

make sure long titles are now wrapping in all the above places