### PR TITLE
EAR-1214-build-toggle-switches-for-each-theme

### DIFF
--- a/eq-author/src/App/settings/GeneralSettingsPage.js
+++ b/eq-author/src/App/settings/GeneralSettingsPage.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { colors } from "constants/theme";
 import { Field, Input, Label } from "components/Forms";
 import PropTypes from "prop-types";
-import { withRouter, useRouteMatch } from "react-router-dom";
+import { withRouter, useParams } from "react-router-dom";
 
 import { useMutation } from "react-apollo";
 
@@ -144,7 +144,7 @@ const GeneralSettingsPage = ({ questionnaire }) => {
     shortTitle
   );
 
-  const match = useRouteMatch();
+  const params = useParams();
 
   return (
     <Container>
@@ -156,7 +156,7 @@ const GeneralSettingsPage = ({ questionnaire }) => {
               <VerticalTabs
                 title="Questionnaire settings"
                 cols={2.5}
-                tabItems={tabItems(match.params, type)}
+                tabItems={tabItems(params, type)}
               />
               <Column gutters={false} cols={9.5}>
                 <SettingsContainer>

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -59,6 +59,7 @@ const themes = [
   { title: "EPE theme" },
   { title: "EPE NI theme" },
   { title: "UKIS theme" },
+  { title: "UKIS NI theme" },
 ];
 
 const ThemesPage = ({ questionnaire }) => {

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { withRouter, useRouteMatch } from "react-router-dom";
+import { withRouter, useParams } from "react-router-dom";
 
 import { colors } from "constants/theme";
 
@@ -65,7 +65,7 @@ const themes = [
 const ThemesPage = ({ questionnaire }) => {
   const { type } = questionnaire;
 
-  const match = useRouteMatch();
+  const params = useParams();
 
   return (
     <Container>
@@ -77,7 +77,7 @@ const ThemesPage = ({ questionnaire }) => {
               <VerticalTabs
                 title="Questionnaire settings"
                 cols={2.5}
-                tabItems={tabItems(match.params, type)}
+                tabItems={tabItems(params, type)}
               />
               <Column gutters={false} cols={9.5}>
                 <SettingsContainer>

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -7,6 +7,7 @@ import { colors } from "constants/theme";
 
 import VerticalTabs from "components/VerticalTabs";
 import tabItems from "./TabItems";
+import CollapsibleToggled from "components/CollapsibleToggled";
 
 import Header from "components/EditorLayout/Header";
 import ScrollPane from "components/ScrollPane";
@@ -41,6 +42,24 @@ const StyledPanel = styled.div`
   max-width: 97.5%;
   padding: 1.3em;
 `;
+
+const HorizontalSeparator = styled.hr`
+  border: 0;
+  border-top: 0.0625em solid ${colors.lightMediumGrey};
+  margin: 1.5em 0;
+`;
+
+const themes = [
+  {
+    title: "GB theme",
+    defaultOpen: true,
+  },
+  { title: "NI theme" },
+  { title: "COVID theme" },
+  { title: "EPE theme" },
+  { title: "EPE NI theme" },
+  { title: "UKIS theme" },
+];
 
 const ThemesPage = ({ questionnaire }) => {
   const { type } = questionnaire;
@@ -80,6 +99,32 @@ const ThemesPage = ({ questionnaire }) => {
                         using the View Survey button.
                       </p>
                     </Field>
+                    <HorizontalSeparator />
+                    {themes.map(({ title, defaultOpen }) => (
+                      <CollapsibleToggled
+                        title={title}
+                        defaultOpen={defaultOpen}
+                      >
+                        {/* Added some filler text to demonstrate the opening and 
+                            closing; this should be removed in future tickets where 
+                            we add the actual functionality. 
+                          */}
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing
+                          elit. Praesent ut eros a turpis tincidunt consectetur
+                          sit amet quis enim. Vivamus scelerisque finibus erat
+                          id mattis. In leo dolor, faucibus non volutpat vel,
+                          pellentesque et nibh.
+                        </p>
+                        <p>
+                          Phasellus viverra malesuada tincidunt. Fusce vulputate
+                          odio mauris, eu finibus nisl luctus quis. Sed
+                          dignissim dapibus sapien, at sollicitudin neque auctor
+                          non. Interdum et malesuada fames ac ante ipsum primis
+                          in faucibus.
+                        </p>
+                      </CollapsibleToggled>
+                    ))}
                   </StyledPanel>
                 </SettingsContainer>
               </Column>

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -102,6 +102,7 @@ const ThemesPage = ({ questionnaire }) => {
                     <HorizontalSeparator />
                     {themes.map(({ title, defaultOpen }) => (
                       <CollapsibleToggled
+                        key={`${title}-toggle`}
                         title={title}
                         defaultOpen={defaultOpen}
                       >

--- a/eq-author/src/components/CollapsibleToggled/index.js
+++ b/eq-author/src/components/CollapsibleToggled/index.js
@@ -17,7 +17,6 @@ const Header = styled.div`
   }
 `;
 const Body = styled.div`
-  display: ${(props) => (props.isOpen ? "block" : "none")};
   margin-top: -1em;
   margin-left: 0.1em;
   padding: 0 0 0 0.5em;

--- a/eq-author/src/components/CollapsibleToggled/index.js
+++ b/eq-author/src/components/CollapsibleToggled/index.js
@@ -13,6 +13,7 @@ const Header = styled.div`
   h2 {
     font-size: 1em;
     color: ${colors.black};
+    margin-right: 1em;
   }
 `;
 const Body = styled.div`

--- a/eq-author/src/components/CollapsibleToggled/index.js
+++ b/eq-author/src/components/CollapsibleToggled/index.js
@@ -44,9 +44,7 @@ const CollapsibleToggled = ({
         />
         {headerContent}
       </Header>
-      <Body isOpen={isOpen} data-test="CollapsibleToggled__Body">
-        {children}
-      </Body>
+      {isOpen && <Body data-test="CollapsibleToggled__Body">{children}</Body>}
     </Wrapper>
   );
 };

--- a/eq-author/src/components/CollapsibleToggled/index.js
+++ b/eq-author/src/components/CollapsibleToggled/index.js
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { colors } from "constants/theme";
+
+import ToggleSwitch from "components/buttons/ToggleSwitch";
+
+const Wrapper = styled.div``;
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+
+  h2 {
+    font-size: 1em;
+    color: ${colors.black};
+  }
+`;
+const Body = styled.div`
+  display: ${(props) => (props.isOpen ? "block" : "none")};
+  margin-top: -1em;
+  margin-left: 0.1em;
+  padding: 0 0 0 0.5em;
+  border-left: 3px solid ${colors.lightGrey};
+`;
+
+const CollapsibleToggled = ({
+  title,
+  defaultOpen = false,
+  headerContent,
+  children,
+}) => {
+  const [isOpen, toggleCollapsible] = useState(defaultOpen);
+
+  return (
+    <Wrapper data-test="CollapsibleToggled">
+      <Header data-test="CollapsibleToggled__Header">
+        <h2>{title}</h2>
+        <ToggleSwitch
+          name={`${title}-toggle-switch`}
+          hideLabels={false}
+          onChange={() => toggleCollapsible(!isOpen)}
+          checked={isOpen}
+        />
+        {headerContent}
+      </Header>
+      <Body isOpen={isOpen} data-test="CollapsibleToggled__Body">
+        {children}
+      </Body>
+    </Wrapper>
+  );
+};
+
+export default CollapsibleToggled;
+
+CollapsibleToggled.propTypes = {
+  /**
+   * The title of the collapsible.
+   */
+  title: PropTypes.string.isRequired,
+  /**
+   * If true, the collapsible will be open when first rendered.
+   */
+  defaultOpen: PropTypes.bool,
+  /**
+   * Content to append to the end of the header, if necessary.
+   */
+  headerContent: PropTypes.node,
+  /**
+   * The content to show when the collapsible is open.
+   */
+  children: PropTypes.node.isRequired,
+};

--- a/eq-author/src/components/CollapsibleToggled/index.test.js
+++ b/eq-author/src/components/CollapsibleToggled/index.test.js
@@ -20,10 +20,10 @@ describe("Collapsible toggled", () => {
   it("Defaults to open when the prop is passed", () => {
     const { getByTestId } = render(
       <CollapsibleToggled
-        title="Anakin, Chancellor Palpatine is evil!"
+        title="Anakin? I told you were coming to this, I was right. THE JEDI ARE TAKING OVER!"
         defaultOpen
       >
-        <p>By my point of view the Jedi are evil!</p>
+        <p>The opression of the Sith will never return. You have lost.</p>
       </CollapsibleToggled>
     );
 
@@ -33,9 +33,9 @@ describe("Collapsible toggled", () => {
   });
 
   it("Defaults to closed when the prop is not passed", () => {
-    const { queryByTestId, debug } = render(
-      <CollapsibleToggled title="Anakin, Chancellor Palpatine is evil!">
-        <p>By my point of view the Jedi are evil!</p>
+    const { queryByTestId } = render(
+      <CollapsibleToggled title="You were the chosen one! It was said that you would destroy the Sith, not join them!">
+        <p>Bring balance to The Force! Not leave it in Darkness!</p>
       </CollapsibleToggled>
     );
 

--- a/eq-author/src/components/CollapsibleToggled/index.test.js
+++ b/eq-author/src/components/CollapsibleToggled/index.test.js
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { render } from "tests/utils/rtl";
+
+import CollapsibleToggled from ".";
+
+describe("Collapsible toggled", () => {
+  it("Can render", () => {
+    const { getByTestId } = render(
+      <CollapsibleToggled title="Anakin, Chancellor Palpatine is evil!">
+        <p>By my point of view the Jedi are evil!</p>
+      </CollapsibleToggled>
+    );
+
+    const toggle = getByTestId("CollapsibleToggled");
+
+    expect(toggle).toBeVisible();
+  });
+
+  it("Defaults to open when the prop is passed", () => {
+    const { getByTestId } = render(
+      <CollapsibleToggled
+        title="Anakin, Chancellor Palpatine is evil!"
+        defaultOpen
+      >
+        <p>By my point of view the Jedi are evil!</p>
+      </CollapsibleToggled>
+    );
+
+    const content = getByTestId("CollapsibleToggled__Body");
+
+    expect(content).toBeVisible();
+  });
+
+  it("Defaults to closed when the prop is not passed", () => {
+    const { queryByTestId, debug } = render(
+      <CollapsibleToggled title="Anakin, Chancellor Palpatine is evil!">
+        <p>By my point of view the Jedi are evil!</p>
+      </CollapsibleToggled>
+    );
+
+    const content = queryByTestId("CollapsibleToggled__Body");
+
+    expect(content).not.toBeVisible();
+  });
+});

--- a/eq-author/src/components/CollapsibleToggled/index.test.js
+++ b/eq-author/src/components/CollapsibleToggled/index.test.js
@@ -41,6 +41,6 @@ describe("Collapsible toggled", () => {
 
     const content = queryByTestId("CollapsibleToggled__Body");
 
-    expect(content).not.toBeVisible();
+    expect(content).not.toBeInTheDocument();
   });
 });

--- a/eq-author/src/storybook/Components/CollapsibleToggled.stories.js
+++ b/eq-author/src/storybook/Components/CollapsibleToggled.stories.js
@@ -1,0 +1,72 @@
+import React from "react";
+
+import {
+  Title,
+  Description,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs/blocks";
+
+import ToggledCollapsible from "components/CollapsibleToggled";
+
+export default {
+  title: "Components/Collapsible Toggled",
+  component: ToggledCollapsible,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Description>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sit
+            amet velit non ligula vulputate efficitur non sit amet ex. Aenean
+            iaculis odio a lobortis tristique. Suspendisse est ipsum, finibus et
+            bibendum a, hendrerit et neque. Aliquam varius porta eros, in
+            suscipit libero tempor eget. Aenean eget lectus posuere, ullamcorper
+            ex sed, scelerisque lacus.
+          </Description>
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
+    },
+  },
+};
+
+const ToggledCollapsibleTemplate = (args) => (
+  <ToggledCollapsible {...args}>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ut eros
+      a turpis tincidunt consectetur sit amet quis enim. Vivamus scelerisque
+      finibus erat id mattis. In leo dolor, faucibus non volutpat vel,
+      pellentesque et nibh. Pellentesque habitant morbi tristique senectus et
+      netus et malesuada fames ac turpis egestas. Aliquam iaculis augue vel
+      tortor tempus cursus. Donec pharetra ac ligula vel suscipit. Nunc tempor,
+      neque eu suscipit auctor, lacus massa dictum nisl, in fringilla augue
+      magna sit amet sem. Mauris at molestie tellus, eget porta enim.
+      Pellentesque quis malesuada libero. Proin in odio egestas, pulvinar ligula
+      non, ultricies nisl. Sed cursus felis tristique, ultrices justo at,
+      ullamcorper risus.
+    </p>
+    <p>
+      Phasellus viverra malesuada tincidunt. Fusce vulputate odio mauris, eu
+      finibus nisl luctus quis. Sed dignissim dapibus sapien, at sollicitudin
+      neque auctor non. Interdum et malesuada fames ac ante ipsum primis in
+      faucibus. Aenean viverra tortor interdum ex malesuada, ac elementum ligula
+      auctor. Sed lacus orci, cursus sed volutpat ac, porta id mauris.
+      Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+      cubilia curae; Cras mattis id lorem sed egestas. Cras mollis erat quis
+      mollis tempus. Donec auctor dictum nibh at commodo. Proin ac varius neque.
+      Integer tristique tellus quis purus convallis lacinia. Duis sit amet eros
+      scelerisque, aliquam justo in, consequat risus.
+    </p>
+  </ToggledCollapsible>
+);
+
+export const Default = ToggledCollapsibleTemplate.bind({});
+Default.args = {
+  title: "GB theme",
+};


### PR DESCRIPTION
### What is the context of this PR?

This PR builds a new collapsible component that is opened and closed by a toggle switch, and accepts content to show when open as well as extra content to display in the header (facilitating the later addition of the preview themes radio).

### How to review

Check that the ACs are covered:

Given I'm on the Themes tab of the Settings page
then I see the title of the different themes (GB, NI, COVID, EPE, EPE NI, UKIS, UKIS NI)
and a toggle switch next to each theme

Given I'm on the Themes tab of the Settings page
then the GB theme is turned on by default
and all of the other themes are turned off by default

Given I'm on the Themes tab of the Settings page
when a theme is toggled on
then the space underneath the theme expands but is empty (eQ ID etc will be added as further AC)

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
