### PR TITLE
EAR 1207 v3 - 🛠 Remove themes/previewTheme from saved JSON

### DIFF
--- a/eq-author-api/migrations/addThemeSettings.js
+++ b/eq-author-api/migrations/addThemeSettings.js
@@ -10,8 +10,10 @@ module.exports = (questionnaire) => {
         id: theme.shortName,
       })),
     };
-    delete questionnaire.themes;
-    delete questionnaire.previewTheme;
+
+    // Undefined attributes will be removed as part of saveQuestionnaire call
+    questionnaire.themes = undefined;
+    questionnaire.previewTheme = undefined;
   }
 
   return questionnaire;

--- a/eq-author-api/migrations/addThemeSettings.test.js
+++ b/eq-author-api/migrations/addThemeSettings.test.js
@@ -42,8 +42,8 @@ describe("migrations: add theme settings structure", () => {
       },
     });
 
-    expect(migratedQuestionnaire).not.toHaveProperty("themes");
-    expect(migratedQuestionnaire).not.toHaveProperty("previewTheme");
+    expect(migratedQuestionnaire.themes).toBeUndefined();
+    expect(migratedQuestionnaire.previewTheme).toBeUndefined();
   });
 
   it("should migrate to using shortName as theme ID and not UUID", () => {


### PR DESCRIPTION
### What is the context of this PR?

Set removed attributes to `undefined` instead of `delete`-ing them so that they get removed
by `removeEmpty` in `saveQuestionnaire`

Previously `themes` and `previewTheme` were lingering around in the saved JSON post-migration to
using `themeSettings`.

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
