### PR TITLE
🛠 EAR 1409 - Fix validation for routing answers on same page

### DIFF
--- a/eq-author-api/schema/resolvers/utils/helpers.js
+++ b/eq-author-api/schema/resolvers/utils/helpers.js
@@ -11,15 +11,9 @@ const generateOrderedIdMap = ({ questionnaire }) => {
       return;
     }
 
-    for (const key of Object.keys(obj)) {
-      if (key === "id") {
-        continue; // Process parent's ID after all children are processed
-      }
-
-      if (typeof obj[key] === "object") {
-        traverseIds(obj[key]);
-      }
-    }
+    Object.keys(obj)
+      .sort()
+      .forEach((key) => traverseIds(obj[key]));
 
     if (obj.id && typeof obj.id === "string") {
       map.set(obj.id, map.size);
@@ -34,11 +28,8 @@ const generateOrderedIdMap = ({ questionnaire }) => {
 // Only re-compute ordered ID hash map when necessary (different questionnaire / questionnaire has changed)
 const getOrderedIdMap = (ctx) => {
   if (getOrderedIdMap.lastInvokation) {
-    const {
-      questionnaireId,
-      updatedAt,
-      result,
-    } = getOrderedIdMap.lastInvokation;
+    const { questionnaireId, updatedAt, result } =
+      getOrderedIdMap.lastInvokation;
     if (
       ctx.questionnaire.id === questionnaireId &&
       ctx.questionnaire.updatedAt === updatedAt


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1409)

GCP environment showed intermittent validation errors when questions referenced their own answers as a routing rule.
This was due Firestore returning a random ordering of object keys in the questionnaire JSON - so sometimes a question's `answers` would come after the `routing` section, triggering the AJV rule for "answer has been moved".

This PR sorts the keys in place to maintain a consistent absolute ordering of objects throughout the questionnaire. 

### How to review

- Import this questionnaire: https://staging.author.eqbs.gcp.onsdigital.uk/#/q/8ffe16db-2de9-49f9-8fde-0071f549f0bb/introduction/feba9664-5719-4087-ad6a-e7bc0f8f3e82/design
- Check the "Are you working now?" question, refresh, change pages
- Should not have logic errors relating to "choose an answer earlier in the questionnaire"

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
