### PR TITLE
💄 EAR-1181: Add on hover styling to chevrons

### DIFF
--- a/eq-author/src/components/CollapsibleNavItem/index.js
+++ b/eq-author/src/components/CollapsibleNavItem/index.js
@@ -18,6 +18,12 @@ const Header = styled.div`
   align-items: center;
 `;
 
+const hoverStyling = `
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+`;
+
 const Title = styled.button`
   display: flex;
   align-items: center;
@@ -49,9 +55,7 @@ const Title = styled.button`
     }
   }}
 
-  &:hover {
-    background: rgba(0, 0, 0, 0.2);
-  }
+  ${hoverStyling}
 
   &:focus {
     outline: 2px solid ${colors.orange};
@@ -104,12 +108,12 @@ const ToggleCollapsibleNavItemButton = styled.button`
     height: 1rem;
     transform-origin: 50% 50%;
     transition: transform 200ms ease-out;
-    transform: rotate(${(props) => (props.isOpen ? "0deg" : "-90deg")});
+    transform: rotate(${({ isOpen }) => (isOpen ? "0deg" : "-90deg")});
   }
-
   &:focus {
     outline: 2px solid ${colors.orange};
   }
+  ${hoverStyling}
 `;
 
 const Body = styled.div`


### PR DESCRIPTION
### What is the context of this PR?

Add on hover styling to section / folder collapsible nav item chevrons.

Just change colour of chevron background (not whole "row") as per conversation w/ Joe
Chevrons have some sizing / positioning issues - to tackle as part of EAR-1172

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1181)

### How to review

- Add a section/folder
- Focus on chevrons
- Background should darken to same colour that rest of the row goes when you hover over it

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
