### PR TITLE
🛠 EAR 1180 - Fix adding folders to q. confirmation

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -67,10 +67,10 @@ const MainNav = styled.div`
   background-color: ${colors.darkerBlack};
 `;
 
-export const getSections = questionnaire => questionnaire.sections;
-export const getFolders = questionnaire =>
+export const getSections = (questionnaire) => questionnaire.sections;
+export const getFolders = (questionnaire) =>
   flatMap(getSections(questionnaire), ({ folders }) => folders);
-export const getPages = questionnaire =>
+export const getPages = (questionnaire) =>
   flatMap(getFolders(questionnaire), ({ pages }) => pages);
 
 export const getFolderById = (questionnaire, folderId) =>
@@ -134,7 +134,7 @@ export const UnwrappedQuestionnaireDesignPage = ({
 
   const getTitle = () => (loading ? "" : questionnaire.title);
 
-  const handleAddPage = pageType => () => {
+  const handleAddPage = (pageType) => () => {
     const { entityName, entityId } = match.params;
 
     let sectionId, position, selectedPage, selectedSection, selectedFolder;
@@ -354,8 +354,8 @@ const withMutations = flowRight(
   withCreateFolder
 );
 
-export const withQuestionnaire = Component => {
-  const WrappedComponent = props => (
+export const withQuestionnaire = (Component) => {
+  const WrappedComponent = (props) => (
     <Query
       query={QUESTIONNAIRE_QUERY}
       variables={{
@@ -366,7 +366,7 @@ export const withQuestionnaire = Component => {
       fetchPolicy="network-only"
       errorPolicy="all"
     >
-      {innerProps => (
+      {(innerProps) => (
         <Component
           {...innerProps}
           {...props}
@@ -388,8 +388,8 @@ export const withQuestionnaire = Component => {
   return WrappedComponent;
 };
 
-export const withAuthCheck = Component => {
-  const WrappedComponent = props => {
+export const withAuthCheck = (Component) => {
+  const WrappedComponent = (props) => {
     if (
       get(props, "error.networkError.bodyText") ===
       ERR_UNAUTHORIZED_QUESTIONNAIRE
@@ -505,13 +505,13 @@ export const VALIDATION_QUERY = gql`
   ${ValidationErrorInfo}
 `;
 
-export const withValidations = Component => {
-  const WrappedComponent = props => (
+export const withValidations = (Component) => {
+  const WrappedComponent = (props) => (
     <Subscription
       subscription={VALIDATION_QUERY}
       variables={{ id: props.match.params.questionnaireId }}
     >
-      {subscriptionProps => (
+      {(subscriptionProps) => (
         <Component
           {...props}
           validations={get(subscriptionProps, "data.validationUpdated")}

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -67,10 +67,10 @@ const MainNav = styled.div`
   background-color: ${colors.darkerBlack};
 `;
 
-export const getSections = (questionnaire) => questionnaire.sections;
-export const getFolders = (questionnaire) =>
+export const getSections = questionnaire => questionnaire.sections;
+export const getFolders = questionnaire =>
   flatMap(getSections(questionnaire), ({ folders }) => folders);
-export const getPages = (questionnaire) =>
+export const getPages = questionnaire =>
   flatMap(getFolders(questionnaire), ({ pages }) => pages);
 
 export const getFolderById = (questionnaire, folderId) =>
@@ -86,7 +86,7 @@ export const getSectionByPageId = (questionnaire, id) =>
 export const getPageById = (questionnaire, id) =>
   find(getPages(questionnaire), { id });
 export const getPageByConfirmationId = (questionnaire, id) =>
-  find(getPages(questionnaire), ({ confirmation }) => confirmation.id === id);
+  find(getPages(questionnaire), ({ confirmation }) => confirmation?.id === id);
 
 export const UnwrappedQuestionnaireDesignPage = ({
   onAddSection,
@@ -134,7 +134,7 @@ export const UnwrappedQuestionnaireDesignPage = ({
 
   const getTitle = () => (loading ? "" : questionnaire.title);
 
-  const handleAddPage = (pageType) => () => {
+  const handleAddPage = pageType => () => {
     const { entityName, entityId } = match.params;
 
     let sectionId, position, selectedPage, selectedSection, selectedFolder;
@@ -354,8 +354,8 @@ const withMutations = flowRight(
   withCreateFolder
 );
 
-export const withQuestionnaire = (Component) => {
-  const WrappedComponent = (props) => (
+export const withQuestionnaire = Component => {
+  const WrappedComponent = props => (
     <Query
       query={QUESTIONNAIRE_QUERY}
       variables={{
@@ -366,7 +366,7 @@ export const withQuestionnaire = (Component) => {
       fetchPolicy="network-only"
       errorPolicy="all"
     >
-      {(innerProps) => (
+      {innerProps => (
         <Component
           {...innerProps}
           {...props}
@@ -388,8 +388,8 @@ export const withQuestionnaire = (Component) => {
   return WrappedComponent;
 };
 
-export const withAuthCheck = (Component) => {
-  const WrappedComponent = (props) => {
+export const withAuthCheck = Component => {
+  const WrappedComponent = props => {
     if (
       get(props, "error.networkError.bodyText") ===
       ERR_UNAUTHORIZED_QUESTIONNAIRE
@@ -505,13 +505,13 @@ export const VALIDATION_QUERY = gql`
   ${ValidationErrorInfo}
 `;
 
-export const withValidations = (Component) => {
-  const WrappedComponent = (props) => (
+export const withValidations = Component => {
+  const WrappedComponent = props => (
     <Subscription
       subscription={VALIDATION_QUERY}
       variables={{ id: props.match.params.questionnaireId }}
     >
-      {(subscriptionProps) => (
+      {subscriptionProps => (
         <Component
           {...props}
           validations={get(subscriptionProps, "data.validationUpdated")}


### PR DESCRIPTION
### What is the context of this PR?

Fixes adding folders to question confirmation pages within folders.

Add guard to `confirmation.id` in `getPageByConfirmationId` - previous error occurred when `page.confirmation` was `undefined`.

[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1180)

### How to review

- Try and add a Folder when focused on a question confirmation page within a folder
- Shouldn't crash

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
