### PR TITLE
🛠 EAR 1386 - Questionnaires table: fix sorting by owner

### DIFF
--- a/eq-author/src/components/QuestionnairesView/reducer.js
+++ b/eq-author/src/components/QuestionnairesView/reducer.js
@@ -1,4 +1,4 @@
-import { chunk, clamp, sortBy, reverse, flowRight } from "lodash";
+import { get, chunk, clamp, sortBy, reverse, flowRight } from "lodash";
 
 import { WRITE } from "constants/questionnaire-permissions";
 
@@ -25,7 +25,7 @@ const calculateAutoFocusId = (questionnaires, deletedQuestionnaire) => {
 
 const sortQuestionnaires = (state) => (questionnaires) => {
   const sortedQuestionnaires = sortBy(questionnaires, (questionnaire) => {
-    const sortKey = questionnaire?.[state.currentSortColumn] ?? false;
+    const sortKey = get(questionnaire, state.currentSortColumn);
     return sortKey?.toUpperCase?.() ?? sortKey;
   });
 


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1386)

Fix sorting by "owner" on the homepage's questionnaires view.

When sorting by owner, the sort key was the composite `createdBy.displayName` which couldn't be accessed using computed object key lookup - switch to using `_.get` instead to traverse the path.

### How to review

- Create questionnaires with different users
- Sort by user name
- Should work consistently

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
