### PR TITLE
add missing proptypes to naughty tests

### DIFF
--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/AnswerSelector.test.js.snap
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/__snapshots__/AnswerSelector.test.js.snap
@@ -69,6 +69,7 @@ exports[`AnswerSelector should render when there are available summary answers 1
                     "displayName": "Page 1.1.1",
                     "folder": Object {
                       "id": "1",
+                      "position": 0,
                     },
                     "guidance": "",
                     "guidanceEnabled": false,
@@ -78,6 +79,7 @@ exports[`AnswerSelector should render when there are available summary answers 1
                     "section": Object {
                       "displayName": "",
                       "id": "1",
+                      "position": 0,
                     },
                     "title": "Page 1.1.1",
                     "validationErrorInfo": Object {

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/PreviousAnswerContentPicker.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/PreviousAnswerContentPicker.test.js.snap
@@ -40,6 +40,7 @@ exports[`PreviousAnswerContentPicker should render 1`] = `
                 "displayName": "Page 1.1.1",
                 "folder": Object {
                   "id": "1",
+                  "position": 0,
                 },
                 "guidance": "",
                 "guidanceEnabled": false,
@@ -49,6 +50,7 @@ exports[`PreviousAnswerContentPicker should render 1`] = `
                 "section": Object {
                   "displayName": "",
                   "id": "1",
+                  "position": 0,
                 },
                 "title": "Page 1.1.1",
                 "validationErrorInfo": Object {

--- a/eq-author/src/App/page/Design/index.test.js
+++ b/eq-author/src/App/page/Design/index.test.js
@@ -64,6 +64,7 @@ describe("PageRoute", () => {
         loading: false,
         data: { page: buildPages()[0] },
       }));
+
       const { getByTestId } = defaultSetup();
 
       expect(getByTestId("question-page-editor")).toBeVisible();
@@ -77,6 +78,7 @@ describe("PageRoute", () => {
         totalTitle: "",
         summaryAnswers: [],
       };
+
       useQuery.mockImplementationOnce(() => ({
         loading: false,
         data: { page },

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/__snapshots__/index.test.js.snap
@@ -44,6 +44,11 @@ exports[`components/RoutingRuleSet should render children 1`] = `
           "id": "3",
         },
         "section": null,
+        "validationErrorInfo": Object {
+          "errors": Array [],
+          "id": "test",
+          "totalCount": 0,
+        },
       }
     }
   />

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/index.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/index.test.js
@@ -18,6 +18,11 @@ describe("components/RoutingRuleSet", () => {
             id: "3",
             displayName: "page",
           },
+          validationErrorInfo: {
+            id: "test",
+            totalCount: 0,
+            errors: [],
+          },
         },
       },
       createRule: jest.fn(),

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -37,6 +37,7 @@ describe("CalculatedSummaryPreview", () => {
       pageType: "CalculatedSummaryPage",
       section: {
         id: "1",
+        position: 0,
         questionnaire: {
           id: "1",
           metadata: [],
@@ -46,6 +47,10 @@ describe("CalculatedSummaryPreview", () => {
         id: "test",
         totalCount: 0,
         errors: [],
+      },
+      folder: {
+        id: "folder-1",
+        position: 0,
       },
     };
 

--- a/eq-author/src/App/page/Preview/QuestionPagePreview.test.js
+++ b/eq-author/src/App/page/Preview/QuestionPagePreview.test.js
@@ -48,6 +48,7 @@ describe("QuestionPagePreview", () => {
       answers: [{ id: "1", type: TEXTFIELD }],
       section: {
         id: "1",
+        position: 0,
         questionnaire: {
           id: "1",
           metadata: [],

--- a/eq-author/src/App/section/Design/SectionEditor/MoveSectionModal/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/section/Design/SectionEditor/MoveSectionModal/__snapshots__/index.test.js.snap
@@ -33,6 +33,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "displayName": "Page 1.1.1",
                   "folder": Object {
                     "id": "1",
+                    "position": 0,
                   },
                   "guidance": "",
                   "guidanceEnabled": false,
@@ -42,6 +43,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "section": Object {
                     "displayName": "",
                     "id": "1",
+                    "position": 0,
                   },
                   "title": "Page 1.1.1",
                   "validationErrorInfo": Object {
@@ -92,6 +94,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "displayName": "Page 2.1.1",
                   "folder": Object {
                     "id": "1",
+                    "position": 0,
                   },
                   "guidance": "",
                   "guidanceEnabled": false,
@@ -101,6 +104,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "section": Object {
                     "displayName": "",
                     "id": "2",
+                    "position": 0,
                   },
                   "title": "Page 2.1.1",
                   "validationErrorInfo": Object {
@@ -156,6 +160,7 @@ exports[`MoveSectionModal should render 1`] = `
               "displayName": "Page 1.1.1",
               "folder": Object {
                 "id": "1",
+                "position": 0,
               },
               "guidance": "",
               "guidanceEnabled": false,
@@ -165,6 +170,7 @@ exports[`MoveSectionModal should render 1`] = `
               "section": Object {
                 "displayName": "",
                 "id": "1",
+                "position": 0,
               },
               "title": "Page 1.1.1",
               "validationErrorInfo": Object {
@@ -222,6 +228,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "displayName": "Page 1.1.1",
                   "folder": Object {
                     "id": "1",
+                    "position": 0,
                   },
                   "guidance": "",
                   "guidanceEnabled": false,
@@ -231,6 +238,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "section": Object {
                     "displayName": "",
                     "id": "1",
+                    "position": 0,
                   },
                   "title": "Page 1.1.1",
                   "validationErrorInfo": Object {
@@ -281,6 +289,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "displayName": "Page 2.1.1",
                   "folder": Object {
                     "id": "1",
+                    "position": 0,
                   },
                   "guidance": "",
                   "guidanceEnabled": false,
@@ -290,6 +299,7 @@ exports[`MoveSectionModal should render 1`] = `
                   "section": Object {
                     "displayName": "",
                     "id": "2",
+                    "position": 0,
                   },
                   "title": "Page 2.1.1",
                   "validationErrorInfo": Object {
@@ -343,6 +353,7 @@ exports[`MoveSectionModal should render 1`] = `
                 "displayName": "Page 1.1.1",
                 "folder": Object {
                   "id": "1",
+                  "position": 0,
                 },
                 "guidance": "",
                 "guidanceEnabled": false,
@@ -352,6 +363,7 @@ exports[`MoveSectionModal should render 1`] = `
                 "section": Object {
                   "displayName": "",
                   "id": "1",
+                  "position": 0,
                 },
                 "title": "Page 1.1.1",
                 "validationErrorInfo": Object {

--- a/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/NoSkipConditions.js
+++ b/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/NoSkipConditions.js
@@ -63,7 +63,7 @@ const SkipConditionsSetMsg = ({
 
 SkipConditionsSetMsg.propTypes = {
   onAddSkipConditions: PropTypes.func.isRequired,
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   paragraph: PropTypes.string.isRequired,
 };

--- a/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/NoSkipCondtions.test.js
+++ b/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/NoSkipCondtions.test.js
@@ -46,7 +46,7 @@ describe("components/NoSkipConditions", () => {
   it("should call onAddSkipConditions when button clicked", () => {
     const onAddSkipConditions = jest.fn();
     const { getByTestId } = render(
-      <NoSkipConditions onAddSkipConditions={onAddSkipConditions} />
+      <NoSkipConditions onAddSkipConditions={onAddSkipConditions} title={enabledTitle} paragraph={enabledParagraph}/>
     );
     const button = getByTestId("btn-add-skip-condition");
     fireEvent.click(button);

--- a/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/index.test.js
+++ b/eq-author/src/App/shared/Logic/SkipLogic/SkipLogicPage/index.test.js
@@ -69,6 +69,7 @@ describe("Skip Condition Page", () => {
           section: {
             position: 0,
           },
+          skipConditions: null,
         }}
       />
     );

--- a/eq-author/src/components/RichTextEditor/__snapshots__/PipingMenu.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/PipingMenu.test.js.snap
@@ -62,6 +62,7 @@ exports[`PipingMenu should render 1`] = `
                   "displayName": "Page 1.1.1",
                   "folder": Object {
                     "id": "1",
+                    "position": 0,
                   },
                   "guidance": "",
                   "guidanceEnabled": false,
@@ -71,6 +72,7 @@ exports[`PipingMenu should render 1`] = `
                   "section": Object {
                     "displayName": "",
                     "id": "1",
+                    "position": 0,
                   },
                   "title": "Page 1.1.1",
                   "validationErrorInfo": Object {

--- a/eq-author/src/tests/utils/createMockQuestionnaire.js
+++ b/eq-author/src/tests/utils/createMockQuestionnaire.js
@@ -54,9 +54,11 @@ export const buildPages = ({
       section: {
         id: `${sectionNumber}`,
         displayName: "",
+        position: 0,
       },
       folder: {
         id: `${folderNumber}`,
+        position: 0,
       },
       answers: buildAnswers({
         sectionNumber,


### PR DESCRIPTION

### What is the context of this PR?

We have quite a few propType errors sneaking into the jest output again.
Would be good to tidy these up and declutter the test runner output.

### How to review

run yarn test on all the repos and check there are no longer any proptype warnings
Also make sure the tests are all still working as many of them have been updated in this PR to add missing propTypes etc...

NOTE:  there is still a warning about IntrospectionFragmentMatcher and a 3rd party warning about componentWillMount, plus a very wierd warning about borderColor and border - if anyone has the faintest idea about how to sort these - please shout!
