### PR TITLE
🛠 EAR 1391 - Fix skip conditions inside folders

### DIFF
--- a/eq-publisher/src/eq_schema/Section.js
+++ b/eq-publisher/src/eq_schema/Section.js
@@ -12,7 +12,13 @@ class Section {
     const pages = flatMap(section.folders, (folder) =>
       flatMap(folder.pages, (page) =>
         folder.skipConditions
-          ? { ...page, skipConditions: folder.skipConditions }
+          ? {
+              ...page,
+              skipConditions: [
+                ...folder.skipConditions,
+                ...(page.skipConditions || []),
+              ],
+            }
           : page
       )
     );


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1391)

Skip conditions for folders were overwriting the skip conditions on their contents - this PR fixes by merging the skip conditions instead.

### How to review

- Add a skip condition to a folder
- Add a skip condition to a page within the folder
- Skip conditions inside the folder should work as expected

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
