### PR TITLE
EAR 1110 (fix) - 🛠 MovePageModal: check questionnaire exists

### DIFF
--- a/eq-author/src/App/page/Design/MovePageModal/index.js
+++ b/eq-author/src/App/page/Design/MovePageModal/index.js
@@ -89,45 +89,47 @@ const MovePageModal = ({ sectionId, page, isOpen, onClose, onMovePage }) => {
 
   const sectionButtonId = uniqueId("MovePageModal");
   const selectedSection = useMemo(
-    () => find(questionnaire.sections, { id: selectedSectionId }),
+    () =>
+      questionnaire && find(questionnaire.sections, { id: selectedSectionId }),
     [questionnaire, selectedSectionId]
   );
 
   return useMemo(
-    () => (
-      <MoveModal title={"Move question"} isOpen={isOpen} onClose={onClose}>
-        <Label htmlFor={sectionButtonId}>Section</Label>
-        <Trigger id={sectionButtonId} onClick={handleOpenSectionSelect}>
-          <Truncated>{selectedSection.displayName}</Truncated>
-        </Trigger>
-        <ItemSelectModal
-          title="Section"
-          data-test={"section-select-modal"}
-          isOpen={isSectionSelectOpen}
-          onClose={handleCloseSectionSelect}
-          onConfirm={handleSectionConfirm}
-        >
-          <ItemSelect
-            data-test="section-item-select"
-            name="section"
-            value={selectedSection.id}
-            onChange={handleSectionChange}
+    () =>
+      questionnaire ? (
+        <MoveModal title={"Move question"} isOpen={isOpen} onClose={onClose}>
+          <Label htmlFor={sectionButtonId}>Section</Label>
+          <Trigger id={sectionButtonId} onClick={handleOpenSectionSelect}>
+            <Truncated>{selectedSection.displayName}</Truncated>
+          </Trigger>
+          <ItemSelectModal
+            title="Section"
+            data-test={"section-select-modal"}
+            isOpen={isSectionSelectOpen}
+            onClose={handleCloseSectionSelect}
+            onConfirm={handleSectionConfirm}
           >
-            {questionnaire.sections.map(section => (
-              <Option key={section.id} value={section.id}>
-                {section.displayName}
-              </Option>
-            ))}
-          </ItemSelect>
-        </ItemSelectModal>
-        <PositionModal
-          data-test={"page-position-modal"}
-          options={selectedSection.folders.flatMap(({ pages }) => pages)}
-          onMove={handlePageMove}
-          selected={page}
-        />
-      </MoveModal>
-    ),
+            <ItemSelect
+              data-test="section-item-select"
+              name="section"
+              value={selectedSection.id}
+              onChange={handleSectionChange}
+            >
+              {questionnaire.sections.map(section => (
+                <Option key={section.id} value={section.id}>
+                  {section.displayName}
+                </Option>
+              ))}
+            </ItemSelect>
+          </ItemSelectModal>
+          <PositionModal
+            data-test={"page-position-modal"}
+            options={selectedSection.folders.flatMap(({ pages }) => pages)}
+            onMove={handlePageMove}
+            selected={page}
+          />
+        </MoveModal>
+      ) : null,
     [selectedSection, questionnaire, page, isOpen, isSectionSelectOpen]
   );
 };

--- a/eq-author/src/App/page/Design/MovePageModal/index.test.js
+++ b/eq-author/src/App/page/Design/MovePageModal/index.test.js
@@ -72,3 +72,23 @@ describe("MovePageModal", () => {
     );
   });
 });
+
+describe("MovePageModal: questionnaire not loaded", () => {
+  it("shouldn't render if questionnaire not yet available", () => {
+    useQuestionnaire.mockImplementation(() => ({
+      questionnaire: undefined,
+    }));
+
+    const wrapper = shallow(
+      <MovePageModal
+        isOpen
+        onClose={jest.fn()}
+        sectionId={null}
+        page={null}
+        onMovePage={jest.fn()}
+      />
+    );
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

Don't render MovePageModal if questionnaire hasn't been loaded into context provider yet.

Intended to fix GCP staging issue which occurs on duplicating questionnaires - the questionnaire context starts as undefined, causing section lookup to fail. Can't reproduce this locally and it seems to work on AWS, so not sure why it's GCP-specific.

This PR add guards around the questionnaire object in MovePageModal.

### How to review

- Make sure you can still duplicate questionnaires & move pages.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
