### PR TITLE
✨ EAR 1209 - Add themes API data / resolvers

### DIFF
--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -64,6 +64,14 @@ const baseQuestionnaireSchema = {
   editors: {
     type: Array,
   },
+  previewTheme: {
+    type: String,
+    required: true,
+  },
+  themes: {
+    type: Array,
+    required: true,
+  },
 };
 
 const questionnanaireSchema = new dynamoose.Schema(

--- a/eq-author-api/migrations/addDefaultTheme.js
+++ b/eq-author-api/migrations/addDefaultTheme.js
@@ -1,0 +1,12 @@
+const { createTheme } = require("../schema/resolvers/utils");
+
+module.exports = (questionnaire) => {
+  if (!questionnaire.previewTheme || !questionnaire.themes) {
+    const defaultTheme = createTheme();
+
+    questionnaire.previewTheme = defaultTheme.shortName;
+    questionnaire.themes = [defaultTheme];
+  }
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addDefaultTheme.js
+++ b/eq-author-api/migrations/addDefaultTheme.js
@@ -2,7 +2,12 @@ const { createTheme } = require("../schema/resolvers/utils");
 
 module.exports = (questionnaire) => {
   if (!questionnaire.previewTheme || !questionnaire.themes) {
-    const defaultTheme = createTheme();
+    const currentLegalBasis =
+      questionnaire.introduction && questionnaire.introduction.legalBasis;
+
+    const defaultTheme = createTheme({
+      legalBasisCode: currentLegalBasis || "NOTICE_1",
+    });
 
     questionnaire.previewTheme = defaultTheme.shortName;
     questionnaire.themes = [defaultTheme];

--- a/eq-author-api/migrations/addDefaultTheme.test.js
+++ b/eq-author-api/migrations/addDefaultTheme.test.js
@@ -1,0 +1,30 @@
+const addDefaultTheme = require("./addDefaultTheme");
+
+describe("migrations: add default theme", () => {
+  it("shouldn't modify a questionnaire which already has theme information", () => {
+    const questionnaire = {
+      themes: [{ shortName: "default", id: "qwerty" }],
+      previewTheme: "default",
+    };
+
+    expect(addDefaultTheme(questionnaire)).toMatchObject(questionnaire);
+  });
+
+  it("should add default theme information to questionnaires lacking it", () => {
+    const questionnaire = {};
+
+    expect(addDefaultTheme(questionnaire)).toMatchObject({
+      previewTheme: "default",
+      themes: [
+        expect.objectContaining({
+          id: expect.any(String),
+          shortName: "default",
+          enabled: true,
+          legalBasisCode: expect.any(String),
+          eqId: "",
+          formType: "",
+        }),
+      ],
+    });
+  });
+});

--- a/eq-author-api/migrations/addDefaultTheme.test.js
+++ b/eq-author-api/migrations/addDefaultTheme.test.js
@@ -27,4 +27,26 @@ describe("migrations: add default theme", () => {
       ],
     });
   });
+
+  it("should keep existing legal basis where present", () => {
+    const questionnaire = {
+      introduction: {
+        legalBasis: "NOTICE_2",
+      },
+    };
+
+    expect(addDefaultTheme(questionnaire)).toMatchObject({
+      previewTheme: "default",
+      themes: [
+        expect.objectContaining({
+          id: expect.any(String),
+          shortName: "default",
+          enabled: true,
+          legalBasisCode: questionnaire.introduction.legalBasis,
+          eqId: "",
+          formType: "",
+        }),
+      ],
+    });
+  });
 });

--- a/eq-author-api/migrations/addDefaultTheme.test.js
+++ b/eq-author-api/migrations/addDefaultTheme.test.js
@@ -28,21 +28,21 @@ describe("migrations: add default theme", () => {
     });
   });
 
-  it("should keep existing legal basis where present", () => {
+  it("should use the existing legal basis when making a new theme", () => {
+    const legalBasis = "NOTICE_2";
     const questionnaire = {
-      introduction: {
-        legalBasis: "NOTICE_2",
-      },
+      introduction: { legalBasis },
     };
 
     expect(addDefaultTheme(questionnaire)).toMatchObject({
+      introduction: { legalBasis },
       previewTheme: "default",
       themes: [
         expect.objectContaining({
           id: expect.any(String),
           shortName: "default",
           enabled: true,
-          legalBasisCode: questionnaire.introduction.legalBasis,
+          legalBasisCode: legalBasis,
           eqId: "",
           formType: "",
         }),

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -15,6 +15,7 @@ const migrations = [
   require("./updateDefaultTextAreaLength"),
   require("./addFolders"),
   require("./addGuidancePanelSwitch"),
+  require("./addDefaultTheme"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -16,7 +16,7 @@ const {
 } = require("lodash");
 const GraphQLJSON = require("graphql-type-json");
 const { v4: uuidv4 } = require("uuid");
-const { withFilter } = require("apollo-server-express");
+const { withFilter, UserInputError } = require("apollo-server-express");
 const fetch = require("node-fetch");
 
 const {
@@ -63,6 +63,8 @@ const {
   returnValidationErrors,
   createSection,
   createFolder,
+  getThemeByShortName,
+  createTheme,
 } = require("./utils");
 
 const createAnswer = require("../../src/businessLogic/createAnswer");
@@ -115,6 +117,7 @@ const deleteFirstPageSkipConditions = require("../../src/businessLogic/deleteFir
 const deleteLastPageRouting = require("../../src/businessLogic/deleteLastPageRouting");
 
 const createNewQuestionnaire = (input) => {
+  const defaultTheme = createTheme();
   const defaultQuestionnaire = {
     id: uuidv4(),
     theme: "default",
@@ -129,6 +132,8 @@ const createNewQuestionnaire = (input) => {
     editors: [],
     isPublic: true,
     publishStatus: UNPUBLISHED,
+    previewTheme: defaultTheme.shortName,
+    themes: [defaultTheme],
   };
 
   let changes = {};
@@ -288,6 +293,44 @@ const Resolvers = {
       };
       return createQuestionnaire(newQuestionnaire, ctx);
     },
+    updateSurveyId: createMutation((root, { input: { surveyId } }, ctx) => {
+      ctx.questionnaire.surveyId = surveyId;
+      return ctx.questionnaire;
+    }),
+    updatePreviewTheme: createMutation(
+      (root, { input: { previewTheme } }, ctx) => {
+        ctx.questionnaire.previewTheme = previewTheme;
+        return ctx.questionnaire;
+      }
+    ),
+    enableTheme: createMutation((root, { input: { shortName } }, ctx) => {
+      let theme = getThemeByShortName(ctx, shortName);
+      if (!theme) {
+        theme = createTheme({ shortName });
+        ctx.questionnaire.themes.push(theme);
+      }
+      theme.enabled = true;
+      return theme;
+    }),
+    updateTheme: createMutation((root, { input }, ctx) => {
+      const theme = getThemeByShortName(ctx, input.shortName);
+      if (!theme) {
+        throw new UserInputError(
+          `updateTheme: No theme found with shortName '${input.shortName}''`
+        );
+      }
+      return Object.assign(theme, input);
+    }),
+    disableTheme: createMutation((root, { input: { shortName } }, ctx) => {
+      const theme = getThemeByShortName(ctx, shortName);
+      if (!theme) {
+        throw new UserInputError(
+          `disableTheme: No theme found with shortName '${shortName}''`
+        );
+      }
+      theme.enabled = false;
+      return theme;
+    }),
     createHistoryNote: (root, { input }, ctx) =>
       createHistoryEvent(input.id, noteCreationEvent(ctx, input.bodyText)),
     updateHistoryNote: async (root, { input }, ctx) => {

--- a/eq-author-api/schema/resolvers/utils.js
+++ b/eq-author-api/schema/resolvers/utils.js
@@ -334,11 +334,27 @@ const getMovePosition = (section, pageId, position) => {
   return { previous, next };
 };
 
+const getThemeByShortName = ({ questionnaire }, shortName) =>
+  questionnaire.themes.find((theme) => theme.shortName === shortName);
+
+const createTheme = (attrs = {}) => ({
+  id: uuidv4(),
+  enabled: true,
+  shortName: "default",
+  legalBasisCode: "NOTICE_1",
+  eqId: "",
+  formType: "",
+  ...attrs,
+});
+
 module.exports = {
   getSections,
   getSectionById,
   getSectionByFolderId,
   getSectionByPageId,
+
+  getThemeByShortName,
+  createTheme,
 
   idExists,
   getAbsolutePositionById,

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -218,13 +218,13 @@ describe("questionnaire", () => {
         await enableTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "dave",
+            shortName: "census",
           },
           ctx
         );
         const updatedQuestionnaire = await queryQuestionnaire(ctx);
         expect(updatedQuestionnaire.themes).toHaveLength(2);
-        expect(updatedQuestionnaire.themes[1].shortName).toEqual("dave");
+        expect(updatedQuestionnaire.themes[1].shortName).toEqual("census");
       });
 
       it("should be able to enable an existing theme", async () => {
@@ -256,7 +256,7 @@ describe("questionnaire", () => {
           disableTheme(
             {
               questionnaireId: questionnaire.id,
-              shortName: "woololo",
+              shortName: "census",
             },
             ctx
           )
@@ -282,7 +282,7 @@ describe("questionnaire", () => {
           updateTheme(
             {
               questionnaireId: questionnaire.id,
-              shortName: "woololo",
+              shortName: "census",
               eqId: "my-fantastic-new-identifier",
             },
             ctx

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -52,9 +52,8 @@ type Questionnaire {
   description: String
   additionalGuidancePanelSwitch: Boolean
   additionalGuidancePanel: String
-  theme: Theme
+  theme: LegacyTheme
   navigation: Boolean
-  surveyId: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User!
@@ -73,10 +72,29 @@ type Questionnaire {
   publishStatus: PublishStatus!
   publishDetails: [PublishDetails]
   totalErrorCount: Int!
+  surveyId: String
+  previewTheme: String!
+  themes: [Theme!]!
 }
 enum HistoryEventTypes {
   system
   note
+}
+
+type Theme {
+  id: ID!
+  enabled: Boolean!
+  shortName: String!
+  legalBasisCode: LegalBasisCode
+  eqId: ID
+  formType: String
+}
+
+enum LegalBasisCode {
+  NOTICE_1
+  NOTICE_2
+  NOTICE_NI
+  VOLUNTARY
 }
 
 type History {
@@ -432,7 +450,7 @@ enum AnswerType {
   Unit
 }
 
-enum Theme {
+enum LegacyTheme {
   default
   census
   northernireland
@@ -649,14 +667,50 @@ input DeleteSkipConditionsInput {
   parentId: ID!
 }
 
+input UpdateSurveyIdInput {
+  questionnaireId: ID!
+  surveyId: String!
+}
+
+input UpdatePreviewThemeInput {
+  questionnaireId: ID!
+  previewTheme: String!
+}
+
+input EnableThemeInput {
+  questionnaireId: ID!
+  shortName: String!
+}
+
+input DisableThemeInput {
+  questionnaireId: ID!
+  shortName: String!
+}
+
+input UpdateThemeInput {
+  questionnaireId: ID!
+  shortName: String!
+  eqId: ID
+  legalBasisCode: LegalBasisCode
+  formType: String
+}
+
 type Mutation {
   createQuestionnaire(input: CreateQuestionnaireInput!): Questionnaire
   updateQuestionnaire(input: UpdateQuestionnaireInput!): Questionnaire
   deleteQuestionnaire(input: DeleteQuestionnaireInput!): DeletedQuestionnaire
   duplicateQuestionnaire(input: DuplicateQuestionnaireInput!): Questionnaire
+
   createHistoryNote(input: createHistoryNoteInput!): [History!]!
   updateHistoryNote(input: updateHistoryNoteInput!): [History!]!
   deleteHistoryNote(input: deleteHistoryNoteInput!): [History!]!
+
+  updateSurveyId(input: UpdateSurveyIdInput!): Questionnaire
+  updatePreviewTheme(input: UpdatePreviewThemeInput!): Questionnaire
+  enableTheme(input: EnableThemeInput!): Theme
+  updateTheme(input: UpdateThemeInput!): Theme
+  disableTheme(input: DisableThemeInput!): Theme
+
   createSection(input: CreateSectionInput!): Section
   updateSection(input: UpdateSectionInput!): Section
   deleteSection(input: DeleteSectionInput!): Questionnaire

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -52,7 +52,7 @@ type Questionnaire {
   description: String
   additionalGuidancePanelSwitch: Boolean
   additionalGuidancePanel: String
-  theme: LegacyTheme
+  theme: ThemeShortName
   navigation: Boolean
   createdAt: DateTime
   updatedAt: DateTime
@@ -84,7 +84,7 @@ enum HistoryEventTypes {
 type Theme {
   id: ID!
   enabled: Boolean!
-  shortName: String!
+  shortName: ThemeShortName!
   legalBasisCode: LegalBasisCode
   eqId: ID
   formType: String
@@ -450,7 +450,7 @@ enum AnswerType {
   Unit
 }
 
-enum LegacyTheme {
+enum ThemeShortName {
   default
   census
   northernireland
@@ -679,17 +679,17 @@ input UpdatePreviewThemeInput {
 
 input EnableThemeInput {
   questionnaireId: ID!
-  shortName: String!
+  shortName: ThemeShortName!
 }
 
 input DisableThemeInput {
   questionnaireId: ID!
-  shortName: String!
+  shortName: ThemeShortName!
 }
 
 input UpdateThemeInput {
   questionnaireId: ID!
-  shortName: String!
+  shortName: ThemeShortName!
   eqId: ID
   legalBasisCode: LegalBasisCode
   formType: String

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
@@ -42,6 +42,15 @@ const createQuestionnaireMutation = `
           id
         }
       }
+      previewTheme
+      themes {
+        id
+        enabled
+        shortName
+        legalBasisCode
+        eqId
+        formType
+      }
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/disableTheme.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/disableTheme.js
@@ -1,0 +1,21 @@
+const executeQuery = require("../../executeQuery");
+
+const disableThemeMutation = `
+mutation DisableTheme($input: DisableThemeInput!) {
+    disableTheme(input: $input) {
+      id
+      shortName
+      enabled
+    }
+  }
+`;
+
+const disableTheme = async (input, ctx) => {
+  const result = await executeQuery(disableThemeMutation, { input }, ctx);
+  return result.data.disableTheme;
+};
+
+module.exports = {
+  disableThemeMutation,
+  disableTheme,
+};

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/enableTheme.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/enableTheme.js
@@ -1,0 +1,21 @@
+const executeQuery = require("../../executeQuery");
+
+const enableThemeMutation = `
+mutation EnableTheme($input: EnableThemeInput!) {
+    enableTheme(input: $input) {
+      id
+      shortName
+      enabled
+    }
+  }
+`;
+
+const enableTheme = async (input, ctx) => {
+  const result = await executeQuery(enableThemeMutation, { input }, ctx);
+  return result.data.enableTheme;
+};
+
+module.exports = {
+  enableThemeMutation,
+  enableTheme,
+};

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
@@ -7,4 +7,9 @@ module.exports = {
   ...require("./listQuestionnaires"),
   ...require("./publishQuestionnaire"),
   ...require("./reviewQuestionnaire"),
+  ...require("./updatePreviewTheme"),
+  ...require("./enableTheme"),
+  ...require("./disableTheme"),
+  ...require("./updateSurveyId"),
+  ...require("./updateTheme"),
 };

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
@@ -31,6 +31,15 @@ const getQuestionnaireQuery = `
       }
       totalErrorCount
       publishStatus
+      previewTheme
+      themes {
+        id
+        enabled
+        shortName
+        legalBasisCode
+        eqId
+        formType
+      }
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/updatePreviewTheme.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/updatePreviewTheme.js
@@ -1,0 +1,20 @@
+const executeQuery = require("../../executeQuery");
+
+const updatePreviewThemeMutation = `
+mutation UpdatePreviewTheme($input: UpdatePreviewThemeInput!) {
+    updatePreviewTheme(input: $input) {
+      id
+      previewTheme
+    }
+  }
+`;
+
+const updatePreviewTheme = async (input, ctx) => {
+  const result = await executeQuery(updatePreviewThemeMutation, { input }, ctx);
+  return result.data.updatePreviewTheme;
+};
+
+module.exports = {
+  updatePreviewThemeMutation,
+  updatePreviewTheme,
+};

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/updateSurveyId.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/updateSurveyId.js
@@ -1,0 +1,20 @@
+const executeQuery = require("../../executeQuery");
+
+const updateSurveyIdMutation = `
+mutation UpdateSurveyId($input: UpdateSurveyIdInput!) {
+    updateSurveyId(input: $input) {
+      id
+      surveyId
+    }
+  }
+`;
+
+const updateSurveyId = async (input, ctx) => {
+  const result = await executeQuery(updateSurveyIdMutation, { input }, ctx);
+  return result.data.updateSurveyId;
+};
+
+module.exports = {
+  updateSurveyIdMutation,
+  updateSurveyId,
+};

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/updateTheme.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/updateTheme.js
@@ -1,0 +1,24 @@
+const executeQuery = require("../../executeQuery");
+
+const updateThemeMutation = `
+mutation UpdateTheme($input: UpdateThemeInput!) {
+    updateTheme(input: $input) {
+      id
+      shortName
+      enabled
+      eqId
+      legalBasisCode
+      formType
+    }
+  }
+`;
+
+const updateTheme = async (input, ctx) => {
+  const result = await executeQuery(updateThemeMutation, { input }, ctx);
+  return result.data.updateTheme;
+};
+
+module.exports = {
+  updateThemeMutation,
+  updateTheme,
+};


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1209)

#### Mutations

`enableTheme`: `questionnaireId, shortName` -> enables theme with
shortName, creates if doesn't exist

`disableTheme`: `questionnaireId, shortName` -> disables theme with
shortName, throws error if doesn't exist

`updateTheme`: `questionnaireId, shortName, ...other` -> applies `other`
attributes to theme (anything from the `Theme` object except for `enabled`) 
with shortName, throws error if doesn't exist

`updateSurveyId`: `questionnaireId, surveyId` -> sets surveyId

`updatePreviewTheme`: `questionnaireId, previewTheme` -> sets previewTheme

#### Root questionnaire object schema additions

- `themes` array of the `Theme` type with `eqId, formType, shortName, enabled, legalBasisCode,
id` attributes

- `LegalBasisCode` enum with states `NOTICE_1, NOTICE_2, NOTICE_NI,
VOLUNTARY`

#### Defaults for new questionnaires

Newly created questionnaires get a default `themes` array consisting of
a single-element default theme with `NOTICE_1` legal basis code.
The default `previewTheme` is `"default"` as per the default theme.

Queries to retrieve the themes information can be called against the
base `questionnaire` object.

#### Migration

Adds a migration to add the `"default"` theme as sole enabled theme in
a `themes` array on pre-existing questionnaires & sets `previewTheme` to 
`"default"`.

Keeps existing questionnaire's `legalBasis` from the introduction page when present
and stores this as the `legalBasisCode` within the default theme.

### How to review

Try out the mutations above using GraphQL playground / Apollo dev tools in Author. 

- Should be able to query `themes` (and all their attributes), `previewTheme` and `surveyId` from the root `questionnaire` object.
- Should be able to add/enable themes, disable themes, update themes, update the survey ID and the preview theme.
- Should throw an error when you try and update / disable non-existent themes.
- Check the migration works & old questionnaires are correctly given a default theme.
 
### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
