### PR TITLE
EAR-1153-selecting-previous-answer-for-numerical-total-shows-error

### DIFF
--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
@@ -100,6 +100,7 @@ export const mapMutateToProps = ({ mutate }) => ({
       "latestDateInput",
       "minDurationInput",
       "maxDurationInput",
+      "totalInput",
     ].find((x) => rest[x]);
     return mutate({
       variables: { input: filter(INPUT_FRAGMENT, input) },

--- a/eq-author/src/components/ContentPickerSelect/index.js
+++ b/eq-author/src/components/ContentPickerSelect/index.js
@@ -91,6 +91,7 @@ const ContentPickerSelect = ({
   selectedContentDisplayName = defaultContentName,
   selectedMetadataDisplayName = defaultMetadataName,
   onSubmit,
+  hasError,
   ...otherProps
 }) => {
   const [isPickerOpen, setPickerOpen] = useState(false);
@@ -118,12 +119,13 @@ const ContentPickerSelect = ({
         data-test={contentPickerSelectID}
         onClick={() => setPickerOpen(true)}
         disabled={loading || !isNil(error) || disabled}
+        hasError={hasError}
         {...otherProps}
       >
         <ContentSelected>{buildTitle(contentSelectButtonText)}</ContentSelected>
       </ContentSelectButton>
     ),
-    [loading, contentSelectButtonText, error, disabled]
+    [loading, contentSelectButtonText, error, disabled, hasError]
   );
 
   const handlePickerSubmit = (selected) => {

--- a/eq-author/src/components/ContentPickerSelect/index.js
+++ b/eq-author/src/components/ContentPickerSelect/index.js
@@ -195,6 +195,7 @@ ContentPickerSelect.propTypes = {
   contentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   answerData: PropTypes.arrayOf(PropTypes.shape(idAndName)),
   metadataData: PropTypes.arrayOf(PropTypes.shape(idAndName)),
+  hasError: PropTypes.bool,
 };
 
 export default ContentPickerSelect;


### PR DESCRIPTION
### What is the context of this PR?

The following bug was reported:

**Current behaviour**

Make two numerical answers
add total validation on the last
select a previous answer
After confirming, the answer picker retains error styling

**Expected behaviour**

Make two numerical answers
add total validation on the last
select a previous answer
After confirming, the answer picker loses error styling

### How to review

Ensure that the expected behaviour happens with these changes, instead of the current behaviour.

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
