### PR TITLE
🛠 EAR 1185 - Fix editing questionnaire introduction on old questionnaires

### DIFF
--- a/eq-author-api/middleware/runQuestionnaireMigrations.js
+++ b/eq-author-api/middleware/runQuestionnaireMigrations.js
@@ -9,14 +9,8 @@ module.exports = (logger) => ({ currentVersion, migrations }) => async (
   res,
   next
 ) => {
-  if (!req.questionnaire) {
-    next();
-    return;
-  }
-
-  if (req.questionnaire.version === currentVersion) {
-    next();
-    return;
+  if (!req.questionnaire || req.questionnaire.version === currentVersion) {
+    return next();
   }
 
   try {

--- a/eq-author-api/migrations/addGuidancePanelSwitch.js
+++ b/eq-author-api/migrations/addGuidancePanelSwitch.js
@@ -1,0 +1,8 @@
+module.exports = (questionnaire) => {
+  if (!questionnaire.introduction.additionalGuidancePanelSwitch) {
+    questionnaire.introduction.additionalGuidancePanel = "";
+    questionnaire.introduction.additionalGuidancePanelSwitch = false;
+  }
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addGuidancePanelSwitch.test.js
+++ b/eq-author-api/migrations/addGuidancePanelSwitch.test.js
@@ -1,0 +1,27 @@
+const addGuidancePanelSwitch = require("./addGuidancePanelSwitch");
+
+describe("migrations: add additional guidance panel switch", () => {
+  it("shouldn't modify a questionnaire which already has the switch", () => {
+    const questionnaire = {
+      introduction: {
+        additionalGuidancePanelSwitch: true,
+        additionalGuidancePanel: "Heed this guidance well...",
+      },
+    };
+
+    expect(addGuidancePanelSwitch(questionnaire)).toMatchObject(questionnaire);
+  });
+
+  it("should add the additional guidance panel switch to questionnaires lacking it", () => {
+    const questionnaire = {
+      introduction: {},
+    };
+
+    expect(addGuidancePanelSwitch(questionnaire)).toMatchObject({
+      introduction: {
+        additionalGuidancePanel: "",
+        additionalGuidancePanelSwitch: false,
+      },
+    });
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -14,6 +14,7 @@ const migrations = [
   require("./addTypeToHistoryEvent"),
   require("./updateDefaultTextAreaLength"),
   require("./addFolders"),
+  require("./addGuidancePanelSwitch"),
 ];
 
 const currentVersion = migrations.length;


### PR DESCRIPTION
### What is the context of this PR?

Adds a migration to add `additionalGuidancePanelSwitch` and `additionalGuidancePanel` fields to existing questionnaires.

Fixes not being able to edit introduction fields on questionnaires made before the "edit guidance panel on introduction page" ticket.

### How to review

- Import an old questionnaire e.g. [this one](https://prod-author.prod.eq.ons.digital/export/11) into your local environment
- Should be able to edit fields on the questionnaire introduction page

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
