### PR TITLE
EAR-565 Add spacing when additional guidance panel is closed

### DIFF
--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -30,7 +30,9 @@ exports[`IntroductionEditor should render 1`] = `
         testSelector="txt-intro-title"
         value="title"
       />
-      <IntroductionEditor__InlineField>
+      <IntroductionEditor__InlineField
+        open={false}
+      >
         <Label
           bold={true}
         >

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -60,8 +60,7 @@ const descriptionControls = {
 const InlineField = styled(Field)`
   display: flex;
   align-items: center;
-  margin-bottom: 0.4em;
-
+  margin-bottom: ${props => (props.open ? "0.4em" : "2em")};
   > * {
     margin-bottom: 0;
   }
@@ -109,7 +108,7 @@ export const IntroductionEditor = ({
             testSelector="txt-intro-title"
           />
 
-          <InlineField>
+          <InlineField open={additionalGuidancePanelSwitch}>
             <Label>Additional guidance panel</Label>
 
             <ToggleSwitch


### PR DESCRIPTION
### What is the context of this PR?

Added space between `additional guidance panel` and `Description` when the additional guidance panel is closed.

### How to review
1. Check the spacing between the above is 2em when the agp is closed