### PR TITLE
✨ EAR 1249 - Add API for locking questionnaires

### DIFF
--- a/eq-author-api/db/baseQuestionnaireSchema.js
+++ b/eq-author-api/db/baseQuestionnaireSchema.js
@@ -43,6 +43,10 @@ const editors = {
   type: Array,
 };
 
+const locked = {
+  type: Boolean,
+};
+
 const baseQuestionnaireFields = {
   id,
   isPublic,
@@ -54,6 +58,7 @@ const baseQuestionnaireFields = {
   publishStatus,
   introduction,
   editors,
+  locked,
 };
 
 module.exports = {

--- a/eq-author-api/db/datastore/datastore-mongodb.js
+++ b/eq-author-api/db/datastore/datastore-mongodb.js
@@ -52,6 +52,7 @@ const BASE_FIELDS = [
   ...Object.keys(baseQuestionnaireFields),
   "updatedAt",
   "history",
+  "locked",
 ];
 
 const justListFields = pick(BASE_FIELDS);

--- a/eq-author-api/db/models/DynamoDB.js
+++ b/eq-author-api/db/models/DynamoDB.js
@@ -72,6 +72,9 @@ const baseQuestionnaireSchema = {
     type: Array,
     required: true,
   },
+  locked: {
+    type: Boolean,
+  },
 };
 
 const questionnanaireSchema = new dynamoose.Schema(

--- a/eq-author-api/migrations/addLockedStatus.js
+++ b/eq-author-api/migrations/addLockedStatus.js
@@ -1,0 +1,7 @@
+module.exports = (questionnaire) => {
+  if (questionnaire.locked === undefined || questionnaire.locked === null) {
+    questionnaire.locked = false;
+  }
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addLockedStatus.test.js
+++ b/eq-author-api/migrations/addLockedStatus.test.js
@@ -1,0 +1,14 @@
+const addLockedStatus = require("./addLockedStatus");
+
+describe("Migration: add lock status", () => {
+  it("should add 'false' locked status to questionnaires lacking it", () => {
+    const questionnaire = {};
+    expect(addLockedStatus(questionnaire).locked).toBe(false);
+  });
+  it("should not change questionnaires with existing locked status", () => {
+    const questionnaire = { locked: true };
+    expect(addLockedStatus(questionnaire)).toEqual(questionnaire);
+    questionnaire.locked = false;
+    expect(addLockedStatus(questionnaire)).toEqual(questionnaire);
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -16,6 +16,7 @@ const migrations = [
   require("./addFolders"),
   require("./addGuidancePanelSwitch"),
   require("./addDefaultTheme"),
+  require("./addLockedStatus"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -106,6 +106,7 @@ const {
   enforceHasWritePermission,
   hasWritePermission,
   enforceHasAdminPermission,
+  enforceQuestionnaireLocking,
 } = require("./withPermissions");
 const { createMutation } = require("./createMutation");
 
@@ -300,8 +301,17 @@ const Resolvers = {
 
       return questionnaire;
     },
+    setQuestionnaireLocked: createMutation(
+      (root, { input: { locked } }, ctx) => {
+        ctx.questionnaire.locked = locked;
+        return ctx.questionnaire;
+      },
+      { ignoreLockStatus: true }
+    ),
     deleteQuestionnaire: async (_, { input }, ctx) => {
-      enforceHasWritePermission(ctx.questionnaire, ctx.user);
+      enforceHasWritePermission(ctx.questionnaire, ctx.user); // throws ForbiddenError
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       await deleteQuestionnaire(input.id);
       ctx.questionnaire = null;
       return { id: input.id };
@@ -318,6 +328,7 @@ const Resolvers = {
         editors: [],
         publishStatus: UNPUBLISHED,
         surveyVersion: 1,
+        locked: false,
       };
       return createQuestionnaire(newQuestionnaire, ctx);
     },
@@ -821,6 +832,8 @@ const Resolvers = {
     createComment: async (_, { input }, ctx) => {
       const { componentId, commentText } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );
@@ -848,6 +861,8 @@ const Resolvers = {
     deleteComment: async (_, { input }, ctx) => {
       const { componentId, commentId } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );
@@ -863,6 +878,8 @@ const Resolvers = {
     updateComment: async (_, { input }, ctx) => {
       const { componentId, commentId, commentText } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );
@@ -884,6 +901,8 @@ const Resolvers = {
     createReply: async (_, { input }, ctx) => {
       const { componentId, commentText, commentId } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );
@@ -913,6 +932,8 @@ const Resolvers = {
     updateReply: async (_, { input }, ctx) => {
       const { componentId, commentId, replyId, commentText } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );
@@ -935,6 +956,8 @@ const Resolvers = {
     deleteReply: async (_, { input }, ctx) => {
       const { componentId, commentId, replyId } = input;
       const questionnaire = ctx.questionnaire;
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
       );

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -1,6 +1,9 @@
 const pubsub = require("../../db/pubSub");
 const validateQuestionnaire = require("../../src/validation");
-const { enforceHasWritePermission } = require("./withPermissions");
+const {
+  enforceHasWritePermission,
+  enforceQuestionnaireLocking,
+} = require("./withPermissions");
 
 const { saveQuestionnaire } = require("../../db/datastore");
 const { createHistoryEvent } = require("../../db/datastore");
@@ -12,14 +15,22 @@ const {
   UNPUBLISHED,
 } = require("../../constants/publishStatus");
 
-const createMutation = (mutation) => async (root, args, ctx) => {
+const createMutation = (mutation, { ignoreLockStatus = false } = {}) => async (
+  root,
+  args,
+  ctx
+) => {
   let hasBeenUnpublished;
-  enforceHasWritePermission(ctx.questionnaire, ctx.user);
+  enforceHasWritePermission(ctx.questionnaire, ctx.user); // throws ForbiddenError
+  if (!ignoreLockStatus) {
+    enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+  }
   if (ctx.questionnaire.publishStatus === AWAITING_APPROVAL) {
     throw new Error(
       "User can not edit questionnaire while waiting for approval"
     );
   }
+
   const result = await mutation(root, args, ctx);
   if (ctx.questionnaire.publishStatus === PUBLISHED) {
     ctx.questionnaire.publishStatus = UNPUBLISHED;

--- a/eq-author-api/schema/resolvers/withPermissions.js
+++ b/eq-author-api/schema/resolvers/withPermissions.js
@@ -2,7 +2,7 @@ const { ForbiddenError } = require("apollo-server-express");
 
 const hasWritePermission = (questionnaire, user) =>
   questionnaire.createdBy === user.id ||
-  questionnaire.editors.indexOf(user.id) > -1 ||
+  questionnaire.editors.includes(user.id) ||
   user.admin === true;
 
 const enforceHasWritePermission = (questionnaire, user) => {

--- a/eq-author-api/schema/resolvers/withPermissions.js
+++ b/eq-author-api/schema/resolvers/withPermissions.js
@@ -1,3 +1,5 @@
+const { ForbiddenError } = require("apollo-server-express");
+
 const hasWritePermission = (questionnaire, user) =>
   questionnaire.createdBy === user.id ||
   questionnaire.editors.indexOf(user.id) > -1 ||
@@ -5,15 +7,21 @@ const hasWritePermission = (questionnaire, user) =>
 
 const enforceHasWritePermission = (questionnaire, user) => {
   if (!hasWritePermission(questionnaire, user)) {
-    throw new Error(
+    throw new ForbiddenError(
       "User does not have write permission for this questionnaire"
     );
   }
 };
 
+const enforceQuestionnaireLocking = (questionnaire) => {
+  if (questionnaire.locked) {
+    throw new ForbiddenError("Questionnaire is locked");
+  }
+};
+
 const enforceHasAdminPermission = (user) => {
   if (!user.admin) {
-    throw new Error("User does not have admin permission");
+    throw new ForbiddenError("User does not have admin permission");
   }
 };
 
@@ -21,4 +29,5 @@ module.exports = {
   hasWritePermission,
   enforceHasWritePermission,
   enforceHasAdminPermission,
+  enforceQuestionnaireLocking,
 };

--- a/eq-author-api/schema/tests/comments.test.js
+++ b/eq-author-api/schema/tests/comments.test.js
@@ -1,5 +1,4 @@
 const { buildContext } = require("../../tests/utils/contextBuilder");
-
 const { createQuestionnaire } = require("../../db/datastore");
 
 const {
@@ -150,6 +149,22 @@ describe("comments", () => {
     const comment = await queryComments(ctx, componentId);
 
     expect(comment.comments).toHaveLength(0);
+  });
+
+  describe("locking", () => {
+    it("should prevent adding comments to a locked questionnaire", async () => {
+      expect(
+        createComment(
+          { ...ctx, questionnaire: { ...ctx.questionnaire, locked: true } },
+          {
+            componentId,
+            commentText: "a new comment is created",
+          }
+        )
+      ).rejects.toThrow();
+
+      questionnaire.locked = false;
+    });
   });
 
   describe("replies", () => {

--- a/eq-author-api/schema/tests/duplication.test.js
+++ b/eq-author-api/schema/tests/duplication.test.js
@@ -196,6 +196,7 @@ describe("Duplication", () => {
         "displayName",
         "createdBy",
         "createdAt",
+        "locked",
       ];
       expect(omit(questionnaireCopy, ignoredFields)).toEqual(
         omit(queriedQuestionnaire, ignoredFields)
@@ -204,6 +205,10 @@ describe("Duplication", () => {
 
     it("should have new id", () => {
       expect(questionnaireCopy.id).not.toEqual(queriedQuestionnaire.id);
+    });
+
+    it("should create duplicate unlocked", () => {
+      expect(questionnaireCopy.locked).toBe(false);
     });
 
     it("should create new title and short title", () => {

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -36,6 +36,7 @@ const {
   disableTheme,
   updateTheme,
   toggleQuestionnaireStarred,
+  setQuestionnaireLocked,
 } = require("../../tests/utils/contextBuilder/questionnaire");
 
 const {
@@ -234,6 +235,49 @@ describe("questionnaire", () => {
         // Dynamoose sets empty arrays to undefined, hence we have to check that starredQuestionnaires
         // is either length 0 or undefined
         expect([0, undefined]).toContain(updatedUser.starredQuestionnaires);
+      });
+    });
+
+    describe("locking", () => {
+      it("should allow questionnaire to be locked and unlocked", async () => {
+        await setQuestionnaireLocked(
+          {
+            questionnaireId: ctx.questionnaire.id,
+            locked: true,
+          },
+          ctx
+        );
+
+        let updatedQuestionnaire = await queryQuestionnaire(ctx);
+        expect(updatedQuestionnaire.locked).toBe(true);
+
+        await setQuestionnaireLocked(
+          {
+            questionnaireId: ctx.questionnaire.id,
+            locked: false,
+          },
+          ctx
+        );
+
+        updatedQuestionnaire = await queryQuestionnaire(ctx);
+        expect(updatedQuestionnaire.locked).toBe(false);
+      });
+
+      it("should prevent modifying questionnaire when locked", async () => {
+        await setQuestionnaireLocked(
+          {
+            questionnaireId: ctx.questionnaire.id,
+            locked: true,
+          },
+          ctx
+        );
+
+        expect(
+          updateSurveyId({
+            questionnaireId: ctx.questionnaire.id,
+            surveyId: "1337",
+          })
+        ).rejects.toThrow();
       });
     });
 
@@ -657,6 +701,19 @@ describe("questionnaire", () => {
       const deletedQuestionnaire = await queryQuestionnaire(ctx);
       expect(deletedQuestionnaire).toBeNull();
       questionnaire = null;
+    });
+
+    it("should not delete a locked questionnaire", async () => {
+      ctx = await buildContext({});
+      await setQuestionnaireLocked(
+        {
+          questionnaireId: ctx.questionnaire.id,
+          locked: true,
+        },
+        ctx
+      );
+
+      expect(deleteQuestionnaire(ctx, ctx.questionnaire.id)).rejects.toThrow();
     });
   });
 

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -76,7 +76,9 @@ type Questionnaire {
   surveyId: String
   previewTheme: String!
   themes: [Theme!]!
+  locked: Boolean
 }
+
 enum HistoryEventTypes {
   system
   note
@@ -701,11 +703,17 @@ input ToggleQuestionnaireStarredInput {
   questionnaireId: ID!
 }
 
+input SetQuestionnaireLockedInput {
+  questionnaireId: ID!
+  locked: Boolean!
+}
+
 type Mutation {
   createQuestionnaire(input: CreateQuestionnaireInput!): Questionnaire
   updateQuestionnaire(input: UpdateQuestionnaireInput!): Questionnaire
   deleteQuestionnaire(input: DeleteQuestionnaireInput!): DeletedQuestionnaire
   duplicateQuestionnaire(input: DuplicateQuestionnaireInput!): Questionnaire
+  setQuestionnaireLocked(input: SetQuestionnaireLockedInput!): Questionnaire
 
   createHistoryNote(input: createHistoryNoteInput!): [History!]!
   updateHistoryNote(input: updateHistoryNoteInput!): [History!]!

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/index.js
@@ -13,4 +13,5 @@ module.exports = {
   ...require("./updateSurveyId"),
   ...require("./updateTheme"),
   ...require("./toggleQuestionnaireStarred"),
+  ...require("./setQuestionnaireLocked"),
 };

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
@@ -41,6 +41,7 @@ const getQuestionnaireQuery = `
         eqId
         formType
       }
+      locked
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/setQuestionnaireLocked.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/setQuestionnaireLocked.js
@@ -1,0 +1,24 @@
+const executeQuery = require("../../executeQuery");
+
+const setQuestionnaireLockedMutation = `
+  mutation SetLocked($input: SetQuestionnaireLockedInput!) {
+    setQuestionnaireLocked(input: $input) {
+      id
+      locked
+    }
+  }
+`;
+
+const setQuestionnaireLocked = async (input, ctx) => {
+  const result = await executeQuery(
+    setQuestionnaireLockedMutation,
+    { input },
+    ctx
+  );
+  return result.data.setQuestionnaireLocked;
+};
+
+module.exports = {
+  setQuestionnaireLocked,
+  setQuestionnaireLockedMutation,
+};


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1249)

Adds mutation:

`setQuestionnaireLocked` : `{ questionnaireId, locked }` ->
  locks / unlocks questionnaire with given ID based on value of `locked`

Adds field:

`locked` :
  Boolean value determining whether current questionnaire is locked /
  unlocked

Adds migration to add `locked` field to existing questionnaires,
defaulting to `false`.

Prevent modifying questionnaires which are locked by making
`createMutation` check for questionnaire's locked status. Can be
overriden through passing in new `options` object with truthy `ignoreLockStatus`
to `createMutation` - needed so that the locking / unlocking mutation can still operate on
locked questionnaires.

Prevent modifying comments of questionnaires which are locked per AC.

Duplicating a locked questionnaire results in the duplicate being
unlocked per AC.

Have tested using dev tools and all appears to work as intended

### How to review

- Create a questionnaire
- Attempt to lock it using the `setQuestionnaireLocked` mutation. Can use this mutation in the Apollo dev tools:

`mutation Lock($input: SetQuestionnaireLockedInput!) {
  setQuestionnaireLocked(input: $input) {
    id
    locked
  }
}
`

For variables, use:

`{
  "input": {
    "questionnaireId": "<your-questionnaire-id>",
    "locked": true
  }
}`

- No changes should save to the questionnaire, no comments should save or be editable
- Unlock it by running the above mutation with `"locked": false` in your `input` object.
- Should be able to edit as normal

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
