### PR TITLE
EAR-1272-Fix-Sorting-Questionnaires-By-Locked-Or-Starred

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/index.test.js
@@ -659,9 +659,15 @@ describe("QuestionnairesView", () => {
       beforeEach(() => {
         props.questionnaires = [
           buildQuestionnaire(4, { createdAt: "2019-05-10T12:36:50.984Z" }),
-          buildQuestionnaire(2, { createdAt: "2019-05-09T12:36:50.984Z" }),
+          buildQuestionnaire(2, {
+            createdAt: "2019-05-09T12:36:50.984Z",
+            locked: true,
+          }),
           buildQuestionnaire(1, { createdAt: "2019-05-11T12:36:50.984Z" }),
-          buildQuestionnaire(3, { createdAt: "2019-05-08T12:36:50.984Z" }),
+          buildQuestionnaire(3, {
+            createdAt: "2019-05-08T12:36:50.984Z",
+            starred: true,
+          }),
           buildQuestionnaire(5, { createdAt: "2019-05-12T12:36:50.984Z" }),
         ];
       });
@@ -707,6 +713,40 @@ describe("QuestionnairesView", () => {
             `Questionnaire ${reverseNum} Title`
           );
         }
+      });
+
+      it("should sort by locked descending when locked header is clicked", () => {
+        const { getByTestId, getAllByTestId } = render(
+          <QuestionnairesView {...props} />
+        );
+
+        const sortTitleButton = getByTestId("lock-sort-button");
+        fireEvent.click(sortTitleButton);
+        expect(getRowTitleAtIndex(getAllByTestId, 0)).toEqual(
+          `Questionnaire 2 Title`
+        );
+
+        fireEvent.click(sortTitleButton);
+        expect(getRowTitleAtIndex(getAllByTestId, 0)).toEqual(
+          `Questionnaire 4 Title`
+        );
+      });
+
+      it("should sort by starred descending when starred header is clicked", () => {
+        const { getByTestId, getAllByTestId } = render(
+          <QuestionnairesView {...props} />
+        );
+
+        const sortTitleButton = getByTestId("star-sort-button");
+        fireEvent.click(sortTitleButton);
+        expect(getRowTitleAtIndex(getAllByTestId, 0)).toEqual(
+          `Questionnaire 3 Title`
+        );
+
+        fireEvent.click(sortTitleButton);
+        expect(getRowTitleAtIndex(getAllByTestId, 0)).toEqual(
+          `Questionnaire 4 Title`
+        );
       });
 
       it("should sort across multiple pages", () => {

--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/reducer.js
@@ -107,7 +107,9 @@ const reducer = (state, action) => {
         ...state,
         autoFocusId: null,
         currentSortColumn: action.payload,
-        currentSortOrder: SORT_ORDER.ASCENDING,
+        currentSortOrder: ["locked", "starred"].includes(action.payload)
+          ? SORT_ORDER.DESCENDING
+          : SORT_ORDER.ASCENDING,
       });
     case ACTIONS.REVERSE_SORT:
       return buildState({


### PR DESCRIPTION
### What is the context of this PR?

> The initial sort order for the Locked and Starred columns is now descending so that locked and starred questionnaires will appear at the top of the list.

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Check each sortable column heading can be sorted and resorted
- Check the initial sort as ascending for all columns except for Locked and Stared which should be descending

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
