### PR TITLE
🛠 EAR 1289 - Fix validation modal optimistic response

### DIFF
--- a/eq-author/src/App/page/Design/Validation/builder.js
+++ b/eq-author/src/App/page/Design/Validation/builder.js
@@ -16,11 +16,10 @@ export default (displayName, testId, readKey, writeKey, readToWriteMapper) =>
     withAnswerValidation(readKey),
     withUpdateValidationRule,
     withToggleValidationRule,
-    withPropRemapped(
-      "onUpdateValidationRule",
-      "onUpdate",
-      readToWriteMapper(writeKey)
-    ),
+    withPropRemapped("onUpdateValidationRule", "onUpdate", (entity) => [
+      readToWriteMapper(writeKey)(entity),
+      entity,
+    ]),
     withEntityEditor(readKey),
     withPropRenamed(readKey, "validation")
   )(Validation);

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.js
@@ -91,8 +91,8 @@ const INPUT_FRAGMENT = gql`
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({
-  onUpdateValidationRule: ({ id, ...rest }) => {
-    const input = { id, ...rest };
+  onUpdateValidationRule: ([mutationInput, entity]) => {
+    const { id, ...rest } = mutationInput;
     const validationRule = [
       "minValueInput",
       "maxValueInput",
@@ -102,14 +102,24 @@ export const mapMutateToProps = ({ mutate }) => ({
       "maxDurationInput",
       "totalInput",
     ].find((x) => rest[x]);
-    return mutate({
-      variables: { input: filter(INPUT_FRAGMENT, input) },
-      optimisticResponse: {
-        updateValidationRule: {
-          id,
-          ...rest[validationRule],
-        },
+
+    const customAttribute =
+      entity?.customDate !== undefined ? "customDate" : "custom";
+
+    const optimisticResponse = {
+      updateValidationRule: {
+        id,
+        ...rest[validationRule],
+        enabled: entity?.enabled ?? null,
+        metadata: entity?.metadata ?? null,
+        [customAttribute]: rest[validationRule]?.custom ?? null,
+        previousAnswer: entity?.previousAnswer ?? null,
       },
+    };
+
+    return mutate({
+      variables: { input: filter(INPUT_FRAGMENT, mutationInput) },
+      optimisticResponse,
     });
   },
 });

--- a/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
+++ b/eq-author/src/App/page/Design/Validation/withUpdateValidationRule.test.js
@@ -14,19 +14,20 @@ describe("withUpdateValidationRule", () => {
 
   it("should call mutate", () => {
     const props = mapMutateToProps({ mutate });
-    const answer = {
+
+    const mutationInput = {
       id: "1",
       minValueInput: { inclusive: true, custom: "201", __typename: "foo" },
     };
 
-    props.onUpdateValidationRule(answer);
+    props.onUpdateValidationRule([mutationInput, { enabled: true }]);
     expect(mutate).toHaveBeenCalledWith({
       variables: {
         input: {
-          id: answer.id,
+          id: mutationInput.id,
           minValueInput: {
-            inclusive: answer.minValueInput.inclusive,
-            custom: answer.minValueInput.custom,
+            inclusive: mutationInput.minValueInput.inclusive,
+            custom: mutationInput.minValueInput.custom,
           },
         },
       },
@@ -34,8 +35,11 @@ describe("withUpdateValidationRule", () => {
         updateValidationRule: {
           __typename: "foo",
           custom: "201",
-          id: "1",
           inclusive: true,
+          id: "1",
+          enabled: true,
+          metadata: null,
+          previousAnswer: null,
         },
       },
     });


### PR DESCRIPTION
### What is the context of this PR?

Fixes for [EAR-1290](https://collaborate2.ons.gov.uk/jira/browse/EAR-1290) and [EAR-1291](https://collaborate2.ons.gov.uk/jira/browse/EAR-1291)

Optimistic response added to fix flickering issue didn't match
all expected fields for queries when metadata / previous answer
were selected (e.g. needed to return metadata typename, id, and
displayname) per fragment rather than ID (as expected by graphql
mutation itself).

Adds `enabled`, `metadata` object, `customDate` and `previousAnswer`
objects to optimistic response by passing initial entity through to the
`onUpdateValidationRule` fn and pulling this info out of that.

### How to review

- Try out all validation modals and make sure you can still modify everything
- Date validation modal should now allow you to enter a duration offset while on the metadata page
- Should also allow you to change metadata selection

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
