### PR TITLE
Ear 1388 enable qcodes on no survey

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
@@ -78,7 +78,10 @@ export const UnwrappedMainNavigation = ({
   formTypeErrorCount,
   title,
   children,
+  hasSurveyID
 }) => {
+  console.log('hasSurveyID :>> ', hasSurveyID);
+  console.log('totalErrorCount :>> ', totalErrorCount);
   const params = useParams();
   const { hasQCodeError } = useQCodeContext();
   const { me } = useMe();
@@ -90,6 +93,12 @@ export const UnwrappedMainNavigation = ({
     variables: { id: params.questionnaireId },
   });
   const totalErrorCountNoFormType = totalErrorCount - formTypeErrorCount;
+
+  if (!hasSurveyID) {
+    totalErrorCount = totalErrorCount-1
+  };
+
+  console.log('totalErrorCount2 :>> ', totalErrorCount);
 
   const previewUrl = `${config.REACT_APP_LAUNCH_URL}/${params.questionnaireId}`;
 
@@ -226,6 +235,7 @@ UnwrappedMainNavigation.propTypes = {
   children: PropTypes.node,
   settingsError: PropTypes.bool,
   formTypeErrorCount: PropTypes.number,
+  hasSurveyID: PropTypes.bool,
 };
 
 export default UnwrappedMainNavigation;

--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
@@ -80,8 +80,6 @@ export const UnwrappedMainNavigation = ({
   children,
   hasSurveyID
 }) => {
-  console.log('hasSurveyID :>> ', hasSurveyID);
-  console.log('totalErrorCount :>> ', totalErrorCount);
   const params = useParams();
   const { hasQCodeError } = useQCodeContext();
   const { me } = useMe();
@@ -97,8 +95,6 @@ export const UnwrappedMainNavigation = ({
   if (!hasSurveyID) {
     totalErrorCount = totalErrorCount-1
   };
-
-  console.log('totalErrorCount2 :>> ', totalErrorCount);
 
   const previewUrl = `${config.REACT_APP_LAUNCH_URL}/${params.questionnaireId}`;
 

--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
@@ -90,6 +90,11 @@ describe("MainNavigation", () => {
     expect(getByTestId("btn-qcodes").hasAttribute("disabled")).toBeTruthy();
   });
 
+  it("should NOT disable qcodes button if there is no surveyId", () => {
+    const { getByTestId } = defaultSetup({ changes: { totalErrorCount:1 } });
+    expect(getByTestId("btn-qcodes").hasAttribute("disabled")).toBeFalsy();
+  });
+
   it("should disable preview button if there are theme errors and other errors on the questionnaire", () => {
     const { getByTestId } = defaultSetup({
       changes: { totalErrorCount: 2, formTypeErrorCount: 1 },

--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
@@ -95,6 +95,11 @@ describe("MainNavigation", () => {
     expect(getByTestId("btn-qcodes").hasAttribute("disabled")).toBeFalsy();
   });
 
+  it("should disable qcodes button if there is no surveyId BUT there is another error", () => {
+    const { getByTestId } = defaultSetup({ changes: { totalErrorCount:2 } });
+    expect(getByTestId("btn-qcodes").hasAttribute("disabled")).toBeTruthy();
+  });
+
   it("should disable preview button if there are theme errors and other errors on the questionnaire", () => {
     const { getByTestId } = defaultSetup({
       changes: { totalErrorCount: 2, formTypeErrorCount: 1 },

--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.test.js
@@ -79,7 +79,7 @@ describe("MainNavigation", () => {
   });
 
   it("should disable qcodes, publish and preview buttons if there are errors on questionnaire", () => {
-    const { getByTestId } = defaultSetup({ changes: { totalErrorCount: 1 } });
+    const { getByTestId } = defaultSetup({ changes: { totalErrorCount:2 } });
     expect(getByTestId("main-navigation")).toBeTruthy();
 
     expect(getByTestId("btn-preview").hasAttribute("disabled")).toBeTruthy();

--- a/eq-author/src/App/QuestionnaireDesignPage/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/index.js
@@ -109,6 +109,7 @@ export const QuestionnaireDesignPage = () => {
                             questionnaire?.validationErrorInfo?.totalCount
                         )}
                         formTypeErrorCount={formTypeErrorCount}
+                        hasSurveyID={questionnaire?.surveyId !== ""}
                       />
                     </MainNav>
                     <NavigationSidebar


### PR DESCRIPTION
**Acceptance criteria**
_Enable Qcodes page_

GIVEN I'm on a questionnaire
WHEN I have not added a survey ID on the themes tab of the Settings page
THEN I can still access the Qcodes page

https://collaborate2.ons.gov.uk/jira/browse/EAR-1388

### How to review

create a new questionnaire
make sure there are no other errors on it _except_ there should be one error for no surveyID
you should still be able to access the Qcodes page

