### PR TITLE
EAR-1206 Upgrade Node to fix GCP deployment

### DIFF
--- a/eq-author/cloudbuild.yaml
+++ b/eq-author/cloudbuild.yaml
@@ -1,11 +1,11 @@
 # [START cloudbuild]
 steps:
-  - name: node:10.15.1
+  - name: node:10.22.2
     entrypoint: yarn
     args: ["install"]
     dir: "eq-author"
 
-  - name: node:10.15.1
+  - name: node:10.22.2
     entrypoint: yarn
     args: ["build"]
     dir: "eq-author"


### PR DESCRIPTION
### What is the context of this PR?

GCPs deployment was breaking because it was pulling in an older version of Node than is required for one of the dependencies.

This upgrades Node to the version needed.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
