### PR TITLE
Tidy up toggle for fallback option

### DIFF
--- a/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/Fallback.js
+++ b/eq-author/src/App/page/PropertiesPanel/GroupedAnswerProperties/Fallback.js
@@ -23,6 +23,21 @@ const ValidationWarning = styled(IconText)`
   justify-content: normal;
 `;
 
+const StyledInlineField = styled(InlineField)`
+  margin-top: 0.75em;
+`;
+
+const StyledCollapsible = styled(Collapsible)`
+  .collapsible-title {
+    padding-top: 0;
+  }
+  .collapsible-toggle-Collapsible-Button {
+      &::before {
+      margin-top: 0;
+    }
+  }
+`;
+
 const FALLBACK_ERRORS = {
   ERR_VALID_REQUIRED_START: SELECTION_REQUIRED,
   ERR_VALID_REQUIRED_END: SELECTION_REQUIRED,
@@ -48,7 +63,7 @@ export const Fallback = ({
 }) => {
   return (
     <>
-      <InlineField id={"fallback-label"} label={"Fallback"}>
+      <StyledInlineField id={"fallback-label"} label={"Fallback"}>
         <ToggleProperty
           id={"fallback-label"}
           value={properties?.fallback?.enabled ?? false}
@@ -58,7 +73,7 @@ export const Fallback = ({
             })
           }
         />
-      </InlineField>
+      </StyledInlineField>
       {properties?.fallback?.enabled
         ? fallbackSelects({ label, secondaryLabel }).map(
             ({ id, label, name }) => {
@@ -109,13 +124,13 @@ export const Fallback = ({
             }
           )
         : null}
-      <Collapsible title="What is a fallback value?">
+      <StyledCollapsible title="What is a fallback value?">
         <p>
           If this date range answer is piped into later questions, you can
           choose a fallback metadata value to be piped in its place if the
           respondent doesn&apos;t answer this question.
         </p>
-      </Collapsible>
+      </StyledCollapsible>
     </>
   );
 };

--- a/eq-author/src/components/Collapsible/index.js
+++ b/eq-author/src/components/Collapsible/index.js
@@ -111,6 +111,7 @@ const Collapsible = ({
             aria-expanded={isOpen}
             aria-controls="collapsible-body"
             data-test="collapsible-toggle-button"
+            className="collapsible-toggle-Collapsible-Button"
           >
             {renderTitle(showHide, isOpen, title)}
           </ToggleCollapsibleButton>


### PR DESCRIPTION
### What is the context of this PR?

small ticket to create a bit more space above the fallback toggle and to reduce the space below it.

This  shows how it was....

![test-toggle-fallback-Untitled-question](https://user-images.githubusercontent.com/6759437/117801953-c8bcb100-b24c-11eb-8afa-a57db6a05120.png)

This shows how it should be....

![toggle-fix-fsdfwefwef](https://user-images.githubusercontent.com/6759437/117802108-f3a70500-b24c-11eb-9d8e-9f09cdaa26fd.png)


I've also made very small adjustments to the this local collapsible arrow to line up as per Joes request




> Add to the list below as appropriate, including screenshots when necessary

_**create a new date range question and check the spacing on the new fallback toggle on the right hand side**_

