### PR TITLE
🛠 EAR 1179 - update folder positions on creation

### DIFF
--- a/eq-author/src/graphql/createFolder.graphql
+++ b/eq-author/src/graphql/createFolder.graphql
@@ -8,6 +8,7 @@ mutation CreateFolder($input: CreateFolderInput!) {
       id
       folders {
         id
+        position
         pages {
           ...Page
           position
@@ -26,7 +27,7 @@ mutation CreateFolder($input: CreateFolderInput!) {
             id
           }
           validationErrorInfo {
-              ...ValidationErrorInfo
+            ...ValidationErrorInfo
           }
         }
       }


### PR DESCRIPTION
### What is the context of this PR?

Update folder positions once new folders are created.

Fixes bug where folders would have stale positions in cache and folders added whilst those were focused would be added to the incorrect position (earlier than the target folder).

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1179)

### How to review

To reproduce existing bug on staging:
- Create a series of folders
- Create a few new folders in the middle of the series
- Targetting one of the later folders produced during step 1, add a folder
- It will go in the wrong position (earlier than expected)

Run through the same thing on this branch and the bug should be gone.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
