### PR TITLE
Ear 1208 - Add previewTheme support to publisher v2

### DIFF
--- a/eq-author-api/migrations/addDefaultTheme.js
+++ b/eq-author-api/migrations/addDefaultTheme.js
@@ -2,11 +2,13 @@ const { createTheme } = require("../src/businessLogic");
 
 module.exports = (questionnaire) => {
   if (!questionnaire.previewTheme || !questionnaire.themes) {
+    const isBusinessSurvey = questionnaire.introduction; // May need different heuristic in future if socials get intros
     const currentLegalBasis =
-      questionnaire.introduction && questionnaire.introduction.legalBasis;
+      isBusinessSurvey && questionnaire.introduction.legalBasis;
 
     const defaultTheme = createTheme({
       legalBasisCode: currentLegalBasis || "NOTICE_1",
+      shortName: isBusinessSurvey ? "default" : "social",
     });
 
     questionnaire.previewTheme = defaultTheme.shortName;

--- a/eq-author-api/migrations/addDefaultTheme.test.js
+++ b/eq-author-api/migrations/addDefaultTheme.test.js
@@ -10,8 +10,8 @@ describe("migrations: add default theme", () => {
     expect(addDefaultTheme(questionnaire)).toMatchObject(questionnaire);
   });
 
-  it("should add default theme information to questionnaires lacking it", () => {
-    const questionnaire = {};
+  it("should add default theme information to business questionnaires lacking it", () => {
+    const questionnaire = { introduction: {} };
 
     expect(addDefaultTheme(questionnaire)).toMatchObject({
       previewTheme: "default",
@@ -45,6 +45,19 @@ describe("migrations: add default theme", () => {
           legalBasisCode: legalBasis,
           eqId: "",
           formType: "",
+        }),
+      ],
+    });
+  });
+
+  it("should give social surveys the social theme by default", () => {
+    const questionnaire = {}; // Look ma, no intro
+
+    expect(addDefaultTheme(questionnaire)).toMatchObject({
+      previewTheme: "social",
+      themes: [
+        expect.objectContaining({
+          shortName: "social",
         }),
       ],
     });

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -117,7 +117,9 @@ const deleteFirstPageSkipConditions = require("../../src/businessLogic/deleteFir
 const deleteLastPageRouting = require("../../src/businessLogic/deleteLastPageRouting");
 
 const createNewQuestionnaire = (input) => {
-  const defaultTheme = createTheme();
+  const defaultTheme = createTheme({
+    shortName: input.type === BUSINESS ? "default" : "social",
+  });
   const defaultQuestionnaire = {
     id: uuidv4(),
     theme: "default",

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -112,7 +112,7 @@ describe("questionnaire", () => {
       });
     });
 
-    it("should create a default theme when questionnaire created", async () => {
+    it("should give business questionnaires the 'default' theme when questionnaire created", async () => {
       const questionnaire = await createQuestionnaire(ctx, {
         ...config,
         type: BUSINESS,
@@ -130,6 +130,25 @@ describe("questionnaire", () => {
         ]),
       });
     });
+
+    it("should give social questionnaires the 'social' theme when questionnaire created", async () => {
+      const questionnaire = await createQuestionnaire(ctx, {
+        ...config,
+        type: SOCIAL,
+      });
+      expect(questionnaire).toMatchObject({
+        previewTheme: "social",
+        themes: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            shortName: "social",
+            legalBasisCode: "NOTICE_1",
+            eqId: "",
+            formType: "",
+          }),
+        ]),
+      });
+    });
   });
 
   describe("mutate", () => {
@@ -139,6 +158,7 @@ describe("questionnaire", () => {
         description: "description",
         sections: [{}],
         metadata: [{}],
+        type: BUSINESS,
       });
     });
     it("should mutate a questionnaire", async () => {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -452,6 +452,7 @@ enum AnswerType {
 
 enum ThemeShortName {
   default
+  social
   census
   northernireland
 }

--- a/eq-publisher/src/constants/legalBases.js
+++ b/eq-publisher/src/constants/legalBases.js
@@ -1,16 +1,10 @@
-const contentMap = {
+module.exports = {
   NOTICE_1:
     "Notice is given under section 1 of the Statistics of Trade Act 1947.",
   NOTICE_2:
     "Notice is given under sections 3 and 4 of the Statistics of Trade Act 1947.",
-  VOLUNTARY: null,
+  VOLUNTARY: undefined,
+  types: {},
 };
 
-module.exports.types = Object.keys(contentMap).reduce(
-  (hash, key) => ({
-    ...hash,
-    [key]: key,
-  }),
-  {}
-);
-module.exports.contentMap = contentMap;
+Object.keys(module.exports).forEach((key) => (module.exports.types[key] = key));

--- a/eq-publisher/src/eq_schema/Questionnaire.test.js
+++ b/eq-publisher/src/eq_schema/Questionnaire.test.js
@@ -1,9 +1,10 @@
 const { last } = require("lodash");
 
 const { BUSINESS, SOCIAL } = require("../constants/questionnaireTypes");
+const legalBases = require("../constants/legalBases");
 const {
   types: { NOTICE_1, VOLUNTARY },
-} = require("../constants/legalBases");
+} = legalBases;
 
 const Questionnaire = require("./Questionnaire");
 const Summary = require("./block-types/Summary");
@@ -34,7 +35,7 @@ describe("Questionnaire", () => {
         ],
         metadata: [],
         introduction: {
-          legalBasis: NOTICE_1,
+          legalBasis: legalBases.types.NOTICE_1,
           collapsibles: [],
         },
       },
@@ -78,7 +79,7 @@ describe("Questionnaire", () => {
     expect(questionnaire.legal_basis).toEqual(undefined);
   });
 
-  it("should set the theme based on the type", () => {
+  it("should set them to 'social' for unmigrated social surveys", () => {
     questionnaire = new Questionnaire(
       createQuestionnaireJSON({ type: SOCIAL })
     );
@@ -335,7 +336,7 @@ describe("Questionnaire", () => {
     ]);
   });
 
-  it("should allow setting northern ireland theme", () => {
+  it("should allow setting northern ireland theme (unmigrated surveys)", () => {
     const questionnaireJson = createQuestionnaireJSON({
       theme: "northernireland",
     });
@@ -346,7 +347,7 @@ describe("Questionnaire", () => {
     );
   });
 
-  it("should allow setting default theme", () => {
+  it("should allow setting default theme (unmigrated surveys)", () => {
     const questionnaireJson = createQuestionnaireJSON({
       theme: "default",
     });
@@ -354,6 +355,35 @@ describe("Questionnaire", () => {
     expect(new Questionnaire(questionnaireJson)).toHaveProperty(
       "theme",
       "default"
+    );
+  });
+
+  it("should allow setting the theme and legal basis according to the previewTheme", () => {
+    const eqId = "my-custom-eqId";
+    const formType = "my-custom-formtype";
+    const shortName = "census";
+    const legalBasis = NOTICE_1;
+
+    const questionnaireJson = createQuestionnaireJSON({
+      previewTheme: shortName,
+      themes: [
+        {
+          id: "mcthemeface1",
+          shortName,
+          legalBasis,
+          eqId,
+          formType,
+        },
+      ],
+    });
+
+    expect(new Questionnaire(questionnaireJson)).toEqual(
+      expect.objectContaining({
+        theme: shortName,
+        eq_id: eqId,
+        form_type: formType,
+        legal_basis: legalBases[legalBasis],
+      })
     );
   });
 });

--- a/eq-publisher/src/getQuestionnaire/queries.js
+++ b/eq-publisher/src/getQuestionnaire/queries.js
@@ -211,6 +211,15 @@ exports.getQuestionnaire = `
       }
       navigation
       surveyId
+      previewTheme
+      themes {
+        id
+        enabled
+        shortName
+        legalBasisCode
+        eqId
+        formType
+      }
       summary
       collapsibleSummary
       metadata {


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1208) 

Publisher will now use the questionnaire's defined `previewTheme` to look up a theme in the `themes` array to use when generating the runner JSON.

The runner `eq_id`, `form_type`, `theme` and `legal_basis` will be set according to the theme referenced by `previewTheme` in the Author JSON.

The publisher changes provide defaults if previewTheme etc. are missing to match existing behaviour (for unmigrated surveys) - can potentially strip out once we're happy the migrations are working as intended.

Also fixes a couple of oversights on the API ticket re: social surveys:
- Social surveys now get the `social` theme by default when created
- The migration now gives social surveys the `social` theme as their default theme

### How to review

- Check publisher still works for existing questionnaires
- Check business questionnaires get `default` as their previewTheme / only theme in the `themes` array of the Author JSON
- Check social questionnaires get `social` as their previewTheme / only theme in the `themes` array of the Author JSON
- If you're feeling adventurous try adding themes / updating previewTheme using the mutations and see if the publisher output does the right thing
- Check out v3 PR too - [https://github.com/ONSdigital/eq-publisher-v3/pull/21](https://github.com/ONSdigital/eq-publisher-v3/pull/21)

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
