### PR TITLE
🛠 EAR 1190 - Fix metadata piping

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/__snapshots__/index.test.js.snap
@@ -94,6 +94,92 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
                           "value": "NavigationSidebar",
                         },
                       },
+                      Object {
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "metadata",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "id",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "displayName",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "type",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "key",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "dateValue",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "regionValue",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "languageValue",
+                              },
+                            },
+                            Object {
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "textValue",
+                              },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
@@ -1289,7 +1375,7 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 1947,
+          "end": 2086,
           "source": Object {
             "body": "query GetQuestionnaire($input: QueryInput!) {
   questionnaire(input: $input) {
@@ -1299,6 +1385,16 @@ exports[`QuestionnaireDesignPage Adding question confirmation withQuestionnaire 
     publishStatus
     totalErrorCount
     ...NavigationSidebar
+    metadata {
+      id
+      displayName
+      type
+      key
+      dateValue
+      regionValue
+      languageValue
+      textValue
+    }
   }
 }
 fragment NavigationSidebar on Questionnaire {
@@ -1533,6 +1629,92 @@ fragment Introduction on Questionnaire {
                       "name": Object {
                         "kind": "Name",
                         "value": "NavigationSidebar",
+                      },
+                    },
+                    Object {
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "metadata",
+                      },
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "selections": Array [
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "id",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "displayName",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "type",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "key",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "dateValue",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "regionValue",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "languageValue",
+                            },
+                          },
+                          Object {
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "textValue",
+                            },
+                          },
+                        ],
                       },
                     },
                   ],
@@ -2730,7 +2912,7 @@ fragment Introduction on Questionnaire {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1947,
+        "end": 2086,
         "source": Object {
           "body": "query GetQuestionnaire($input: QueryInput!) {
   questionnaire(input: $input) {
@@ -2740,6 +2922,16 @@ fragment Introduction on Questionnaire {
     publishStatus
     totalErrorCount
     ...NavigationSidebar
+    metadata {
+      id
+      displayName
+      type
+      key
+      dateValue
+      regionValue
+      languageValue
+      textValue
+    }
   }
 }
 fragment NavigationSidebar on Questionnaire {

--- a/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
+++ b/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
@@ -6,6 +6,16 @@ query GetQuestionnaire($input: QueryInput!) {
     publishStatus
     totalErrorCount
     ...NavigationSidebar
+    metadata {
+      id
+      displayName
+      type
+      key
+      dateValue
+      regionValue
+      languageValue
+      textValue
+    }
   }
 }
 fragment NavigationSidebar on Questionnaire {


### PR DESCRIPTION
### What is the context of this PR?

Fix not being able to pipe metadata into any of the rich text editors.

Adds metadata to back to main questionnaire query as RTEs depend on it being present in the `QuestionnaireContext`.

### How to review

- Open a questionnaire
- Check that you can now pipe in metadata

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
