### PR TITLE
EAR-1347-validate empty section title when HUB is ON

### DIFF
--- a/eq-author-api/src/validation/schemas/section.json
+++ b/eq-author-api/src/validation/schemas/section.json
@@ -7,8 +7,16 @@
             "type": "string"
         },
         "title": {
-            "type": "string",
-            "requiredWhenQuestionnaireSetting": "navigation"
+            "allOf": [
+                {
+                    "type": "string",
+                    "requiredWhenQuestionnaireSetting": "navigation"
+                },
+                {
+                    "type": "string",
+                    "requiredWhenQuestionnaireSetting": "hub"
+                }
+            ]
         },
         "introductionTitle": {
             "type": "string",
@@ -29,5 +37,7 @@
             }
         }
     },
-    "required": ["id"]
+    "required": [
+        "id"
+    ]
 }

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -110,7 +110,7 @@ describe("SectionEditor", () => {
     );
   });
 
-  it("should disable the section title when navigation is disabled", () => {
+  it("should disable the section title when navigation (andHub) is disabled", () => {
     const section = {
       ...section1,
       questionnaire: {

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -15,6 +15,7 @@ describe("SectionEditor", () => {
     questionnaire: {
       id: "2",
       navigation: true,
+      hub: false
     },
     validationErrorInfo: {
       id: "3",
@@ -32,6 +33,7 @@ describe("SectionEditor", () => {
     questionnaire: {
       id: "2",
       navigation: true,
+      hub: false
     },
     validationErrorInfo: {
       id: "3",
@@ -99,6 +101,7 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: true,
+        hub: false
       },
     };
     const wrapper = render({ section });
@@ -113,10 +116,26 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: false,
+        hub: false
       },
     };
     const wrapper = render({ section });
     expect(wrapper.find(RichTextEditor).first().prop("disabled")).toEqual(true);
+  });
+
+  it("should enable the section title when Hub is enabled", () => {
+    const section = {
+      ...section1,
+      questionnaire: {
+        id: "2",
+        navigation: false,
+        hub: true
+      },
+    };
+    const wrapper = render({ section });
+    expect(wrapper.find(RichTextEditor).first().prop("disabled")).toEqual(
+      false
+    );
   });
 
   it("should not autofocus the section title when its empty and navigation has just been turned on", () => {
@@ -127,6 +146,7 @@ describe("SectionEditor", () => {
         questionnaire: {
           id: "2",
           navigation: false,
+          hub: false
         },
       },
     });
@@ -138,6 +158,7 @@ describe("SectionEditor", () => {
         questionnaire: {
           id: "2",
           navigation: true,
+          hub: false
         },
       },
     });


### PR DESCRIPTION

### What is the context of this PR?
Add validation to ensure section titles are filled in when hub navigation is enabled. Otherwise there won't be a section title to display on eQ and an error 500 will happen.

This is essentially the same as what happens when section navigation is turned on/off so we should be able to use the same wording

I've updated the section.json file to include section title validation when either HUB OR Navigation is turned on

### How to review

1. Turn on Hub feature flag - REACT_APP_FEATURE_FLAGS="hub" yarn start (in eq-author)
2. Make sure Hub i turned ON in the settings page
3. section titles should now be required
4. restart author with just "yarn start" to default to HUB = off
5. check that section title validation is still working when section Navigation is turned on
6. Give big fat TICK 😁

