### PR TITLE
✨ EAR 1345 - Add not any of option

### DIFF
--- a/eq-author-api/src/businessLogic/answerTypeToConditions.js
+++ b/eq-author-api/src/businessLogic/answerTypeToConditions.js
@@ -21,6 +21,7 @@ const answerConditions = {
   [answerTypes.CHECKBOX]: [
     conditions.ALL_OF,
     conditions.ANY_OF,
+    conditions.NOT_ANY_OF,
     conditions.UNANSWERED,
   ],
 };

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/MultipleChoiceAnswerOptionsSelector.js
@@ -23,6 +23,7 @@ const answerConditions = {
   ALLOF: "AllOf",
   ANYOF: "AnyOf",
   ONEOF: "OneOf",
+  NOTANYOF: "NotAnyOf",
 };
 
 const MultipleChoiceAnswerOptions = styled.div`
@@ -232,6 +233,7 @@ class MultipleChoiceAnswerOptionsSelector extends React.Component {
             data-test="condition-dropdown"
           >
             <option value={answerConditions.ANYOF}>Any of</option>
+            <option value={answerConditions.NOTANYOF}>Not any of</option>
             <option value={answerConditions.ALLOF}>All of</option>
             <option value={answerConditions.UNANSWERED}>Unanswered</option>
           </ConditionSelect>

--- a/eq-publisher/src/utils/convertRoutingConditions.js
+++ b/eq-publisher/src/utils/convertRoutingConditions.js
@@ -5,6 +5,7 @@ const routingConditionConversions = {
   LessThan: "less than",
   GreaterOrEqual: "greater than or equal to",
   LessOrEqual: "less than or equal to",
+  NotAnyOf: "not contains any",
   AllOf: "contains all",
   AnyOf: "contains any",
   Unanswered: "not set",

--- a/eq-publisher/src/utils/convertRoutingConditions.test.js
+++ b/eq-publisher/src/utils/convertRoutingConditions.test.js
@@ -9,6 +9,7 @@ describe("Convert routing conditions", () => {
       LessThan: "less than",
       GreaterOrEqual: "greater than or equal to",
       LessOrEqual: "less than or equal to",
+      NotAnyOf: "not contains any",
     };
     Object.keys(conditionMap).forEach((authorCondition) =>
       expect(converter(authorCondition)).toEqual(conditionMap[authorCondition])


### PR DESCRIPTION
### What is the context of this PR?

Adds a "not any of" option for skip logic / routing rules as per [Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1345) for `Checkbox` type questions.

### How to review

- Try making skip logic / routing rules using the new option
- Should work as you expect when you "view survey"

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
