### PR TITLE
Removed optional fields for Cal Sum page

### DIFF
--- a/eq-author/src/App/page/Design/index.js
+++ b/eq-author/src/App/page/Design/index.js
@@ -90,7 +90,9 @@ export class UnwrappedPageRoute extends React.Component {
     return (
       <EditorLayout
         onAddQuestionPage={this.handleAddPage}
-        renderPanel={() => <PropertiesPanel page={page} />}
+        renderPanel={() =>
+          page.pageType === "QuestionPage" && <PropertiesPanel page={page} />
+        }
         title={(page || {}).displayName || ""}
         {...deriveAvailableTabs(page)}
         validationErrorInfo={page && page.validationErrorInfo}


### PR DESCRIPTION
### What is the context of this PR?

> Check optional fields are not shown for Calculated Summary pages
>

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
