### PR TITLE
calc sum page - focus on page title when new

### DIFF
--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/index.test.js.snap
@@ -64,7 +64,7 @@ exports[`CalculatedSummaryPageEditor should display the correct error message wh
           "Variables",
         ]
       }
-      autoFocus={false}
+      autoFocus={true}
       controls={
         Object {
           "emphasis": true,
@@ -217,7 +217,7 @@ exports[`CalculatedSummaryPageEditor should display the correct error message wh
           "Variables",
         ]
       }
-      autoFocus={false}
+      autoFocus={true}
       controls={
         Object {
           "emphasis": true,
@@ -370,7 +370,7 @@ exports[`CalculatedSummaryPageEditor should display the correct error message wh
           "Variables",
         ]
       }
-      autoFocus={false}
+      autoFocus={true}
       controls={
         Object {
           "emphasis": true,
@@ -516,7 +516,7 @@ exports[`CalculatedSummaryPageEditor should render 1`] = `
           "Variables",
         ]
       }
-      autoFocus={false}
+      autoFocus={true}
       controls={
         Object {
           "emphasis": true,

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -113,6 +113,7 @@ export const CalculatedSummaryPageEditor = props => {
           allowableTypes={[ANSWER, METADATA, VARIABLES]}
           defaultTab="variables"
           errorValidationMsg={ErrorMsg()}
+          autoFocus={!page.title}
         />
         <div>
           <SelectorTitle>Answers to calculate</SelectorTitle>


### PR DESCRIPTION
### What is the context of this PR?

Acceptance criteria (user perspective)
GIVEN I am authoring a survey
WHEN I create a new calculated summary page
THEN the "Page title" box is focussed

https://collaborate2.ons.gov.uk/jira/browse/EAR-211

### How to review

