### PR TITLE
🛠 EAR 1389 - Don't validate `surveyId` on social Q

### DIFF
--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -40,7 +40,8 @@ const {
 
 const validation = require(".");
 
-const uuidRejex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const uuidRejex =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 const addExpression = ({ questionnaire, number, condition }) => {
   questionnaire.sections[0].folders[0].pages[1].routing.rules[0].expressionGroup.expressions.push(
@@ -66,6 +67,7 @@ describe("schema validation", () => {
   beforeEach(() => {
     questionnaire = {
       id: "1",
+      type: "Business",
       sections: [
         {
           id: "section_1",
@@ -171,6 +173,13 @@ describe("schema validation", () => {
       questionnaire.surveyId = "cat";
       const errors = validation(questionnaire);
       expect(errors[0].errorCode).toBe(ERR_INVALID);
+    });
+
+    it("shouldn't return an error if survey ID is missing on a social survey", () => {
+      questionnaire.surveyId = null;
+      questionnaire.type = "Social";
+      const errors = validation(questionnaire);
+      expect(errors).toHaveLength(0);
     });
   });
 
@@ -689,17 +698,18 @@ describe("schema validation", () => {
             ...answer,
             id: "a2",
           });
-          questionnaire.sections[0].folders[0].pages[0].answers[0].validation = {
-            earliestDate: {
-              enabled: true,
-              entityType: "PreviousAnswer",
-              previousAnswer: "a2",
-              relativePosition: "Before",
-            },
-            latestDate: {
-              enabled: false,
-            },
-          };
+          questionnaire.sections[0].folders[0].pages[0].answers[0].validation =
+            {
+              earliestDate: {
+                enabled: true,
+                entityType: "PreviousAnswer",
+                previousAnswer: "a2",
+                relativePosition: "Before",
+              },
+              latestDate: {
+                enabled: false,
+              },
+            };
 
           let errors = validation(questionnaire);
           expect(errors).toEqual(
@@ -1606,7 +1616,8 @@ describe("schema validation", () => {
         expect(validation(questionnaire)).toHaveLength(0);
 
         addExpression({ questionnaire, condition: "GreaterThan" });
-        questionnaire.sections[0].folders[0].pages[1].routing.rules[0].expressionGroup.expressions[1].right = null;
+        questionnaire.sections[0].folders[0].pages[1].routing.rules[0].expressionGroup.expressions[1].right =
+          null;
 
         const errors = validation(questionnaire);
         expect(errors).toHaveLength(1);

--- a/eq-author-api/src/validation/schemas/questionnaire.json
+++ b/eq-author-api/src/validation/schemas/questionnaire.json
@@ -10,19 +10,35 @@
     },
     "themeSettings": {
       "$ref": "themeSettings.json"
+    }
+  },
+  "anyOf": [
+    {
+      "properties": {
+        "type": {
+          "const": "Social"
+        }
+      }
     },
-    "surveyId": {
-      "if": {
-        "type": "string",
-        "minLength": 1
-      },
-      "then": {
-        "pattern": "^\\d{3}$",
-        "errorMessage": "ERR_INVALID"
-      },
-      "else": {
-        "$ref": "definitions.json#/definitions/populatedString"
+    {
+      "properties": {
+        "type": {
+          "const": "Business"
+        },
+        "surveyId": {
+          "if": {
+            "type": "string",
+            "minLength": 1
+          },
+          "then": {
+            "pattern": "^\\d{3}$",
+            "errorMessage": "ERR_INVALID"
+          },
+          "else": {
+            "$ref": "definitions.json#/definitions/populatedString"
+          }
+        }
       }
     }
-  }
+  ]
 }


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1389)

The "Settings" page was showing to have an error dot on social surveys due to the `surveyId` field being missing - despite no way to access the themes page on social surveys.

This PR updates the AJV schema to only validate for `surveyId` if `questionnaire.type` is `"Business"`.

### How to review

- Make a business questionnaire
- Should see an error due to missing survey ID
- Make a social questionnaire
- Should not see an error due to missing survey ID

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
