### PR TITLE
removed redundant Ids

### DIFF
--- a/eq-author-api/schema/resolvers/pages/index.js
+++ b/eq-author-api/schema/resolvers/pages/index.js
@@ -52,12 +52,10 @@ Resolvers.Mutation = {
     if (folderId) {
       const folder = getFolderById(ctx, folderId);
       folder.pages.splice(position, 0, page);
-      page.folderId = folder.id;
     } else {
       const { folders } = newSection;
       const newFolder = createFolder({ pages: [page] });
       folders.splice(position, 0, newFolder);
-      page.folderId = newFolder.id;
     }
 
     deleteFirstPageSkipConditions(ctx);

--- a/eq-author-api/schema/resolvers/pages/questionPage.js
+++ b/eq-author-api/schema/resolvers/pages/questionPage.js
@@ -1,4 +1,4 @@
-const { merge } = require("lodash");
+const { merge, omit } = require("lodash");
 
 const { getName } = require("../../../utils/getName");
 
@@ -48,7 +48,7 @@ Resolvers.Mutation = {
   ),
   updateQuestionPage: createMutation((_, { input }, ctx) => {
     const page = getPageById(ctx, input.id);
-    merge(page, input);
+    merge(page, omit(input, "folderId"));
     return page;
   }),
 };

--- a/eq-author-api/src/businessLogic/createCalculatedSummary.js
+++ b/eq-author-api/src/businessLogic/createCalculatedSummary.js
@@ -1,11 +1,12 @@
 const { v4: uuidv4 } = require("uuid");
+const { omit } = require("lodash");
 
 const createCalculatedSummary = (input = {}) => ({
   id: uuidv4(),
   title: "",
   pageType: "CalculatedSummaryPage",
   summaryAnswers: [],
-  ...input,
+  ...omit(input, "folderId"),
 });
 
 module.exports = createCalculatedSummary;

--- a/eq-author-api/src/businessLogic/createFolder.js
+++ b/eq-author-api/src/businessLogic/createFolder.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require("uuid");
+const { omit } = require("lodash");
 const createQuestionPage = require("./createQuestionPage");
 const createCalculatedSummary = require("./createCalculatedSummary");
 
@@ -8,7 +9,7 @@ const createFolder = (input = {}, calcSum = false) => ({
   enabled: false,
   pages: [calcSum ? createCalculatedSummary() : createQuestionPage()],
   skipConditions: null,
-  ...input,
+  ...omit(input, "sectionId", "folderId"),
 });
 
 module.exports = createFolder;

--- a/eq-author-api/src/businessLogic/createQuestionPage.js
+++ b/eq-author-api/src/businessLogic/createQuestionPage.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require("uuid");
+const { omit } = require("lodash");
 
 const createQuestionPage = (input = {}) => ({
   id: uuidv4(),
@@ -12,7 +13,7 @@ const createQuestionPage = (input = {}) => ({
   answers: [],
   routing: null,
   alias: null,
-  ...input,
+  ...omit(input, "folderId"),
 });
 
 module.exports = createQuestionPage;


### PR DESCRIPTION
FolderId and SectionId are being saved in the Author JSON against page and folders, 
This is redundant info, as it's worked out in resolvers from the node Id or parent node id, also they don't always get updated on page moves and as such could cause confusion.

To test:
Spin up the author
Check most features still work,
Review author Json to ensure folderId and sectionId not being added to folders and question pages.
