### PR TITLE
Section title now shows when hub enabled

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1142,7 +1142,9 @@ const Resolvers = {
     folders: (section) => section.folders,
     questionnaire: (section, args, ctx) => ctx.questionnaire,
     title: (section, args, ctx) =>
-      ctx.questionnaire.navigation ? section.title : "",
+      ctx.questionnaire.navigation || ctx.questionnaire.hub
+        ? section.title
+        : "",
     displayName: (section, args, ctx) =>
       ctx.questionnaire.navigation
         ? getName(section, "Section")

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -119,6 +119,8 @@ export class SectionEditor extends React.Component {
     const hasNav = section.questionnaire.navigation;
     const hasHub = section.questionnaire.hub;
 
+    console.log(section);
+
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>
         <DeleteConfirmDialog

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -119,8 +119,6 @@ export class SectionEditor extends React.Component {
     const hasNav = section.questionnaire.navigation;
     const hasHub = section.questionnaire.hub;
 
-    console.log(section);
-
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>
         <DeleteConfirmDialog


### PR DESCRIPTION
### What is the context of this PR?

When the Hub is enabled, the section title was saving but not being returned by the DB. This meant that, from the users perspective, they filled in the section title and it would then dissapear, giving the impression that it wasn't saving. **Now**, the DB returns the title which is then shown on the UI as expected.

### How to review

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
