### PR TITLE
🛠 Route on section (not folder) ID

### DIFF
--- a/eq-publisher/src/eq_schema/builders/routing2/translateRoutingDestination.js
+++ b/eq-publisher/src/eq_schema/builders/routing2/translateRoutingDestination.js
@@ -1,18 +1,10 @@
 const { flatMap, get, findIndex, isNil } = require("lodash");
 
-const getAbsoluteDestination = (destination, ctx) => {
+const getAbsoluteDestination = (destination) => {
   if (destination.page) {
     return { block: `block${destination.page.id}` };
   }
-
-  // Get first folder in the section when routing to sections
-  // TODO: folder-specific routing code
-  const targetSection = ctx.questionnaireJson.sections.find(
-    ({ id }) => id === destination.section.id
-  );
-  const targetFolder = targetSection.folders[0];
-
-  return { group: `group${targetFolder.id}` };
+  return { group: `group${destination.section.id}` };
 };
 
 const getNextPageDestination = (pageId, ctx) => {

--- a/eq-publisher/src/eq_schema/builders/routing2/translateRoutingDestination.test.js
+++ b/eq-publisher/src/eq_schema/builders/routing2/translateRoutingDestination.test.js
@@ -37,7 +37,7 @@ describe("Translation of a routing destination", () => {
     expect(
       translateRoutingDestination(authorDestination, null, ctx)
     ).toMatchObject({
-      group: "group" + ctx.questionnaireJson.sections[0].folders[0].id,
+      group: "group2",
     });
   });
   it("should translate a next page destination", () => {
@@ -55,7 +55,7 @@ describe("Translation of a routing destination", () => {
     };
     expect(
       translateRoutingDestination(authorDestination, "2", { questionnaireJson })
-    ).toMatchObject({ group: "groupfolder-2" });
+    ).toMatchObject({ group: "group2" });
   });
 
   it("should translate a next page destination when last page in questionnaire", () => {


### PR DESCRIPTION
### What is the context of this PR?

Publisher was still attempting to route to folder IDs, which are now gone (merged into sections' groups).

This PR routes on section group ID instead. Fixes issues with broken routing on surveys.

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
