### PR TITLE
🛠 Fix sort order for locked status

### DIFF
--- a/eq-author/src/components/QuestionnairesView/reducer.js
+++ b/eq-author/src/components/QuestionnairesView/reducer.js
@@ -26,7 +26,7 @@ const calculateAutoFocusId = (questionnaires, deletedQuestionnaire) => {
 const sortQuestionnaires = (state) => (questionnaires) => {
   const sortedQuestionnaires = sortBy(questionnaires, (questionnaire) => {
     const sortKey = get(questionnaire, state.currentSortColumn);
-    return sortKey?.toUpperCase?.() ?? sortKey;
+    return sortKey?.toUpperCase?.() ?? sortKey ?? false;
   });
 
   return state.currentSortOrder === SORT_ORDER.ASCENDING


### PR DESCRIPTION
### What is the context of this PR?

Sorting on the "locked" column was inadvertently broken by fix to sort sorting by the "owner" column.

This PR fixes issues in sorting a mix of objects where the locked attribute is a mix of `null` and `false` by mapping all nullish sort key values to `false`.

### How to review

- Import a questionnaire and set `locked` to `null` in the JSON document
- Lock a different questionnaire
- Make another unlocked questionnaire
- Sort by locked status
- Should work as expected
- 🧉

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
