### PR TITLE
🛠 EAR 1250 - Fix sorting & unlock message

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -139,6 +139,7 @@ const createNewQuestionnaire = (input) => {
     publishStatus: UNPUBLISHED,
     previewTheme: defaultTheme.shortName,
     themes: [defaultTheme],
+    locked: false,
   };
 
   let changes = {};

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
@@ -1,4 +1,4 @@
-import { chunk, clamp, sortBy, reverse, get, flowRight } from "lodash";
+import { chunk, clamp, sortBy, reverse, flowRight } from "lodash";
 
 import { WRITE } from "constants/questionnaire-permissions";
 
@@ -25,7 +25,7 @@ const calculateAutoFocusId = (questionnaires, deletedQuestionnaire) => {
 
 const sortQuestionnaires = (state) => (questionnaires) => {
   const sortedQuestionnaires = sortBy(questionnaires, (questionnaire) => {
-    const sortKey = get(questionnaire, state.currentSortColumn);
+    const sortKey = questionnaire?.[state.currentSortColumn] ?? false;
     return sortKey?.toUpperCase?.() ?? sortKey;
   });
 

--- a/eq-author/src/components/modals/QuestionnaireLockingModal/index.js
+++ b/eq-author/src/components/modals/QuestionnaireLockingModal/index.js
@@ -11,8 +11,9 @@ export const useQuestionnaireLockingModal = ({ id, locked }) => {
     action: () => operation(id),
     icon: locked ? UnlockIcon : LockIcon,
     title: `${locked ? "Unlock" : "Lock"} questionnaire`,
-    message:
-      "When locked any changes made to the questionnaire will not be saved.",
+    message: locked
+      ? "Changes can be made to the questionnaire if it's unlocked."
+      : "When locked any changes made to the questionnaire will not be saved.",
     confirmText: locked ? "Unlock" : "Lock",
   });
 };


### PR DESCRIPTION
### What is the context of this PR?

Fixes for locking issues spotted at PO approval:

- Sorting questionnaires on homepage now works correctly - unmigrated and new questionnaires had `null` lock status which appeared before those with `true`. New questionnaires now start with `locked: false` and the sorting logic maps `null` or `undefined` values to `false`

Changing made to wording to match new request:

- Unlocking modal now has message `Changes can be made to the questionnaire if it's unlocked.` per request on [Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1250)

### How to review

- Check sorting works with a combination of new, existing, locked and unlocked questionnaires
- Check new unlocked message

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
