### PR TITLE
Remove if preventing dependabot prs building

### DIFF
--- a/.github/workflows/apiPullRequest.yml
+++ b/.github/workflows/apiPullRequest.yml
@@ -37,8 +37,6 @@ jobs:
           fail_ci_if_error: true
 
   Build:
-    if: contains( github.event.pull_request.labels.*.name, 'dependencies') != true
-
     runs-on: ubuntu-latest
 
     needs: Tests

--- a/.github/workflows/authorPullRequest.yml
+++ b/.github/workflows/authorPullRequest.yml
@@ -37,8 +37,6 @@ jobs:
           fail_ci_if_error: true
 
   Build:
-    if: contains( github.event.pull_request.labels.*.name, 'dependencies') != true
-
     runs-on: ubuntu-latest
 
     needs: Tests

--- a/.github/workflows/publisherPullRequest.yml
+++ b/.github/workflows/publisherPullRequest.yml
@@ -37,8 +37,6 @@ jobs:
           fail_ci_if_error: true
 
   Build:
-    if: contains( github.event.pull_request.labels.*.name, 'dependencies') != true
-
     runs-on: ubuntu-latest
 
     needs: Tests


### PR DESCRIPTION
### What is the context of this PR?

Didn't take off the condition that stops dependabot prs from building

EDIT: we aren't going to use dependabot stuff with docker tags

### How to review

Check in the github action log that the most recent commit is the one tagged for docker 
