### PR TITLE
EAR-1278 Add questions pages inside their own folders

### DIFF
--- a/eq-author/src/components/NavigationCallbacks.js
+++ b/eq-author/src/components/NavigationCallbacks.js
@@ -56,7 +56,9 @@ export const useSetNavigationCallbacks = (callbacks, dependencies) => {
 
 export const useSetNavigationCallbacksForPage = ({ page, folder, section }) => {
   const addQuestionPage = useCreateQuestionPage();
+
   const addFolderWithPage = useCreatePageWithFolder();
+
   const addCalculatedSummaryPage = useCreateCalculatedSummaryPage();
   const addFolder = useCreateFolder();
 

--- a/eq-author/src/components/NavigationCallbacks.js
+++ b/eq-author/src/components/NavigationCallbacks.js
@@ -5,7 +5,10 @@ import {
   useCreateQuestionPage,
   useCreateCalculatedSummaryPage,
 } from "hooks/useCreateQuestionPage";
-import { useCreateFolder } from "hooks/useCreateFolder";
+import {
+  useCreateFolder,
+  useCreatePageWithFolder,
+} from "hooks/useCreateFolder";
 
 export const defaultCallbacks = {
   onAddQuestionPage: () => {
@@ -53,21 +56,33 @@ export const useSetNavigationCallbacks = (callbacks, dependencies) => {
 
 export const useSetNavigationCallbacksForPage = ({ page, folder, section }) => {
   const addQuestionPage = useCreateQuestionPage();
+  const addFolderWithPage = useCreatePageWithFolder();
   const addCalculatedSummaryPage = useCreateCalculatedSummaryPage();
   const addFolder = useCreateFolder();
 
   useSetNavigationCallbacks(
     {
       onAddQuestionPage: () =>
-        addQuestionPage({
-          folderId: folder.id,
-          position: page.position + 1,
-        }),
+        page?.folder?.enabled
+          ? addQuestionPage({
+              folderId: folder.id,
+              position: page.position + 1,
+            })
+          : addFolderWithPage({
+              sectionId: section.id,
+              position: folder.position + 1,
+            }),
       onAddCalculatedSummaryPage: () =>
-        addCalculatedSummaryPage({
-          folderId: folder.id,
-          position: page.position + 1,
-        }),
+        page?.folder?.enabled
+          ? addCalculatedSummaryPage({
+              folderId: folder.id,
+              position: page.position + 1,
+            })
+          : addFolderWithPage({
+              sectionId: section.id,
+              position: folder.position + 1,
+              isCalcSum: true,
+            }),
       onAddFolder: () =>
         addFolder({
           sectionId: section.id,

--- a/eq-author/src/components/NavigationCallbacks.test.js
+++ b/eq-author/src/components/NavigationCallbacks.test.js
@@ -19,6 +19,7 @@ jest.mock("hooks/useCreateQuestionPage", () => ({
 }));
 
 jest.mock("hooks/useCreateFolder", () => ({
+  useCreatePageWithFolder: jest.fn(),
   useCreateFolder: jest.fn(),
 }));
 
@@ -62,7 +63,7 @@ describe("Navigation callbacks", () => {
     useCreateFolder.mockImplementation(() => addFolder);
 
     useSetNavigationCallbacksForPage({
-      page: { position: 0 },
+      page: { position: 0, folder: { enabled: true } },
       folder: { id: "folder-1", position: 0 },
       section: { id: "section-1" },
     });

--- a/eq-author/src/components/NavigationCallbacks.test.js
+++ b/eq-author/src/components/NavigationCallbacks.test.js
@@ -11,7 +11,10 @@ import {
   useCreateQuestionPage,
   useCreateCalculatedSummaryPage,
 } from "hooks/useCreateQuestionPage";
-import { useCreateFolder } from "hooks/useCreateFolder";
+import {
+  useCreateFolder,
+  useCreatePageWithFolder,
+} from "hooks/useCreateFolder";
 
 jest.mock("hooks/useCreateQuestionPage", () => ({
   useCreateQuestionPage: jest.fn(),
@@ -30,6 +33,8 @@ jest.mock("react", () => ({
 }));
 
 describe("Navigation callbacks", () => {
+  afterEach(() => jest.clearAllMocks());
+
   it("should throw an error when undefined callbacks used", () => {
     expect(() => defaultCallbacks.onAddQuestionPage()).toThrow();
     expect(() => defaultCallbacks.onAddCalculatedSummaryPage()).toThrow();
@@ -63,7 +68,7 @@ describe("Navigation callbacks", () => {
     useCreateFolder.mockImplementation(() => addFolder);
 
     useSetNavigationCallbacksForPage({
-      page: { position: 0, folder: { enabled: true } },
+      page: { position: 0, folder: { enabled: true, position: 5 } },
       folder: { id: "folder-1", position: 0 },
       section: { id: "section-1" },
     });
@@ -75,7 +80,60 @@ describe("Navigation callbacks", () => {
     callbacks.onAddFolder();
 
     expect(addQuestionPage).toHaveBeenCalledTimes(1);
+    expect(addQuestionPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: "folder-1",
+        position: 1,
+      })
+    );
     expect(addCalculatedSummaryPage).toHaveBeenCalledTimes(1);
+    expect(addCalculatedSummaryPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: "folder-1",
+        position: 1,
+      })
+    );
+    expect(addFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it("useSetNavigationCallbacksForPage: should generate correct callback functions outside folder", () => {
+    let contextValue;
+    useContext.mockImplementation(() => ({
+      callbacks: contextValue,
+      setCallbacks: (value) => {
+        contextValue = value;
+      },
+    }));
+
+    const addPageWithFolder = jest.fn();
+    const addFolder = jest.fn();
+    useCreatePageWithFolder.mockImplementation(() => addPageWithFolder);
+    useCreateFolder.mockImplementation(() => addFolder);
+
+    useSetNavigationCallbacksForPage({
+      page: { position: 0, folder: { enabled: false } },
+      folder: { id: "folder-1", position: 0 },
+      section: { id: "section-1" },
+    });
+
+    const callbacks = useNavigationCallbacks();
+
+    callbacks.onAddQuestionPage();
+    expect(addPageWithFolder).toHaveBeenCalledTimes(1);
+    expect(addPageWithFolder).toHaveBeenCalledWith({
+      sectionId: "section-1",
+      position: 1,
+    });
+
+    callbacks.onAddCalculatedSummaryPage();
+    expect(addPageWithFolder).toHaveBeenCalledTimes(2);
+    expect(addPageWithFolder).toHaveBeenCalledWith({
+      sectionId: "section-1",
+      position: 1,
+      isCalcSum: true,
+    });
+    callbacks.onAddFolder();
+
     expect(addFolder).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What is the context of this PR?

After refactoring the adding question pages, there was a leftover bug where adding question pages was getting dumped in with previous disabled folders. 

This fix ensures that the new question pages are added to their own folders. 

This in turn will stop the position stuff from breaking.


### How to review

When adding question pages, check that they are in their own folder using the `/export/<qid>` end point
