### PR TITLE
EAR 1085 Fix issue where long questionnaire title has no spaces

### DIFF
--- a/eq-author/src/components/EditorLayout/Header/index.js
+++ b/eq-author/src/components/EditorLayout/Header/index.js
@@ -30,6 +30,9 @@ const Flex = styled.div`
 
 const Subtitle = styled.div`
   font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export const UtilityBtns = styled.div`


### PR DESCRIPTION
### What is the context of this PR?

Fixes an issue where a long questionnaire title without spaces is cut off the page, causing the page to be extended

Replaces the error to use ellipses, preventing the text from being cut off the page 
