### PR TITLE
EAR 1121 fix modal flicker

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -593,15 +593,10 @@ const Resolvers = {
     }),
     updateValidationRule: createMutation((_, args, ctx) => {
       const validation = getValidationById(ctx, args.input.id);
-
       const { validationType } = validation;
       merge(validation, args.input[`${validationType}Input`]);
 
-      const newValidation = Object.assign({}, validation);
-
-      delete validation.validationType;
-
-      return newValidation;
+      return validation;
     }),
     createMetadata: createMutation((root, args, ctx) => {
       const newMetadata = {

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
@@ -93,13 +93,20 @@ const INPUT_FRAGMENT = gql`
 export const mapMutateToProps = ({ mutate }) => ({
   onUpdateValidationRule: ({ id, ...rest }) => {
     const input = { id, ...rest };
-    const validationRule = rest[Object.keys(rest)[0]];
+    const validationRule = [
+      "minValueInput",
+      "maxValueInput",
+      "earliestDateInput",
+      "latestDateInput",
+      "minDurationInput",
+      "maxDurationInput",
+    ].find((x) => rest[x]);
     return mutate({
       variables: { input: filter(INPUT_FRAGMENT, input) },
       optimisticResponse: {
         updateValidationRule: {
           id,
-          ...validationRule,
+          ...rest[validationRule],
         },
       },
     });

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
@@ -91,10 +91,19 @@ const INPUT_FRAGMENT = gql`
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({
-  onUpdateValidationRule: (input) =>
-    mutate({
+  onUpdateValidationRule: ({ id, ...rest }) => {
+    const input = { id, ...rest };
+    const validationRule = rest[Object.keys(rest)[0]];
+    return mutate({
       variables: { input: filter(INPUT_FRAGMENT, input) },
-    }),
+      optimisticResponse: {
+        updateValidationRule: {
+          id,
+          ...validationRule,
+        },
+      },
+    });
+  },
 });
 
 export default graphql(UPDATE_VALIDATION_RULE, {

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
@@ -30,6 +30,14 @@ describe("withUpdateValidationRule", () => {
           },
         },
       },
+      optimisticResponse: {
+        updateValidationRule: {
+          __typename: "foo",
+          custom: "201",
+          id: "1",
+          inclusive: true,
+        },
+      },
     });
   });
 });

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -707,10 +707,7 @@ exports[`Option should render a checkbox 1`] = `
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
                                               "styledComponentId": "WrappingInput__TextArea-mcpw45-1",
-                                              "target": Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "render": [Function],
-                                              },
+                                              "target": [Function],
                                               "toString": [Function],
                                               "warnTooManyClasses": [Function],
                                               "withComponent": [Function],
@@ -725,17 +722,20 @@ exports[`Option should render a checkbox 1`] = `
                                           placeholder=""
                                           value=""
                                         >
-                                          <ForwardRef(TextareaAutosize)
+                                          <TextareaAutosize
                                             aria-invalid="false"
                                             className="c7"
                                             data-autofocus={true}
                                             data-test="option-label"
                                             id="option-label-1"
+                                            inputRef={[Function]}
                                             name="label"
                                             onBlur={[MockFunction]}
                                             onChange={[Function]}
+                                            onHeightChange={[Function]}
                                             onKeyDown={[Function]}
                                             placeholder=""
+                                            useCacheForDOMMeasurements={false}
                                             value=""
                                           >
                                             <textarea
@@ -749,9 +749,14 @@ exports[`Option should render a checkbox 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               placeholder=""
+                                              style={
+                                                Object {
+                                                  "height": 0,
+                                                }
+                                              }
                                               value=""
                                             />
-                                          </ForwardRef(TextareaAutosize)>
+                                          </TextareaAutosize>
                                         </StyledComponent>
                                       </WrappingInput__TextArea>
                                     </div>
@@ -1000,10 +1005,7 @@ exports[`Option should render a checkbox 1`] = `
                                         "foldedComponentIds": Array [],
                                         "render": [Function],
                                         "styledComponentId": "WrappingInput__TextArea-mcpw45-1",
-                                        "target": Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "render": [Function],
-                                        },
+                                        "target": [Function],
                                         "toString": [Function],
                                         "warnTooManyClasses": [Function],
                                         "withComponent": [Function],
@@ -1017,15 +1019,18 @@ exports[`Option should render a checkbox 1`] = `
                                     onKeyDown={[Function]}
                                     value=""
                                   >
-                                    <ForwardRef(TextareaAutosize)
+                                    <TextareaAutosize
                                       aria-invalid="false"
                                       className="c7"
                                       data-test="option-description"
                                       id="option-description-1"
+                                      inputRef={[Function]}
                                       name="description"
                                       onBlur={[MockFunction]}
                                       onChange={[Function]}
+                                      onHeightChange={[Function]}
                                       onKeyDown={[Function]}
+                                      useCacheForDOMMeasurements={false}
                                       value=""
                                     >
                                       <textarea
@@ -1037,9 +1042,14 @@ exports[`Option should render a checkbox 1`] = `
                                         onBlur={[MockFunction]}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                          }
+                                        }
                                         value=""
                                       />
-                                    </ForwardRef(TextareaAutosize)>
+                                    </TextareaAutosize>
                                   </StyledComponent>
                                 </WrappingInput__TextArea>
                               </div>

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -707,7 +707,10 @@ exports[`Option should render a checkbox 1`] = `
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
                                               "styledComponentId": "WrappingInput__TextArea-mcpw45-1",
-                                              "target": [Function],
+                                              "target": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
                                               "toString": [Function],
                                               "warnTooManyClasses": [Function],
                                               "withComponent": [Function],
@@ -722,20 +725,17 @@ exports[`Option should render a checkbox 1`] = `
                                           placeholder=""
                                           value=""
                                         >
-                                          <TextareaAutosize
+                                          <ForwardRef(TextareaAutosize)
                                             aria-invalid="false"
                                             className="c7"
                                             data-autofocus={true}
                                             data-test="option-label"
                                             id="option-label-1"
-                                            inputRef={[Function]}
                                             name="label"
                                             onBlur={[MockFunction]}
                                             onChange={[Function]}
-                                            onHeightChange={[Function]}
                                             onKeyDown={[Function]}
                                             placeholder=""
-                                            useCacheForDOMMeasurements={false}
                                             value=""
                                           >
                                             <textarea
@@ -749,14 +749,9 @@ exports[`Option should render a checkbox 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               placeholder=""
-                                              style={
-                                                Object {
-                                                  "height": 0,
-                                                }
-                                              }
                                               value=""
                                             />
-                                          </TextareaAutosize>
+                                          </ForwardRef(TextareaAutosize)>
                                         </StyledComponent>
                                       </WrappingInput__TextArea>
                                     </div>
@@ -1005,7 +1000,10 @@ exports[`Option should render a checkbox 1`] = `
                                         "foldedComponentIds": Array [],
                                         "render": [Function],
                                         "styledComponentId": "WrappingInput__TextArea-mcpw45-1",
-                                        "target": [Function],
+                                        "target": Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "render": [Function],
+                                        },
                                         "toString": [Function],
                                         "warnTooManyClasses": [Function],
                                         "withComponent": [Function],
@@ -1019,18 +1017,15 @@ exports[`Option should render a checkbox 1`] = `
                                     onKeyDown={[Function]}
                                     value=""
                                   >
-                                    <TextareaAutosize
+                                    <ForwardRef(TextareaAutosize)
                                       aria-invalid="false"
                                       className="c7"
                                       data-test="option-description"
                                       id="option-description-1"
-                                      inputRef={[Function]}
                                       name="description"
                                       onBlur={[MockFunction]}
                                       onChange={[Function]}
-                                      onHeightChange={[Function]}
                                       onKeyDown={[Function]}
-                                      useCacheForDOMMeasurements={false}
                                       value=""
                                     >
                                       <textarea
@@ -1042,14 +1037,9 @@ exports[`Option should render a checkbox 1`] = `
                                         onBlur={[MockFunction]}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
-                                        style={
-                                          Object {
-                                            "height": 0,
-                                          }
-                                        }
                                         value=""
                                       />
-                                    </TextareaAutosize>
+                                    </ForwardRef(TextareaAutosize)>
                                   </StyledComponent>
                                 </WrappingInput__TextArea>
                               </div>


### PR DESCRIPTION
### What is the context of this PR?

Fixes the flicker when changing between validation pills when using answer validation

### How to review

- Add any answer with validation
- change between validation pill options (previousAnswer / custom)
- The modal shouldn't flicker back and forth between options 
