### PR TITLE
EAR 1205 - Keep selected tab when switching pages

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -94,7 +94,7 @@ const UnwrappedNavigationSidebar = ({
   canAddQuestionPage,
   canAddFolder,
   match: {
-    params: { entityId },
+    params: { entityId, tab = "design" },
   },
   history,
 }) => {
@@ -135,7 +135,7 @@ const UnwrappedNavigationSidebar = ({
               titleUrl={buildPagePath({
                 questionnaireId: questionnaire.id,
                 pageId,
-                tab: "design",
+                tab,
               })}
               disabled={isCurrentPage(pageId, entityId)}
               icon={IconQuestionPage}
@@ -156,7 +156,7 @@ const UnwrappedNavigationSidebar = ({
               titleUrl={buildPagePath({
                 questionnaireId: questionnaire.id,
                 pageId,
-                tab: "design",
+                tab,
               })}
               disabled={isCurrentPage(pageId, entityId)}
               icon={IconSummaryPage}
@@ -180,7 +180,7 @@ const UnwrappedNavigationSidebar = ({
               titleUrl={buildConfirmationPath({
                 questionnaireId: questionnaire.id,
                 confirmationId: confirmation.id,
-                tab: "design",
+                tab,
               })}
               disabled={isCurrentPage(confirmation.id, entityId)}
               icon={IconConfirmationPage}
@@ -210,7 +210,7 @@ const UnwrappedNavigationSidebar = ({
                   titleUrl={buildFolderPath({
                     questionnaireId: questionnaire.id,
                     folderId,
-                    tab: "design",
+                    tab,
                   })}
                   disabled={isCurrentPage(folderId, entityId)}
                   icon={IconFolder}
@@ -263,7 +263,7 @@ const UnwrappedNavigationSidebar = ({
                 titleUrl={buildSectionPath({
                   questionnaireId: questionnaire.id,
                   sectionId,
-                  tab: "design",
+                  tab,
                 })}
                 bordered
                 selfErrorCount={validationErrorInfo.totalCount}
@@ -318,7 +318,7 @@ const UnwrappedNavigationSidebar = ({
                     titleUrl={buildIntroductionPath({
                       questionnaireId: questionnaire.id,
                       introductionId: questionnaire.introduction.id,
-                      tab: "design",
+                      tab,
                     })}
                     disabled={isCurrentPage(
                       questionnaire.introduction.id,


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1205)

Restore previous behaviour of keeping selected tabs (Design / Logic, etc.) between pages when using the nav menu.

### How to review

- Switch pages with the nav menu - should keep selected view

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
