### PR TITLE
EAR 1289 (+1) - 🛠 Fix total validation mutation from UI

### DIFF
--- a/eq-author/src/App/page/Design/Validation/GroupValidations/TotalValidation/TotalValidationEditor/index.js
+++ b/eq-author/src/App/page/Design/Validation/GroupValidations/TotalValidation/TotalValidationEditor/index.js
@@ -111,11 +111,10 @@ TotalValidationEditor.propTypes = {
 
 export default flowRight(
   withUpdateValidationRule,
-  withPropRemapped(
-    "onUpdateValidationRule",
-    "onUpdate",
-    numericReadToWriteMapper("totalInput")
-  ),
+  withPropRemapped("onUpdateValidationRule", "onUpdate", (entity) => [
+    numericReadToWriteMapper("totalInput")(entity),
+    entity,
+  ]),
   withEntityEditor("total"),
   withChangeUpdate
 )(TotalValidationEditor);


### PR DESCRIPTION
### What is the context of this PR?

I didn't update TotalValidationEditor's use of
`withUpdateValidationRule` after changes to fix optimistic response in
EAR 1289, breaking the total validation modal - this PR fixes it

### How to review

- Check you can use the total validation modal once more without crashes
- Check changes persist after refresh

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
