### PR TITLE
Ear 1404 remove or option for date range

### DIFF
--- a/eq-author/src/App/page/Design/answers/Date/index.js
+++ b/eq-author/src/App/page/Design/answers/Date/index.js
@@ -212,6 +212,7 @@ UnwrappedDate.propTypes = {
   labelPlaceholder: PropTypes.string,
   autoFocus: PropTypes.bool,
   descriptionPlaceholder: PropTypes.string,
+  disableMutuallyExclusive: PropTypes.bool,
 };
 
 UnwrappedDate.defaultProps = {

--- a/eq-author/src/App/page/Design/answers/Date/index.js
+++ b/eq-author/src/App/page/Design/answers/Date/index.js
@@ -76,6 +76,7 @@ export const UnwrappedDate = ({
   labelPlaceholder,
   autoFocus,
   descriptionPlaceholder,
+  disableMutuallyExclusive,
 }) => {
   const getMutuallyExclusive = ({ options }) =>
     options?.find(({ mutuallyExclusive }) => mutuallyExclusive === true);
@@ -141,19 +142,21 @@ export const UnwrappedDate = ({
           />
         </Format>
       </Field>
-      <ToggleWrapper data-test="toggle-wrapper" disabled={multipleAnswers}>
-        <InlineField>
-          <Label htmlFor="toggle-or-option">{`"Or" option`}</Label>
-          <ToggleSwitch
-            id="toggle-or-option-date"
-            name="toggle-or-option-date"
-            hideLabels={false}
-            onChange={onChangeToggle}
-            checked={getMutuallyExclusive(answer) && !multipleAnswers}
-            data-test="toggle-or-option-date"
-          />
-        </InlineField>
-      </ToggleWrapper>
+      {!disableMutuallyExclusive && (
+        <ToggleWrapper data-test="toggle-wrapper" disabled={multipleAnswers}>
+          <InlineField>
+            <Label htmlFor="toggle-or-option">{`"Or" option`}</Label>
+            <ToggleSwitch
+              id="toggle-or-option-date"
+              name="toggle-or-option-date"
+              hideLabels={false}
+              onChange={onChangeToggle}
+              checked={getMutuallyExclusive(answer) && !multipleAnswers}
+              data-test="toggle-or-option-date"
+            />
+          </InlineField>
+        </ToggleWrapper>
+      )}
       {getMutuallyExclusive(answer) && !multipleAnswers && (
         <StyledOption>
           <Flex>

--- a/eq-author/src/App/page/Design/answers/Date/index.test.js
+++ b/eq-author/src/App/page/Design/answers/Date/index.test.js
@@ -90,4 +90,12 @@ describe("Date", () => {
 
     expect(getByTestId("option-label")).toBeInTheDocument();
   });
+
+  it("Can disable the option to have a mutually exclusive", () => {
+    const { queryByTestId } = rtlRender(() => (
+      <UnwrappedDate {...props} multipleAnswers disableMutuallyExclusive />
+    ));
+
+    expect(queryByTestId("toggle-or-option-date")).not.toBeInTheDocument();
+  });
 });

--- a/eq-author/src/App/page/Design/answers/DateRange/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/DateRange/__snapshots__/index.test.js.snap
@@ -23,6 +23,7 @@ exports[`DateRange should render 1`] = `
         },
       }
     }
+    disableMutuallyExclusive={true}
     key="from-1"
     name="label"
     onChange={[MockFunction]}
@@ -57,6 +58,7 @@ exports[`DateRange should render 1`] = `
         },
       }
     }
+    disableMutuallyExclusive={true}
     key="to-1"
     name="secondaryLabel"
     onChange={[MockFunction]}

--- a/eq-author/src/App/page/Design/answers/DateRange/index.js
+++ b/eq-author/src/App/page/Design/answers/DateRange/index.js
@@ -24,6 +24,7 @@ const DateRange = ({ answer, ...otherProps }) => (
       showDay
       showMonth
       showYear
+      disableMutuallyExclusive
       {...otherProps}
     />
     <Date
@@ -33,6 +34,7 @@ const DateRange = ({ answer, ...otherProps }) => (
       showDay
       showMonth
       showYear
+      disableMutuallyExclusive
       {...otherProps}
     />
   </Wrapper>

--- a/eq-author/src/App/page/Design/answers/DateRange/index.test.js
+++ b/eq-author/src/App/page/Design/answers/DateRange/index.test.js
@@ -80,4 +80,12 @@ describe("DateRange", () => {
 
     expect(getByText(DATE_LABEL_REQUIRED)).toBeTruthy();
   });
+
+  it("Does not have a mutually exclusive option toggle", () => {
+    const { queryByTestId } = rtlRender(
+      <DateRange onUpdate={handleUpdate} {...props} />
+    );
+
+    expect(queryByTestId("toggle-or-option-date")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?

Mutually exclusive options were enabled on a date range. This is not correct. So, this PR introduces a prop to be able to disable the toggle, which is used on a date-range.

### How to review

Check everything works as expected, and that Date answers remain the same in the UI.

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
