### PR TITLE
EAR-1155-metadata-in-date-validation-renders-wrong-text

### DIFF
--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -9,6 +9,7 @@ const MetadataEditor = ({ onChangeUpdate, answer, validation }) => (
     answerId={answer.id}
     onSubmit={onChangeUpdate}
     selectedContentDisplayName={get(validation.previousAnswer, "displayName")}
+    selectedMetadataDisplayName={get(validation.metadata, "displayName")}
     selectedId={get(validation.previousAnswer, "id")}
   />
 );


### PR DESCRIPTION
### What is the context of this PR?

This ticket resolves the following bug:

**Steps to recreate**

Create a date or a date range answer
Turn on earliest date
Choose Metadata
Select a metadata field
Click Confirm

**Actual behaviour**

It doesn't look like you've selected an answer in the pop up.

**Expected behaviour**

It shows you what metadata has been selected

### How to review

Try the steps to recreate and ensure that the bug is no longer happening.

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
