### PR TITLE
EAR-1174-align-validation-dots

### DIFF
--- a/eq-author/src/components/Badge/index.js
+++ b/eq-author/src/components/Badge/index.js
@@ -13,6 +13,7 @@ export const navBadge = css`
   padding: 0.2em 0.4em;
   height: 20px;
   display: ${(props) => (props.small ? `inline-flex` : ``)};
+  margin-right: ${(props) => (props.small ? `0.3em` : ``)};
 `;
 
 export const mainNavBadge = css`


### PR DESCRIPTION
### What is the context of this PR?

Error dots in the navigation bar were mis-aligned as in the image.

![image](https://user-images.githubusercontent.com/15129656/109189602-1cf6df80-778c-11eb-93d8-bf34547e826d.png)

This PR fixes this.

### How to review

Make sure the error dots are aligned, like in this photo:

![image](https://user-images.githubusercontent.com/15129656/109189715-3ac44480-778c-11eb-8455-0af95d73a432.png)

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
