### PR TITLE
EAR-1124-Fix unit type selection

### DIFF
--- a/eq-author/src/components/Autocomplete/index.js
+++ b/eq-author/src/components/Autocomplete/index.js
@@ -119,6 +119,7 @@ const Autocomplete = ({
       const clickedElement = event.currentTarget;
       setSelectedOption(clickedElement.innerText);
       updateOption(clickedElement);
+      setQuery("");
     },
     [selectedIndex, isOpen]
   );
@@ -245,7 +246,7 @@ const Autocomplete = ({
           </ListItem>
         );
       }),
-    [query, options, filterOptions, categories]
+    [query, options, filterOptions, categories, handleClick, selectedOption]
   );
 
   return (

--- a/eq-author/src/components/Autocomplete/index.test.js
+++ b/eq-author/src/components/Autocomplete/index.test.js
@@ -257,7 +257,7 @@ describe("components/Autocomplete", () => {
 
     expect(getByTestId(inputId)).toHaveAttribute(
       "aria-activedescendant",
-      "autocomplete-input"
+      "false"
     );
   });
 


### PR DESCRIPTION
### What is the context of this PR?

The unit type selector was persistent across different pages. This meant you could save a type on one page and it would save it in another instead

Handy video courtesy of @farres1 
https://user-images.githubusercontent.com/22731314/106477516-25673d80-64a0-11eb-8e58-9f5eac953c6a.mov

### How to review
- Create a questionnaire
- Create 3 or 4 questions with unit answers
- Should be able to assign unique types to each answer
- Should add/remove error messages consistently
