### PR TITLE
EAR 1334 - 🛠 Fix "view survey" when running local dev env.

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     build:
       context: .
     depends_on:
-      - dynamo
+      - mongo
       - jaeger
     links:
-      - dynamo
+      - mongo
       - jaeger
       - firestore
     volumes:
@@ -19,14 +19,9 @@ services:
       - AWS_REGION=eu-west-1
       - AWS_ACCESS_KEY_ID=dummy
       - AWS_SECRET_ACCESS_KEY=dummy
-      - DYNAMO_ENDPOINT_OVERRIDE=http://dynamo:8000
-      - DYNAMO_QUESTIONNAIRE_TABLE_NAME=dev-author-questionnaires
-      - DYNAMO_QUESTIONNAIRE_VERSION_TABLE_NAME=dev-author-questionnaire-versions
-      - DYNAMO_USER_TABLE_NAME=dev-author-users
-      - DYNAMO_COMMENTS_TABLE_NAME=dev-author-comments
       - NODE_ENV=development
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
-      - PUBLISHER_URL=http://localhost:9000/publish/
+      - PUBLISHER_URL=http://host.docker.internal:9000/publish/
       - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api
@@ -51,11 +46,6 @@ services:
       - FIRESTORE_PROJECT_ID=eq-author-api
     ports:
       - 8070:8080
-
-  dynamo:
-    image: amazon/dynamodb-local
-    ports:
-      - 8050:8000
 
   redis:
     image: redis:5-alpine


### PR DESCRIPTION
### What is the context of this PR?

[Retrospectively made ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1334)

Change `PUBLISHER_URL` in API docker-compose so that runner (when
running via docker-compose too) can access publisher - fixes "view
survey" not working when running everything locally in docker

Removes `dynamo` service from docker-compose for API as no longer needed; strip
out related environment variables

### How to review

Spin up `eq-author-api`, `eq-publisher` and `eq-survey-runner` all using `docker-compose` locally

"View survey" should now work from your local dev environment (previously would show a Runner error unless you'd manually changed the environment variables).

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
