### PR TITLE
EAR 1090 - Fix BICS qCode UI validation for Radios

### DIFF
--- a/eq-author-api/src/validation/schemas/entities.json
+++ b/eq-author-api/src/validation/schemas/entities.json
@@ -1165,9 +1165,6 @@
             "id",
             "label"
           ]
-        },
-        "qCode": {
-          "$ref": "definitions.json#/definitions/populatedString"
         }
       },
       "required": [


### PR DESCRIPTION
### What is the context of this PR?

Removes qCode validation from options schema so Radio answers pass validation with qCodes on the answer alone (as they should).

Only checkbox options have qCodes - and the AJV schema already checks these separately.

Fixes UI issue where qCode validation errors are shown on [BICS in Author](https://author.ons.gov.uk/#/q/87b40b66-1cb8-4176-8d5a-aa433237c413/qcodes)

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1090)

### How to review

- Import [this survey](https://author.ons.gov.uk/#/q/87b40b66-1cb8-4176-8d5a-aa433237c413/qcodes)
- Check out the qCodes page locally
- Radio answers with valid qCodes should have no visible validation errors

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
