### PR TITLE
✨ EAR 1390 - Enable logic entry for calc sum pages

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1129,11 +1129,11 @@ const Resolvers = {
 
   Skippable: {
     __resolveType: ({ pageType, pages }) =>
-      pages
-        ? "Folder"
-        : pageType === "QuestionPage"
-        ? "QuestionPage"
-        : "QuestionConfirmation",
+      pageType ? pageType : pages ? "Folder" : "QuestionConfirmation",
+  },
+
+  Routable: {
+    __resolveType: ({ pageType }) => pageType,
   },
 
   Section: {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -173,7 +173,12 @@ interface Skippable {
   skipConditions: [ExpressionGroup2]
 }
 
-type QuestionPage implements Page & Skippable {
+interface Routable {
+  id: ID!
+  routing: Routing2
+}
+
+type QuestionPage implements Page & Skippable & Routable {
   id: ID!
   title: String!
   alias: String
@@ -200,7 +205,7 @@ type QuestionPage implements Page & Skippable {
   validationErrorInfo: ValidationErrorInfo
 }
 
-type CalculatedSummaryPage implements Page {
+type CalculatedSummaryPage implements Page & Skippable & Routable {
   id: ID!
   title: String!
   alias: String
@@ -213,6 +218,8 @@ type CalculatedSummaryPage implements Page {
   summaryAnswers: [Answer!]!
   totalTitle: String
   validationErrorInfo: ValidationErrorInfo
+  routing: Routing2
+  skipConditions: [ExpressionGroup2]
 }
 
 type ConfirmationOption {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -814,7 +814,7 @@ type Mutation {
   updateRouting2(input: UpdateRouting2Input!): Routing2!
   createRoutingRule2(input: CreateRoutingRule2Input!): RoutingRule2!
   updateRoutingRule2(input: UpdateRoutingRule2Input!): RoutingRule2!
-  deleteRoutingRule2(input: DeleteRoutingRule2Input!): QuestionPage!
+  deleteRoutingRule2(input: DeleteRoutingRule2Input!): Routable!
   updateExpressionGroup2(input: UpdateExpressionGroup2Input!): ExpressionGroup2!
   createBinaryExpression2(input: CreateBinaryExpression2Input!): BinaryExpression2!
   updateBinaryExpression2(input: UpdateBinaryExpression2Input!): BinaryExpression2!

--- a/eq-author/src/App/page/Design/index.js
+++ b/eq-author/src/App/page/Design/index.js
@@ -22,7 +22,7 @@ import { QuestionPage, CalculatedSummaryPage } from "constants/page-types";
 
 const availableTabMatrix = {
   QuestionPage: { design: true, preview: true, logic: true },
-  CalculatedSummaryPage: { design: true, preview: true },
+  CalculatedSummaryPage: { design: true, preview: true, logic: true },
 };
 
 export const PAGE_QUERY = gql`

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/createRouting.graphql
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/createRouting.graphql
@@ -4,10 +4,9 @@
 mutation createRouting2($input: CreateRouting2Input!) {
   createRouting2(input: $input) {
     ...RoutingEditor
-
     page {
       id
-      ... on QuestionPage {
+      ... on Routable {
         routing {
           id
         }

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/fragment.graphql
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/fragment.graphql
@@ -1,10 +1,12 @@
 # import "./RoutingEditor/fragment.graphql"
 
-fragment RoutingPage on QuestionPage {
+fragment RoutingPage on Page {
   id
   position
-  routing {
-    ...RoutingEditor
+  ... on Routable {
+    routing {
+      ...RoutingEditor
+    }
   }
   folder {
     id

--- a/eq-author/src/App/page/Logic/Routing/index.js
+++ b/eq-author/src/App/page/Logic/Routing/index.js
@@ -17,7 +17,7 @@ import Logic from "App/shared/Logic";
 
 import { PageContextProvider } from "components/QuestionnaireContext";
 
-const ROUTING_PAGE_TYPES = ["QuestionPage"];
+const ROUTING_PAGE_TYPES = ["QuestionPage", "CalculatedSummaryPage"];
 
 export class UnwrappedQuestionRoutingRoute extends React.Component {
   static propTypes = {

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -86,7 +86,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     <EditorLayout
       title={page.displayName}
       preview
-      logic={false}
+      logic
       validationErrorInfo={page.validationErrorInfo}
       renderPanel={() => <CommentsPanel componentId={page.id} />}
     >

--- a/eq-author/src/App/shared/Logic/SkipLogic/fragment.graphql
+++ b/eq-author/src/App/shared/Logic/SkipLogic/fragment.graphql
@@ -7,7 +7,7 @@ query GetSkipLogic($input: QueryInput!) {
     skipConditions {
       ...SkipLogicEditor
     }
-    ... on QuestionPage {
+    ... on Page {
       position
       pageType
       displayName

--- a/eq-publisher/src/getQuestionnaire/queries.js
+++ b/eq-publisher/src/getQuestionnaire/queries.js
@@ -184,7 +184,7 @@ exports.getQuestionnaire = `
     fallbackKey
     type
   }
-  
+
   query GetQuestionnaire($input: QueryInput!) {
     questionnaire(input: $input) {
       id
@@ -248,6 +248,25 @@ exports.getQuestionnaire = `
               summaryAnswers {
                 id
               }
+              skipConditions {
+                ...ExpressionGroup
+              }
+            }
+            ... on Routable {
+              routing {
+                rules {
+                  expressionGroup {
+                    operator
+                    ...ExpressionGroup
+                  }
+                  destination {
+                    ...destination2Fragment
+                  }
+                }
+                else {
+                  ...destination2Fragment
+                }
+              }
             }
             ... on QuestionPage {
               description
@@ -290,20 +309,6 @@ exports.getQuestionnaire = `
                   mutuallyExclusiveOption {
                     ...optionFragment
                   }
-                }
-              }
-              routing {
-                rules {
-                  expressionGroup {
-                    operator
-                    ...ExpressionGroup
-                  }
-                  destination {
-                    ...destination2Fragment
-                  }
-                }
-                else {
-                  ...destination2Fragment
                 }
               }
               skipConditions {


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1390)

Allows users to add skip conditions and routing rules to calculated summary pages.

Only relatively minor changes needed in the end. This PR:

- Adds `Routable` graphQL interface
- Makes `QuestionPage` and `CalculatedSummaryPage` implementors of said interface
- Update clientside graphQL to query routing info from `Routable` instead of `QuestionPage`
- Enable the "Logic" tab for calculated summary pages

### How to review

**NB** - Restart your UI dev server after you check this branch out (to update client fragment types)

- Make a calculated summary page
- Check you can now access the "Logic" tab
- Skip conditions & routing rules should work as you expect (as per other pages)

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
