### PR TITLE
EAR 1367 Fix bug preventing date Qcode input

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -564,7 +564,7 @@ const Resolvers = {
       const answer = find(concat(answers, additionalAnswers), { id: input.id });
       merge(answer, input);
 
-      if (answer.type === DATE && !input.label && input.properties) {
+      if (answer.type === DATE && !input.label && input?.properties?.format) {
         answer.validation.earliestDate.offset.unit =
           DURATION_LOOKUP[input.properties.format];
         answer.validation.latestDate.offset.unit =

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -564,7 +564,7 @@ const Resolvers = {
       const answer = find(concat(answers, additionalAnswers), { id: input.id });
       merge(answer, input);
 
-      if (answer.type === DATE && !input.label && input.properties.format) {
+      if (answer.type === DATE && !input.label && input.properties) {
         answer.validation.earliestDate.offset.unit =
           DURATION_LOOKUP[input.properties.format];
         answer.validation.latestDate.offset.unit =


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixing a bug preventing date QCodes from being edited

**Before**
Entering a date QCode would not save the new date input, and the QCode required error was displayed

**After**
Entering a date QCode saves the new date input correctly without an error

### How to review

**Check:**
- [ ] Entering a date QCode saves the new input correctly

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
