### PR TITLE
EAR-678-DateRange-label-validation

### DIFF
--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -870,6 +870,9 @@
           "secondaryQCode": {
             "$ref": "definitions.json#/definitions/populatedString"
           },
+          "secondaryLabel": {
+            "$ref": "definitions.json#/definitions/populatedString"
+          },
           "validation": {
             "allOf": [
               {

--- a/eq-author/src/App/page/Design/answers/Date/index.js
+++ b/eq-author/src/App/page/Design/answers/Date/index.js
@@ -61,7 +61,7 @@ export const UnwrappedDate = ({
         data-autofocus
         bold
         errorValidationMsg={getValidationError({
-          field: "label",
+          field: name,
           label: errorLabel,
           requiredMsg: DATE_LABEL_REQUIRED,
         })}

--- a/eq-author/src/App/page/Design/answers/DateRange/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/DateRange/__snapshots__/index.test.js.snap
@@ -7,18 +7,20 @@ exports[`DateRange should render 1`] = `
   <Connect(withEntityEditor(withValidationError(UnwrappedDate)))
     answer={
       Object {
-        "childAnswers": Array [
-          Object {
-            "id": "1from",
-            "label": "Period from",
-          },
-          Object {
-            "id": "1to",
-            "label": "Period to",
-          },
-        ],
+        "description": "test",
+        "displayName": "Untitled answer",
+        "guidance": "",
         "id": "1",
-        "label": "Lorem ipsum",
+        "label": "",
+        "properties": Object {
+          "required": false,
+        },
+        "qCode": "yuky",
+        "secondaryLabel": "",
+        "type": "DateRange",
+        "validationErrorInfo": Object {
+          "errors": Array [],
+        },
       }
     }
     key="from-1"
@@ -39,18 +41,20 @@ exports[`DateRange should render 1`] = `
   <Connect(withEntityEditor(withValidationError(UnwrappedDate)))
     answer={
       Object {
-        "childAnswers": Array [
-          Object {
-            "id": "1from",
-            "label": "Period from",
-          },
-          Object {
-            "id": "1to",
-            "label": "Period to",
-          },
-        ],
+        "description": "test",
+        "displayName": "Untitled answer",
+        "guidance": "",
         "id": "1",
-        "label": "Lorem ipsum",
+        "label": "",
+        "properties": Object {
+          "required": false,
+        },
+        "qCode": "yuky",
+        "secondaryLabel": "",
+        "type": "DateRange",
+        "validationErrorInfo": Object {
+          "errors": Array [],
+        },
       }
     }
     key="to-1"

--- a/eq-author/src/App/page/Design/answers/DateRange/index.test.js
+++ b/eq-author/src/App/page/Design/answers/DateRange/index.test.js
@@ -2,25 +2,34 @@ import React from "react";
 import { shallow } from "enzyme";
 import DateRange from "./";
 import createMockStore from "tests/utils/createMockStore";
-
-const answer = {
-  id: "1",
-  label: "Lorem ipsum",
-  childAnswers: [
-    { id: "1from", label: "Period from" },
-    { id: "1to", label: "Period to" },
-  ],
-};
+import { DATE_LABEL_REQUIRED } from "constants/validationMessages";
+import { render as rtlRender } from "tests/utils/rtl";
 
 describe("DateRange", () => {
-  let handleChange;
-  let handleUpdate;
-  let store;
+  let handleChange, handleUpdate, store, props;
 
   beforeEach(() => {
     handleChange = jest.fn();
     handleUpdate = jest.fn();
     store = createMockStore();
+
+    props = {
+      answer: {
+        id: "1",
+        label: "",
+        type: "DateRange",
+        description: "test",
+        guidance: "",
+        secondaryLabel: "",
+        properties: {required: false},
+        displayName: "Untitled answer",
+        qCode: "yuky",
+        validationErrorInfo:
+        {
+          errors: [],
+        },
+      },
+    };
   });
 
   it("should render", () => {
@@ -28,10 +37,45 @@ describe("DateRange", () => {
       <DateRange
         onChange={handleChange}
         onUpdate={handleUpdate}
-        answer={answer}
+        answer={props.answer}
         store={store}
       />
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("should render an error message when date label input is empty", () => {
+    const error = [
+      {
+        errorCode: "ERR_VALID_REQUIRED",
+        field: "label",
+        id: "71b5f8a2-5de1-4a9a-8923-acd7fd3b7080",
+        type: "answer",
+        __typename: "ValidationError",
+      },
+    ];
+    props.answer.validationErrorInfo.errors = error;
+
+    const { getAllByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
+
+    expect(getAllByText(DATE_LABEL_REQUIRED)).toBeTruthy();
+  });
+
+  it("should render an error message when date secondarylabel input is empty", () => {
+    const error = [
+      {
+        errorCode: "ERR_VALID_REQUIRED",
+        field: "secondaryLabel",
+        id: "71b5f8a2-5de1-4a9a-8923-acd7fd3b7081",
+        type: "answer",
+        __typename: "ValidationError",
+      },
+    ];
+    props.answer.validationErrorInfo.errors = error;
+
+    const { getAllByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
+
+    expect(getAllByText(DATE_LABEL_REQUIRED)).toBeTruthy();
+  });
+
 });

--- a/eq-author/src/App/page/Design/answers/DateRange/index.test.js
+++ b/eq-author/src/App/page/Design/answers/DateRange/index.test.js
@@ -56,9 +56,9 @@ describe("DateRange", () => {
     ];
     props.answer.validationErrorInfo.errors = error;
 
-    const { getAllByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
+    const { getByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
 
-    expect(getAllByText(DATE_LABEL_REQUIRED)).toBeTruthy();
+    expect(getByText(DATE_LABEL_REQUIRED)).toBeTruthy();
   });
 
   it("should render an error message when date secondarylabel input is empty", () => {
@@ -73,9 +73,9 @@ describe("DateRange", () => {
     ];
     props.answer.validationErrorInfo.errors = error;
 
-    const { getAllByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
+    const { getByText } = rtlRender(<DateRange onUpdate={handleUpdate} {...props} />);
 
-    expect(getAllByText(DATE_LABEL_REQUIRED)).toBeTruthy();
+    expect(getByText(DATE_LABEL_REQUIRED)).toBeTruthy();
   });
 
 });


### PR DESCRIPTION
### What is the context of this PR?

https://collaborate2.ons.gov.uk/jira/browse/EAR-678

'from' and 'to' date labels in DateRange answer type are not validating missing labels correctly

Enter a date label' - Error shows for the 2nd date label when the From date is missing a label - Even though TO date HAS a label.
If the 1st (from) date label has a label, but not the TO date - then no error is shown - it should show TO date as missing a label

### How to review

**Wrong behaviour (1)**
Create a question with a date range answer type
Fill out the first date label field
The error on the second box disappears 

**Expected behaviour (1)**
Create a question with a date range answer type
Fill out the first date label field
The error on the second box shouldn't disappear 

**Wrong behaviour (2)**
Create a question with a date range answer type
Fill out the second date label field
The error remains on the second box disappears 

**Expected behaviour (2)**
Create a question with a date range answer type
Fill out the first date label field
The error on the second box should NOT disappear 

