### PR TITLE
Disabling a theme set to be previewed now swaps to next available

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -66,6 +66,8 @@ const {
   remapAllNestedIds,
   returnValidationErrors,
   getThemeByShortName,
+  getPreviewTheme,
+  getFirstEnabledTheme,
 } = require("./utils");
 
 const createAnswer = require("../../src/businessLogic/createAnswer");
@@ -392,7 +394,19 @@ const Resolvers = {
           `disableTheme: No theme found with shortName '${shortName}''`
         );
       }
+
       theme.enabled = false;
+
+      const isPreviewTheme = getPreviewTheme(ctx) === shortName;
+
+      if (isPreviewTheme) {
+        const { shortName } = getFirstEnabledTheme(ctx) || {};
+
+        if (shortName) {
+          ctx.questionnaire.themeSettings.previewTheme = shortName;
+        }
+      }
+
       return theme;
     }),
     createHistoryNote: (root, { input }, ctx) =>

--- a/eq-author-api/schema/resolvers/utils/theme.js
+++ b/eq-author-api/schema/resolvers/utils/theme.js
@@ -3,6 +3,14 @@ const getThemeByShortName = ({ questionnaire }, shortName) =>
     (theme) => theme.shortName === shortName
   );
 
+const getPreviewTheme = ({ questionnaire }) =>
+  questionnaire.themeSettings.previewTheme || null;
+
+const getFirstEnabledTheme = ({ questionnaire }) =>
+  questionnaire.themeSettings.themes.find(({ enabled }) => enabled === true);
+
 module.exports = {
   getThemeByShortName,
+  getPreviewTheme,
+  getFirstEnabledTheme,
 };

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -372,6 +372,53 @@ describe("questionnaire", () => {
         );
       });
 
+      it("should move the set preview theme to the first available theme when disabling a theme set as the preview theme", async () => {
+        const { themeSettings: initialThemes } = await queryQuestionnaire(ctx);
+
+        expect(initialThemes.themes[0].enabled).toBe(true);
+        expect(initialThemes.previewTheme).toBe("default");
+
+        await enableTheme(
+          {
+            questionnaireId: questionnaire.id,
+            shortName: "covid",
+          },
+          ctx
+        );
+
+        const {
+          themeSettings: themeSettingsWithTwoThemes,
+        } = await queryQuestionnaire(ctx);
+
+        expect(
+          themeSettingsWithTwoThemes.themes.find(
+            ({ shortName }) => shortName === "covid"
+          ).enabled
+        ).toBe(true);
+
+        expect(themeSettingsWithTwoThemes.previewTheme).toBe("default");
+
+        await disableTheme(
+          {
+            questionnaireId: questionnaire.id,
+            shortName: "default",
+          },
+          ctx
+        );
+
+        const {
+          themeSettings: themeSettingsWithOneTheme,
+        } = await queryQuestionnaire(ctx);
+
+        expect(themeSettingsWithOneTheme.themes[0].enabled).toBe(false);
+        expect(
+          themeSettingsWithTwoThemes.themes.find(
+            ({ shortName }) => shortName === "covid"
+          ).enabled
+        ).toBe(true);
+        expect(themeSettingsWithOneTheme.previewTheme).toBe("covid");
+      });
+
       it("should not be able to disable a non-existent theme", () => {
         expect(
           disableTheme(

--- a/eq-author/src/graphql/disableTheme.graphql
+++ b/eq-author/src/graphql/disableTheme.graphql
@@ -13,6 +13,7 @@ mutation DisableTheme($input: DisableThemeInput!) {
     }
     themeSettings {
       id
+      previewTheme
       validationErrorInfo {
         ...ValidationErrorInfo
       }


### PR DESCRIPTION
### What is the context of this PR?

I forgot to implement the following AC:

Given I'm on the Themes tab of the Settings page
when I turn a theme off
and that theme was set as the Preview theme
and there are other themes turned on
then whichever theme is turned on first on the page will be set as the preview theme

### How to review

Make sure it works now

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
