### PR TITLE
🛠 EAR 1047 - Disable duplicate button on click

### DIFF
--- a/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
+++ b/eq-author/src/App/QuestionnairesPage/QuestionnairesView/QuestionnairesTable/Row/index.js
@@ -106,7 +106,9 @@ const TD = styled.td`
   }
 `;
 
-export const DuplicateQuestionnaireButton = styled(DuplicateButton)`
+export const DuplicateQuestionnaireButton = styled(DuplicateButton).attrs({
+  disableOnClick: false,
+})`
   margin-right: 0.5em;
 `;
 

--- a/eq-author/src/components/buttons/DuplicateButton/__snapshots__/index.spec.js.snap
+++ b/eq-author/src/components/buttons/DuplicateButton/__snapshots__/index.spec.js.snap
@@ -1,17 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Duplicate Button should render 1`] = `
-<DuplicateButton
+<Button
   data-test="foo"
-  onClick={[MockFunction]}
+  onClick={[Function]}
+  small={true}
+  type="button"
+  variant="tertiary"
   withText={true}
-/>
+>
+  <IconText
+    hideText={false}
+    icon={[Function]}
+  >
+    Duplicate
+  </IconText>
+</Button>
 `;
 
 exports[`Duplicate Button should render without duplicate text when asked to 1`] = `
-<DuplicateButton
+<Button
   data-test="foo"
-  onClick={[MockFunction]}
+  onClick={[Function]}
+  small={true}
+  type="button"
+  variant="tertiary"
   withText={false}
-/>
+>
+  <IconText
+    hideText={false}
+    icon={[Function]}
+  >
+    Duplicate
+  </IconText>
+</Button>
 `;

--- a/eq-author/src/components/buttons/DuplicateButton/index.js
+++ b/eq-author/src/components/buttons/DuplicateButton/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 
 import IconCopy from "assets/icon-copy.svg?inline";
@@ -12,46 +12,50 @@ const ToolTip = ({ children }) => (
   </Tooltip>
 );
 
-const DuplicateButton = ({ onClick, hideText, children, ...props }) => (
-  <Button onClick={onClick} variant="tertiary" small {...props}>
-    <IconText icon={IconCopy} hideText={hideText}>
-      {children || "Duplicate"}
-    </IconText>
-  </Button>
-);
+const DuplicateButton = ({
+  onClick,
+  hideText,
+  children,
+  disabled,
+  disableOnClick = true,
+  ...props
+}) => {
+  const [buttonClicked, setButtonClicked] = useState(false);
 
-const Component = ({ onClick, hideText, children, ...props }) => {
-  if (hideText) {
-    return (
-      <ToolTip>
-        <DuplicateButton onClick={onClick} hideText={hideText} {...props}>
-          {children}
-        </DuplicateButton>
-      </ToolTip>
-    );
-  }
+  const handleClick = (event) => {
+    if (disableOnClick) {
+      setButtonClicked(true);
+    }
+    return onClick(event);
+  };
 
-  return (
-    <DuplicateButton onClick={onClick} hideText={hideText} {...props}>
-      {children}
-    </DuplicateButton>
+  const renderButton = () => (
+    <Button
+      onClick={handleClick}
+      variant="tertiary"
+      small
+      {...props}
+      disabled={buttonClicked || disabled}
+    >
+      <IconText icon={IconCopy} hideText={hideText}>
+        {children || "Duplicate"}
+      </IconText>
+    </Button>
   );
+
+  return hideText ? <ToolTip>{renderButton()}</ToolTip> : renderButton();
 };
 
 ToolTip.propTypes = {
   children: PropTypes.node,
 };
 
-Component.propTypes = {
-  children: PropTypes.node,
-  onClick: PropTypes.func.isRequired,
-  hideText: PropTypes.bool,
-};
-
 DuplicateButton.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func.isRequired,
   hideText: PropTypes.bool,
+  disableOnClick: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
-export default Component;
+export default DuplicateButton;

--- a/eq-author/src/components/buttons/DuplicateButton/index.spec.js
+++ b/eq-author/src/components/buttons/DuplicateButton/index.spec.js
@@ -1,5 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
+import { render } from "tests/utils/rtl";
+import userEvent from "@testing-library/user-event";
 
 import DuplicateButton from ".";
 
@@ -26,5 +28,21 @@ describe("Duplicate Button", () => {
   it("should render without duplicate text when asked to", () => {
     const wrapper = shallow(<DuplicateButton {...props} withText={false} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should immediately disable the button on click if disableOnClick is set", () => {
+    const { getByRole } = render(<DuplicateButton {...props} />);
+    const button = getByRole("button");
+    userEvent.click(button);
+    expect(button).toBeDisabled();
+  });
+
+  it("should not disable the button on click if disableOnClick is falsy", () => {
+    const { getByRole } = render(
+      <DuplicateButton {...props} disableOnClick={false} />
+    );
+    const button = getByRole("button");
+    userEvent.click(button);
+    expect(button).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
### Context

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1047)

Previously users were able to rapidly click the "Duplicate" button while requests were still in flight, breaking author UI due to race conditions occurring in the DB.

This PR disables the "Duplicate" button after it's clicked on pages, sections and folders, ensuring users can only duplicate pages in the expected sequential order.

NB - I did implement another much more complicated solution using custom Apollo network hooks etc. to disable the button only while mutations were in flight, but it still required manually disabling the button anyway since it was still clickable in the period where such events were still percolating through. This is a super simple solution that works.

### How to review

- Open a questionnaire
- Try and rapidly duplicate a page, section or folder
- Shouldn't be able to duplicate (button should be disabled) while waiting for the newly created entities to appear

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
