### PR TITLE
🛠 EAR 1324 - Fix updating users with firebase backend

### DIFF
--- a/eq-author-api/db/datastore/datastore-firestore.js
+++ b/eq-author-api/db/datastore/datastore-firestore.js
@@ -442,13 +442,10 @@ const updateUser = async (changedUser) => {
     if (!id) {
       throw new Error("Cannot update user without required field: id");
     }
-    const existingUser = await db.collection("users").doc(id).get();
-    const user = Object.assign(changedUser, existingUser);
-    await db
-      .collection("users")
-      .doc(id)
-      .update({ ...user });
-    return user;
+    const doc = db.collection("users").doc(id);
+    const existingUser = await doc.get();
+    await doc.update(changedUser);
+    return { ...existingUser, ...changedUser };
   } catch (error) {
     logger.error(error, `Unable update user with ID ${id}`);
     return;

--- a/eq-author-api/db/datastore/datastore-mongodb.js
+++ b/eq-author-api/db/datastore/datastore-mongodb.js
@@ -52,7 +52,6 @@ const BASE_FIELDS = [
   ...Object.keys(baseQuestionnaireFields),
   "updatedAt",
   "history",
-  "locked",
 ];
 
 const justListFields = pick(BASE_FIELDS);
@@ -383,7 +382,7 @@ const updateUser = async (changedUser) => {
     const existingUser = await collection.findOne({ id: id });
 
     const user = Object.assign(existingUser, changedUser);
-    await collection.updateOne({ id: id }, { $set: { ...user } });
+    await collection.updateOne({ id: id }, { $set: user });
     return user;
   } catch (error) {
     logger.error(error, `Unable update user with ID ${id}`);


### PR DESCRIPTION
### What is the context of this PR?

Fixes "starring" feature with Firestore backend.

Users were not being saved correctly - the original object was being
copied into the change set, removing any changed attributes present in
the original. This PR updates to just save the changes rather than trying
to merge with the original object (the Firestore API will merge the changes).

### How to review

- Modify your `docker-compose.yml` for `eq-author-api` to have `DATABASE=firestore` in `web`'s `environment` rather than `mongodb`; restart API
- Create some questionnaires - locking and starring should work as expected

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
