### PR TITLE
⬆️ GA: Use node v14 to build API on release

### DIFF
--- a/.github/workflows/buildAuthorRelease.yml
+++ b/.github/workflows/buildAuthorRelease.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set env
         run: echo "TAG=${GITHUB_REF#refs/*/}-release" >> $GITHUB_ENV
-      
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -45,7 +45,6 @@ jobs:
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:$IMAGE_TAG_LATEST
           docker push --all-tags $REGISTRY/$REPOSITORY
 
-
   API:
     runs-on: ubuntu-latest
     defaults:
@@ -53,7 +52,7 @@ jobs:
         working-directory: eq-author-api
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -80,12 +79,11 @@ jobs:
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:$IMAGE_TAG_LATEST
           docker push --all-tags $REGISTRY/$REPOSITORY
 
-
   Publisher:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: eq-publisher   
+        working-directory: eq-publisher
     strategy:
       matrix:
         node-version: [10.x]
@@ -114,4 +112,3 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg APPLICATION_VERSION=$IMAGE_TAG .
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:$IMAGE_TAG_LATEST
           docker push --all-tags $REGISTRY/$REPOSITORY
-


### PR DESCRIPTION
### What is the context of this PR?

Use node v14 to build Author API when releases are triggered from GitHub.

### How to review

- Check it ain't broke when we next deploy to pre-prod ;-)

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
