### PR TITLE
✨ EAR 1252 - Add confirmation modal component

### DIFF
--- a/eq-author/.storybook/main.js
+++ b/eq-author/.storybook/main.js
@@ -1,3 +1,7 @@
+const Path = require("path");
+
+const AppSourceDir = Path.join(__dirname, "..", "src");
+
 module.exports = {
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
@@ -6,4 +10,20 @@ module.exports = {
     "@storybook/addon-controls",
     "@storybook/addon-a11y",
   ],
+  webpackFinal: (config) => {
+    // Disable the Storybook internal-`.svg`-rule for components loaded from our app.
+    const svgRule = config.module.rules.find((rule) =>
+      "test.svg".match(rule.test)
+    );
+    svgRule.exclude = [AppSourceDir];
+
+    // Use svgr / url-loader to load SVG files
+    config.module.rules.push({
+      test: /\.svg$/i,
+      include: [AppSourceDir],
+      use: ["@svgr/webpack", "url-loader"],
+    });
+
+    return config;
+  },
 };

--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -150,7 +150,8 @@
       "!src/graphql/*.js",
       "!src/tests/**/*.js",
       "!src/index.js",
-      "!src/stories/*.js"
+      "!src/stories/*.js",
+      "!src/storybook/**/*"
     ],
     "setupFiles": [
       "<rootDir>/src/tests/setup/throwOnConsole.js",

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -1514,11 +1514,11 @@ exports[`Option should render a checkbox 1`] = `
                               }
                               forwardedRef={null}
                             >
-                              <Component
+                              <ReactComponent
                                 className="c13"
                               >
-                                <svg />
-                              </Component>
+                                <div />
+                              </ReactComponent>
                             </StyledComponent>
                           </DeleteButton__CloseIcon>
                         </button>

--- a/eq-author/src/assets/icon-locked.svg
+++ b/eq-author/src/assets/icon-locked.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1"
+xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Locked</title>
+  <g stroke="none" stroke-width="1" fill="none"
+  fill-rule="evenodd">
+    <g transform="translate(-945.000000, -319.000000)">
+      <g transform="translate(945.000000, 319.000000)">
+        <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+        <path d="M18,8 L17,8 L17,6 C17,3.24 14.76,1 12,1 C9.24,1 7,3.24 7,6 L7,8 L6,8 C4.9,8 4,8.9 4,10 L4,20 C4,21.1 4.9,22 6,22 L18,22 C19.1,22 20,21.1 20,20 L20,10 C20,8.9 19.1,8 18,8 Z M12,17 C10.9,17 10,16.1 10,15 C10,13.9 10.9,13 12,13 C13.1,13 14,13.9 14,15 C14,16.1 13.1,17 12,17 Z M15.1,8 L8.9,8 L8.9,6 C8.9,4.29 10.29,2.9 12,2.9 C13.71,2.9 15.1,4.29 15.1,6 L15.1,8 Z"
+        id="Shape" fill="#3B7A9E" fill-rule="nonzero"></path>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/eq-author/src/assets/icon-unlocked.svg
+++ b/eq-author/src/assets/icon-unlocked.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="22px" height="21px" viewBox="0 0 22 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>unlock_dot_icon</title>
+    <g id="Star-&amp;-Lock-journey" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Home-page---Unlocked-hover" transform="translate(-947.000000, -255.000000)">
+            <g id="unlock_dot_icon" transform="translate(947.000000, 255.000000)">
+                <polyline id="Path" points="15.5 7 14.2 7 13.2 7"></polyline>
+                <line x1="11.3" y1="7" x2="5.1" y2="7" id="Path"></line>
+                <polyline id="Path" points="3.2 7 2.2 7 1 7"></polyline>
+                <circle id="Oval" fill="#888888" fill-rule="nonzero" cx="8" cy="14" r="2"></circle>
+                <path d="M16.1,0 C13.3,0 11.1,2.2 11.1,5 L11.1,7 L2,7 C0.9,7 0,7.9 0,9 L0,19 C0,20.1 0.9,21 2,21 L14,21 C15.1,21 16,20.1 16,19 L16,9 C16,7.9 15.1,7 14,7 L13,7 L13,5 C13,3.3 14.4,1.9 16.1,1.9 C17.8,1.9 19.2,3.3 19.2,5 L19.2,7 L21.1,7 L21.1,5 C21.1,2.3 18.9,0 16.1,0 Z M14,9 L14,19 L2,19 L2,9 L14,9 Z" id="Shape" fill="#888888" fill-rule="nonzero"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/eq-author/src/assets/icon-warning.svg
+++ b/eq-author/src/assets/icon-warning.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="32" fill="#D0021B" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M16.82 17.68v-3.36h-1.64v3.36h1.64zm0 3.32v-1.68h-1.64V21h1.64zm-10 2.5L16 7.68l9.18 15.82H6.82z" fill-rule="evenodd"></path></svg> 

--- a/eq-author/src/components/buttons/DeleteButton/__snapshots__/deletebutton.test.js.snap
+++ b/eq-author/src/components/buttons/DeleteButton/__snapshots__/deletebutton.test.js.snap
@@ -34,7 +34,7 @@ exports[`DeleteButton should render: large 1`] = `
     role="button"
     type="button"
   >
-    <svg />
+    <div />
   </button>
 </DocumentFragment>
 `;
@@ -73,7 +73,7 @@ exports[`DeleteButton should render: medium 1`] = `
     role="button"
     type="button"
   >
-    <svg />
+    <div />
   </button>
 </DocumentFragment>
 `;
@@ -112,7 +112,7 @@ exports[`DeleteButton should render: small 1`] = `
     role="button"
     type="button"
   >
-    <svg />
+    <div />
   </button>
 </DocumentFragment>
 `;

--- a/eq-author/src/components/buttons/DeleteButton/index.js
+++ b/eq-author/src/components/buttons/DeleteButton/index.js
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { colors } from "constants/theme";
 
-import Icon from "./icon-close.svg?inline";
+import { ReactComponent as Icon } from "./icon-close.svg";
 
 const sizes = {
   small: css`

--- a/eq-author/src/components/datatable/Controls/__snapshots__/DeleteRowButton.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/DeleteRowButton.test.js.snap
@@ -40,7 +40,7 @@ exports[`DeleteRowButton should render 1`] = `
     role="button"
     type="button"
   >
-    <svg />
+    <div />
   </button>
 </DocumentFragment>
 `;

--- a/eq-author/src/components/modals/ConfirmationModal/ConfirmationModal.test.js
+++ b/eq-author/src/components/modals/ConfirmationModal/ConfirmationModal.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { screen, render } from "tests/utils/rtl";
+import userEvent from "@testing-library/user-event";
+
+import ConfirmationModal, {
+  DEFAULT_CANCEL_TEXT,
+  DEFAULT_CONFIRM_TEXT,
+} from ".";
+
+describe("Confirmation modal", () => {
+  it("should invoke onConfirm when confirm button pushed", () => {
+    const onConfirm = jest.fn();
+    render(
+      <ConfirmationModal isOpen onCancel={jest.fn()} onConfirm={onConfirm} />
+    );
+    userEvent.click(screen.getByText(DEFAULT_CONFIRM_TEXT));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("should invoke onCancel when cancel button pushed", () => {
+    const onCancel = jest.fn();
+    render(
+      <ConfirmationModal isOpen onCancel={onCancel} onConfirm={jest.fn()} />
+    );
+    userEvent.click(screen.getByText(DEFAULT_CANCEL_TEXT));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should be hidden by default", () => {
+    render(<ConfirmationModal onCancel={jest.fn()} onConfirm={jest.fn()} />);
+    expect(screen.queryByText(DEFAULT_CANCEL_TEXT)).toBeNull();
+  });
+});

--- a/eq-author/src/components/modals/ConfirmationModal/index.js
+++ b/eq-author/src/components/modals/ConfirmationModal/index.js
@@ -1,0 +1,95 @@
+import React from "react";
+import styled from "styled-components";
+import { colors } from "constants/theme";
+import { Grid, Column } from "components/Grid";
+import Modal from "components/modals/Modal";
+import ButtonGroup from "components/buttons/ButtonGroup";
+import Button from "components/buttons/Button";
+import PropTypes from "prop-types";
+
+import { ReactComponent as WarningIcon } from "assets/icon-warning.svg";
+
+const Title = styled.h2`
+  color: ${colors.darkGrey};
+`;
+
+const WarningText = styled.p`
+  color: ${colors.red};
+  font-weight: bold;
+`;
+
+const IconColumn = styled(Column).attrs({ cols: 1, gutters: false })`
+  text-align: right;
+  padding-right: 0.5em;
+  svg {
+    width: 1.5em;
+    height: 1.5em;
+    position: relative;
+    top: 0.125em;
+  }
+`;
+
+const TextColumn = styled(Column).attrs({ cols: 11, gutters: true })``;
+
+const ButtonGroupStyled = styled(ButtonGroup).attrs({
+  horizontal: true,
+  align: "right",
+})`
+  padding-top: 1.5em;
+`;
+
+export const DEFAULT_CONFIRM_TEXT = "Confirm";
+export const DEFAULT_CANCEL_TEXT = "Cancel";
+
+const ConfirmationModal = ({
+  icon: Icon = () => null,
+  title = "Are you sure?",
+  message = "Please confirm this operation.",
+  confirmText = DEFAULT_CONFIRM_TEXT,
+  cancelText = DEFAULT_CANCEL_TEXT,
+  isOpen = false,
+  onConfirm: handleConfirm,
+  onCancel: handleCancel,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={handleCancel}>
+      <Grid align="center">
+        <IconColumn>
+          <Icon />
+        </IconColumn>
+        <TextColumn>
+          <Title>{title}</Title>
+        </TextColumn>
+      </Grid>
+      <Grid align="center">
+        <IconColumn>
+          <WarningIcon />
+        </IconColumn>
+        <TextColumn>
+          <WarningText>{message}</WarningText>
+        </TextColumn>
+      </Grid>
+      <ButtonGroupStyled>
+        <Button variant="secondary" onClick={handleCancel}>
+          {cancelText}
+        </Button>
+        <Button variant="primary" onClick={handleConfirm}>
+          {confirmText}
+        </Button>
+      </ButtonGroupStyled>
+    </Modal>
+  );
+};
+
+ConfirmationModal.propTypes = {
+  icon: PropTypes.node,
+  title: PropTypes.string,
+  message: PropTypes.string,
+  confirmText: PropTypes.string,
+  cancelText: PropTypes.string,
+  isOpen: PropTypes.bool,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ConfirmationModal;

--- a/eq-author/src/storybook/Components/ConfirmationModal.stories.js
+++ b/eq-author/src/storybook/Components/ConfirmationModal.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import ConfirmationModal from "components/modals/ConfirmationModal";
+
+export default {
+  title: "Components/Modals/Confirmation",
+  component: ConfirmationModal,
+  argTypes: {
+    onConfirm: { action: "Confirmed" },
+    onCancel: { action: "Cancelled" },
+  },
+};
+
+export const Default = (args) => <ConfirmationModal isOpen {...args} />;


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1252)
[Prototype](https://overflow.io/s/HSI3MZGH?node=9d931855&prototype&view=fit) (click on lock twice)

Adds `ConfirmationModal` component with props:

`message :: String (confirmation message)`
`title :: String (title shown in dialog)`
`icon :: ReactComponent (icon to display next to title)`
`isOpen :: Boolean (whether to display modal)`
`confirmText :: String (text for 'confirm' button)`
`cancelText :: String (text for 'cancel' button)`
`onConfirm :: void -> void (called on confirm push)`
`onCancel :: void -> void (called on cancel push or close)`

Adds basic storybook template to show component in canvas
Fixes SVGR use in storybook via webpack config changes

## In vivo view

<img width="807" alt="Screenshot 2021-04-08 at 11 30 29" src="https://user-images.githubusercontent.com/60441612/114014839-f2a34200-9860-11eb-95b9-3791187a087d.png">

### How to review

- Have a wee look at it 👀

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
