### PR TITLE
EAR-1197-set-preview-theme

### DIFF
--- a/eq-author/src/App/settings/EqId/index.js
+++ b/eq-author/src/App/settings/EqId/index.js
@@ -40,19 +40,25 @@ const Container = styled.div`
   float: left;
 `;
 
-const EqId = ({ eId, questionnaireId, shortName }) => {
+const EqId = ({ eqId, questionnaireId, shortName }) => {
   return (
     <Container>
       <Field>
         <Label>eQ ID</Label>
       </Field>
       <EqIdInput
-        eqId={eId}
+        eqId={eqId}
         questionnaireId={questionnaireId}
         shortName={shortName}
       />
     </Container>
   );
+};
+
+EqId.propTypes = {
+  eqId: PropTypes.string,
+  questionnaireId: PropTypes.string,
+  shortName: PropTypes.string.isRequired,
 };
 
 export default EqId;

--- a/eq-author/src/App/settings/EqId/index.js
+++ b/eq-author/src/App/settings/EqId/index.js
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { useMutation } from "@apollo/react-hooks";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import updateTheme from "graphql/updateTheme.graphql";
+import { Input, Field, Label } from "components/Forms";
+
+const StyledInput = styled(Input)`
+  width: 11em;
+`;
+
+const EqIdInput = ({ eqId = "", questionnaireId, shortName }) => {
+  const [state, setState] = useState(eqId);
+  const [updateQuestionnaireTheme] = useMutation(updateTheme);
+
+  const handleEQIdBlur = ({ value }, shortName) =>
+    updateQuestionnaireTheme({
+      variables: {
+        input: { questionnaireId, shortName, eqId: value.trim() },
+      },
+    });
+
+  return (
+    <StyledInput
+      value={state}
+      onChange={({ value }) => setState(value)}
+      onBlur={(e) => handleEQIdBlur({ ...e.target }, shortName)}
+      data-test={`${shortName}-eq-id-input`}
+    />
+  );
+};
+
+EqIdInput.propTypes = {
+  eqId: PropTypes.string,
+  questionnaireId: PropTypes.string,
+  shortName: PropTypes.string.isRequired,
+};
+
+const Container = styled.div`
+  float: left;
+`;
+
+const EqId = ({ eId, qId, shortName }) => {
+  return (
+    <Container>
+      <Field>
+        <Label>eQ ID</Label>
+      </Field>
+      <EqIdInput eqId={eId} questionnaireId={qId} shortName={shortName} />
+    </Container>
+  );
+};
+
+export default EqId;

--- a/eq-author/src/App/settings/EqId/index.js
+++ b/eq-author/src/App/settings/EqId/index.js
@@ -40,13 +40,17 @@ const Container = styled.div`
   float: left;
 `;
 
-const EqId = ({ eId, qId, shortName }) => {
+const EqId = ({ eId, questionnaireId, shortName }) => {
   return (
     <Container>
       <Field>
         <Label>eQ ID</Label>
       </Field>
-      <EqIdInput eqId={eId} questionnaireId={qId} shortName={shortName} />
+      <EqIdInput
+        eqId={eId}
+        questionnaireId={questionnaireId}
+        shortName={shortName}
+      />
     </Container>
   );
 };

--- a/eq-author/src/App/settings/EqId/index.test.js
+++ b/eq-author/src/App/settings/EqId/index.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import EqId from ".";
+
+describe("EQ Id", () => {
+  const renderEqId = (props) =>
+    render(
+      <EqId
+        eId="123"
+        questionnaireId="123-456-789"
+        shortName="default"
+        {...props}
+      />
+    );
+
+  it("Can render", () => {
+    const { getByTestId } = renderEqId();
+
+    const field = getByTestId("default-eq-id-input");
+
+    expect(field).toBeVisible();
+  });
+});

--- a/eq-author/src/App/settings/FormType/index.js
+++ b/eq-author/src/App/settings/FormType/index.js
@@ -43,7 +43,7 @@ const Container = styled.div`
   float: left;
 `;
 
-const FormType = ({ formType, qId, shortName }) => {
+const FormType = ({ formType, questionnaireId, shortName }) => {
   return (
     <Container>
       <Field>
@@ -51,7 +51,7 @@ const FormType = ({ formType, qId, shortName }) => {
       </Field>
       <FormTypeInput
         formType={formType}
-        questionnaireId={qId}
+        questionnaireId={questionnaireId}
         shortName={shortName}
       />
     </Container>

--- a/eq-author/src/App/settings/FormType/index.js
+++ b/eq-author/src/App/settings/FormType/index.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { useMutation } from "@apollo/react-hooks";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import updateTheme from "graphql/updateTheme.graphql";
+import { Input, Label, Field } from "components/Forms";
+
+const StyledInput = styled(Input)`
+  width: 11em;
+`;
+
+const FormTypeInput = ({ formType = "", questionnaireId, shortName }) => {
+  const [state, setState] = useState(formType);
+  const [updateQuestionnaireTheme] = useMutation(updateTheme);
+
+  const handleFormTypeBlur = ({ value }, shortName) => {
+    value = value.trim();
+    updateQuestionnaireTheme({
+      variables: {
+        input: { questionnaireId, shortName, formType: value },
+      },
+    });
+  };
+
+  return (
+    <StyledInput
+      value={state}
+      onChange={({ value }) => setState(value)}
+      onBlur={(e) => handleFormTypeBlur({ ...e.target }, shortName)}
+      data-test={`${shortName}-form-type-input`}
+    />
+  );
+};
+
+FormTypeInput.propTypes = {
+  formType: PropTypes.string,
+  questionnaireId: PropTypes.string,
+  shortName: PropTypes.string.isRequired,
+};
+
+const Container = styled.div`
+  margin-left: 1em;
+  float: left;
+`;
+
+const FormType = ({ formType, qId, shortName }) => {
+  return (
+    <Container>
+      <Field>
+        <Label>Form type</Label>
+      </Field>
+      <FormTypeInput
+        formType={formType}
+        questionnaireId={qId}
+        shortName={shortName}
+      />
+    </Container>
+  );
+};
+
+export default FormType;

--- a/eq-author/src/App/settings/FormType/index.js
+++ b/eq-author/src/App/settings/FormType/index.js
@@ -58,4 +58,10 @@ const FormType = ({ formType, questionnaireId, shortName }) => {
   );
 };
 
+FormType.propTypes = {
+  formType: PropTypes.string,
+  questionnaireId: PropTypes.string,
+  shortName: PropTypes.string.isRequired,
+};
+
 export default FormType;

--- a/eq-author/src/App/settings/FormType/index.test.js
+++ b/eq-author/src/App/settings/FormType/index.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import FormType from ".";
+
+describe("Form type", () => {
+  const renderEqId = (props) =>
+    render(
+      <FormType
+        formType="123"
+        questionnaireId="123-456-789"
+        shortName="default"
+        {...props}
+      />
+    );
+
+  it("Can render", () => {
+    const { getByTestId } = renderEqId();
+
+    const field = getByTestId("default-form-type-input");
+
+    expect(field).toBeVisible();
+  });
+});

--- a/eq-author/src/App/settings/PreviewTheme/index.js
+++ b/eq-author/src/App/settings/PreviewTheme/index.js
@@ -37,8 +37,12 @@ const PreviewTheme = ({ questionnaireId, thisTheme, previewTheme }) => {
           })
         }
         checked={thisTheme === previewTheme}
+        dataTest={`${thisTheme}-preview-theme-button`}
       />
-      <StyledLabel htmlFor={`${thisTheme}-preview-theme`}>
+      <StyledLabel
+        htmlFor={`${thisTheme}-preview-theme`}
+        dataTest={`${thisTheme}-preview-theme-label`}
+      >
         Preview theme
       </StyledLabel>
     </Container>

--- a/eq-author/src/App/settings/PreviewTheme/index.js
+++ b/eq-author/src/App/settings/PreviewTheme/index.js
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+import { useMutation } from "@apollo/react-hooks";
+
+import UPDATE_PREVIEW_THEME from "../graphql/updatePreviewTheme.graphql";
+
+import { Input, Label } from "components/Forms";
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 1em;
+`;
+
+const StyledLabel = styled(Label)`
+  margin: 0 0.5em;
+`;
+
+const StyledInput = styled(Input)`
+  margin: 0.5em;
+  position: unset;
+  margin: 0;
+`;
+
+const PreviewTheme = ({ questionnaireId, thisTheme, previewTheme }) => {
+  const [updatePreviewTheme] = useMutation(UPDATE_PREVIEW_THEME);
+
+  return (
+    <Container>
+      <StyledInput
+        id={`${thisTheme}-preview-theme`}
+        type={"radio"}
+        variant="radioBox"
+        onChange={() =>
+          updatePreviewTheme({
+            variables: { input: { questionnaireId, previewTheme: thisTheme } },
+          })
+        }
+        checked={thisTheme === previewTheme}
+      />
+      <StyledLabel htmlFor={`${thisTheme}-preview-theme`}>
+        Preview theme
+      </StyledLabel>
+    </Container>
+  );
+};
+
+export default PreviewTheme;

--- a/eq-author/src/App/settings/PreviewTheme/index.js
+++ b/eq-author/src/App/settings/PreviewTheme/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import PropTypes from "prop-types";
 import { useMutation } from "@apollo/react-hooks";
 
 import UPDATE_PREVIEW_THEME from "../graphql/updatePreviewTheme.graphql";
@@ -17,7 +18,6 @@ const StyledLabel = styled(Label)`
 `;
 
 const StyledInput = styled(Input)`
-  margin: 0.5em;
   position: unset;
   margin: 0;
 `;
@@ -47,6 +47,12 @@ const PreviewTheme = ({ questionnaireId, thisTheme, previewTheme }) => {
       </StyledLabel>
     </Container>
   );
+};
+
+PreviewTheme.propTypes = {
+  questionnaireId: PropTypes.string.isRequired,
+  thisTheme: PropTypes.string.isRequired,
+  previewTheme: PropTypes.string,
 };
 
 export default PreviewTheme;

--- a/eq-author/src/App/settings/PreviewTheme/index.test.js
+++ b/eq-author/src/App/settings/PreviewTheme/index.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import PreviewTheme from ".";
+
+describe("Preview theme", () => {
+  const renderEqId = (props) =>
+    render(
+      <PreviewTheme
+        thisTheme="default"
+        previewTheme="default"
+        questionnaireId="123-456-789"
+        {...props}
+      />
+    );
+
+  it("Can render", () => {
+    const { getByLabelText } = renderEqId();
+
+    const field = getByLabelText("Preview theme");
+
+    expect(field).toBeVisible();
+  });
+});

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -5,7 +5,7 @@ import { withRouter, useParams } from "react-router-dom";
 import { useMutation } from "@apollo/react-hooks";
 
 import updateQuestionnaireMutation from "graphql/updateQuestionnaire.graphql";
-import updateTheme from "graphql/updateTheme.graphql";
+
 import { colors } from "constants/theme";
 
 import VerticalTabs from "components/VerticalTabs";
@@ -18,6 +18,9 @@ import Header from "components/EditorLayout/Header";
 import ScrollPane from "components/ScrollPane";
 import { Field, Input, Label } from "components/Forms";
 import { Grid, Column } from "components/Grid";
+
+import FormType from "./FormType";
+import EqId from "./EqId";
 
 import { THEME_TITLES } from "constants/themeSettings";
 import { THEME_ERROR_MESSAGES } from "constants/validationMessages";
@@ -48,23 +51,15 @@ const PageContainer = styled.div`
   border-left: 1px solid ${colors.lightGrey};
 `;
 
-const StyledPanel = styled.div`
+const Panel = styled.div`
   max-width: 97.5%;
   padding: 1.3em;
 `;
 
-const StyledIdContainerOuter = styled.div`
+const IdContainer = styled.div`
   overflow: hidden;
   padding: 0 0 4px 4px;
-`;
-
-const StyledEqIdContainer = styled.div`
-  float: left;
-`;
-
-const StyledFormTypeContainer = styled.div`
-  margin-left: 1em;
-  float: left;
+  margin-top: 1em;
 `;
 
 const StyledInput = styled(Input)`
@@ -83,68 +78,22 @@ const HorizontalSeparator = styled.hr`
   margin: 1.5em 0;
 `;
 
-const EqIdInput = ({ eqId = "", questionnaireId, shortName }) => {
-  const [state, setState] = useState(eqId);
-  const [updateQuestionnaireTheme] = useMutation(updateTheme);
+const Heading = styled.h2`
+  font-size: 1em;
+  margin-top: 0;
+`;
 
-  const handleEQIdBlur = ({ value }, shortName) =>
-    updateQuestionnaireTheme({
-      variables: {
-        input: { questionnaireId, shortName, eqId: value.trim() },
-      },
-    });
-
-  return (
-    <StyledInput
-      value={state}
-      onChange={({ value }) => setState(value)}
-      onBlur={(e) => handleEQIdBlur({ ...e.target }, shortName)}
-      data-test={`${shortName}-eq-id-input`}
-    />
-  );
-};
-
-const FormTypeInput = ({ formType = "", questionnaireId, shortName }) => {
-  const [state, setState] = useState(formType);
-  const [updateQuestionnaireTheme] = useMutation(updateTheme);
-
-  const handleFormTypeBlur = ({ value }, shortName) => {
-    value = value.trim();
-    updateQuestionnaireTheme({
-      variables: {
-        input: { questionnaireId, shortName, formType: value },
-      },
-    });
-  };
-
-  return (
-    <StyledInput
-      value={state}
-      onChange={({ value }) => setState(value)}
-      onBlur={(e) => handleFormTypeBlur({ ...e.target }, shortName)}
-      data-test={`${shortName}-form-type-input`}
-    />
-  );
-};
-
-EqIdInput.propTypes = {
-  eqId: PropTypes.string,
-  questionnaireId: PropTypes.string,
-  shortName: PropTypes.string.isRequired,
-};
-
-FormTypeInput.propTypes = {
-  formType: PropTypes.string,
-  questionnaireId: PropTypes.string,
-  shortName: PropTypes.string.isRequired,
-};
+const Text = styled.p``;
 
 const ThemesPage = ({ questionnaire }) => {
   const { type, surveyId, id, themeSettings } = questionnaire;
+  const { themes: questionnaireThemes } = themeSettings;
+
   const [updateQuestionnaire] = useMutation(updateQuestionnaireMutation);
+  const [enableTheme] = useMutation(enableThemeMutation);
+  const [disableTheme] = useMutation(disableThemeMutation);
   const [questionnaireId, setQuestionnaireId] = useState(surveyId);
   const params = useParams();
-  const { themes: questionnaireThemes } = themeSettings;
 
   const handleBlur = ({ value }) => {
     value = value.trim();
@@ -153,17 +102,14 @@ const ThemesPage = ({ questionnaire }) => {
     });
   };
 
-  const [enableTheme] = useMutation(enableThemeMutation);
-  const [disableTheme] = useMutation(disableThemeMutation);
-
-  const themeErrorCount = themeSettings.validationErrorInfo?.totalCount ?? 0;
-
   const toggleTheme = ({ shortName, enabled }) => {
     const mutation = enabled ? disableTheme : enableTheme;
     mutation({
       variables: { input: { questionnaireId: id, shortName } },
     });
   };
+
+  const themeErrorCount = themeSettings.validationErrorInfo?.totalCount ?? 0;
 
   const groupErrorMessages = themeSettings.validationErrorInfo.errors
     .filter(({ type }) => type === "themeSettings")
@@ -187,26 +133,19 @@ const ThemesPage = ({ questionnaire }) => {
               />
               <Column gutters={false} cols={9.5}>
                 <SettingsContainer>
-                  <StyledPanel>
-                    <Field>
-                      <Label>Themes, IDs, form types and legal bases</Label>
-                    </Field>
-                    <Field>
-                      <p data-test="theme-description">
-                        The theme sets the design of the eQ for respondents. It
-                        changes the header across the survey, as well as the
-                        contact details and the legal basis on the introduction
-                        page. The COVID theme also changes the thank you page
-                        respondents see once they&apos;ve submitted the survey.
-                      </p>
-                    </Field>
-                    <Field>
-                      <p>
-                        The preview theme is applied when you view the survey
-                        using the View Survey button.
-                      </p>
-                    </Field>
-
+                  <Panel>
+                    <Heading>Themes, IDs, form types and legal bases</Heading>
+                    <Text data-test="theme-description">
+                      The theme sets the design of the eQ for respondents. It
+                      changes the header across the survey, as well as the
+                      contact details and the legal basis on the introduction
+                      page. The COVID theme also changes the thank you page
+                      respondents see once they&apos;ve submitted the survey.
+                    </Text>
+                    <Text>
+                      The preview theme is applied when you view the survey
+                      using the View Survey button.
+                    </Text>
                     <Field>
                       <Label>Survey ID</Label>
                       <Caption>
@@ -235,33 +174,18 @@ const ThemesPage = ({ questionnaire }) => {
                           onChange={() => toggleTheme({ shortName, enabled })}
                           data-test={`${shortName}-toggle`}
                         >
-                          <p />
-                          <StyledIdContainerOuter>
-                            <StyledEqIdContainer>
-                              <Field>
-                                <Label>eQ ID</Label>
-                              </Field>
-                              <EqIdInput
-                                eqId={eqId}
-                                questionnaireId={id}
-                                shortName={shortName}
-                              />
-                            </StyledEqIdContainer>
-                            <StyledFormTypeContainer>
-                              <Field>
-                                <Label>Form type</Label>
-                              </Field>
-                              <FormTypeInput
-                                formType={formType}
-                                questionnaireId={id}
-                                shortName={shortName}
-                              />
-                            </StyledFormTypeContainer>
-                          </StyledIdContainerOuter>
+                          <IdContainer>
+                            <EqId eId={eqId} qId={id} shortName={shortName} />
+                            <FormType
+                              formType={formType}
+                              qId={id}
+                              shortName={shortName}
+                            />
+                          </IdContainer>
                         </CollapsibleToggled>
                       )
                     )}
-                  </StyledPanel>
+                  </Panel>
                 </SettingsContainer>
               </Column>
             </Grid>

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -19,6 +19,7 @@ import ScrollPane from "components/ScrollPane";
 import { Field, Input, Label } from "components/Forms";
 import { Grid, Column } from "components/Grid";
 
+import PreviewTheme from "./PreviewTheme";
 import FormType from "./FormType";
 import EqId from "./EqId";
 
@@ -87,7 +88,7 @@ const Text = styled.p``;
 
 const ThemesPage = ({ questionnaire }) => {
   const { type, surveyId, id, themeSettings } = questionnaire;
-  const { themes: questionnaireThemes } = themeSettings;
+  const { themes: questionnaireThemes, previewTheme } = themeSettings;
 
   const [updateQuestionnaire] = useMutation(updateQuestionnaireMutation);
   const [enableTheme] = useMutation(enableThemeMutation);
@@ -114,6 +115,42 @@ const ThemesPage = ({ questionnaire }) => {
   const groupErrorMessages = themeSettings.validationErrorInfo.errors
     .filter(({ type }) => type === "themeSettings")
     .map(({ errorCode }) => THEME_ERROR_MESSAGES[errorCode]);
+
+  const renderErrors = (errors) =>
+    errors.map((errorMessage, index) => (
+      <ValidationError key={index} right={false}>
+        {errorMessage}
+      </ValidationError>
+    ));
+
+  const renderThemes = (themes, previewTheme, questionnaireId) =>
+    themes.map(({ shortName, eqId, enabled, formType }) => (
+      <CollapsibleToggled
+        key={`${shortName}-toggle`}
+        title={THEME_TITLES[shortName]}
+        isOpen={enabled}
+        onChange={() => toggleTheme({ shortName, enabled })}
+        data-test={`${shortName}-toggle`}
+        headerContent={
+          enabled && (
+            <PreviewTheme
+              questionnaireId={questionnaireId}
+              thisTheme={shortName}
+              previewTheme={previewTheme}
+            />
+          )
+        }
+      >
+        <IdContainer>
+          <EqId eId={eqId} questionnaireId={id} shortName={shortName} />
+          <FormType
+            formType={formType}
+            questionnaireId={id}
+            shortName={shortName}
+          />
+        </IdContainer>
+      </CollapsibleToggled>
+    ));
 
   return (
     <Container>
@@ -160,31 +197,8 @@ const ThemesPage = ({ questionnaire }) => {
                       />
                     </Field>
                     <HorizontalSeparator />
-                    {groupErrorMessages.map((errorMessage, index) => (
-                      <ValidationError key={index} right={false}>
-                        {errorMessage}
-                      </ValidationError>
-                    ))}
-                    {questionnaireThemes.map(
-                      ({ shortName, eqId, enabled, formType }) => (
-                        <CollapsibleToggled
-                          key={`${shortName}-toggle`}
-                          title={THEME_TITLES[shortName]}
-                          isOpen={enabled}
-                          onChange={() => toggleTheme({ shortName, enabled })}
-                          data-test={`${shortName}-toggle`}
-                        >
-                          <IdContainer>
-                            <EqId eId={eqId} qId={id} shortName={shortName} />
-                            <FormType
-                              formType={formType}
-                              qId={id}
-                              shortName={shortName}
-                            />
-                          </IdContainer>
-                        </CollapsibleToggled>
-                      )
-                    )}
+                    {renderErrors(groupErrorMessages)}
+                    {renderThemes(questionnaireThemes, previewTheme, id)}
                   </Panel>
                 </SettingsContainer>
               </Column>

--- a/eq-author/src/App/settings/ThemesPage.js
+++ b/eq-author/src/App/settings/ThemesPage.js
@@ -142,7 +142,7 @@ const ThemesPage = ({ questionnaire }) => {
         }
       >
         <IdContainer>
-          <EqId eId={eqId} questionnaireId={id} shortName={shortName} />
+          <EqId eqId={eqId} questionnaireId={id} shortName={shortName} />
           <FormType
             formType={formType}
             questionnaireId={id}

--- a/eq-author/src/App/settings/graphql/updatePreviewTheme.graphql
+++ b/eq-author/src/App/settings/graphql/updatePreviewTheme.graphql
@@ -1,0 +1,11 @@
+mutation UpdatePreviewTheme($input: UpdatePreviewThemeInput!) {
+  updatePreviewTheme(input: $input) {
+    id
+    previewTheme
+    themes {
+      id
+      enabled
+      shortName
+    }
+  }
+}

--- a/eq-author/src/components/VerticalTabs/index.js
+++ b/eq-author/src/components/VerticalTabs/index.js
@@ -10,11 +10,13 @@ import { Column } from "components/Grid";
 
 const activeClassName = "active";
 
-const Title = styled.div`
+const Title = styled.h2`
   width: 100%;
   padding: 1em 1.2em;
   font-weight: bold;
   border-bottom: 1px solid ${colors.lightGrey};
+  font-size: 1em;
+  margin: 0;
 `;
 
 const StyledTabUl = styled.ul`


### PR DESCRIPTION
### What is the context of this PR?

This ticket adds the 'Preview theme' setting to each theme, which facilitates what theme is applied when viewing in Runner through Author.

I have also made some other refactoring changes along the way:

#### Accessibility refactoring

Vertical tabs heading is now a `h2` element so it can be read by screen readers as a heading to jump to.
Themes page heading is now a `h2` element so it can be read by screen readers as a heading to jump to.

I've made the above two the same level as each other as neither are beneath the other in importance. They're both a `h2` as `h1` is taken by the "Settings" title.

Themes page text is now a `p` element instead of a `label`, as it is not a label.

Unecessary `field` elements have been removed.

#### General refactoring

To encapsulate functionality, I've moved the EQ ID and Form Type logic into their own component that's defined in another file.

Created two new functions, `renderErrors` and `renderThemes`, to encapsulate their respective logic.

### How to review

Have a play around and make sure it all works OK.

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
