### PR TITLE
EAR-1221 Return folder button into add content menu

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu.js
@@ -9,7 +9,7 @@ import IconSection from "assets/icon-section.svg?inline";
 import IconQuestion from "assets/icon-questionpage.svg?inline";
 import IconSummary from "assets/icon-summarypage.svg?inline";
 import IconConfirmation from "assets/icon-playback.svg?inline";
-import IconFolder from "assets/icon-folder.svg?inline";
+// import IconFolder from "assets/icon-folder.svg?inline";
 
 import IconText from "components/IconText";
 import { radius, colors } from "constants/theme";
@@ -94,8 +94,8 @@ const AddMenu = ({
   canAddCalculatedSummaryPage,
   onAddQuestionConfirmation,
   canAddQuestionConfirmation,
-  onAddFolder,
-  canAddFolder,
+  // onAddFolder,
+  // canAddFolder,
   ...otherProps
 }) => {
   const addBtn = (
@@ -131,7 +131,8 @@ const AddMenu = ({
           >
             <StyledIconText icon={IconSection}>Section</StyledIconText>
           </AddMenuButton>
-          <AddMenuButton
+          {/* Temporarily removed -- do not delete! */}
+          {/* <AddMenuButton
             primary
             data-test="btn-add-folder"
             onClick={onAddFolder}
@@ -140,7 +141,7 @@ const AddMenu = ({
             <StyledIconText icon={IconFolder} data-hook="icon-folder">
               Folder
             </StyledIconText>
-          </AddMenuButton>
+          </AddMenuButton> */}
           <AddMenuButton
             primary
             data-test="btn-add-question-confirmation"

--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/AddMenu.test.js.snap
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/__snapshots__/AddMenu.test.js.snap
@@ -151,20 +151,6 @@ exports[`AddMenu should render 1`] = `
         </AddMenu__StyledIconText>
       </AddMenu__AddMenuButton>
       <AddMenu__AddMenuButton
-        data-test="btn-add-folder"
-        disabled={true}
-        primary={true}
-        type="button"
-        variant="primary"
-      >
-        <AddMenu__StyledIconText
-          data-hook="icon-folder"
-          icon={[Function]}
-        >
-          Folder
-        </AddMenu__StyledIconText>
-      </AddMenu__AddMenuButton>
-      <AddMenu__AddMenuButton
         data-test="btn-add-question-confirmation"
         disabled={false}
         onClick={[MockFunction]}


### PR DESCRIPTION
Removes the 'Folder' button from the list so we can deploy