### PR TITLE
EAR 521 (fix) - 🛠 Ignore calc summary pages for qCodes

### DIFF
--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -36,7 +36,9 @@ export const flattenAnswer = (answer) =>
 // Generate list of rows of flattened answers, with parent page information,
 // from input questionnaire object
 export const getFlattenedAnswerRows = (questionnaire) => {
-  const pages = getPages(questionnaire);
+  const pages = getPages(questionnaire)?.filter(
+    ({ pageType }) => pageType !== "CalculatedSummaryPage"
+  );
 
   return pages?.flatMap((page) => {
     const answerRows = page.answers.flatMap(flattenAnswer);


### PR DESCRIPTION
### What is the context of this PR?

Prevent crash caused by trying to process qCodes on calculated summary pages

### How to review

- Check calc sum pages don't crash Author

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
