### PR TITLE
EAR-1348-section-settings-for-hub

### DIFF
--- a/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.js
@@ -94,7 +94,7 @@ const HubSettings = ({ id, requiredCompleted, showOnHub }) => {
           </InlineField>
         </EnableDisableWrapper>
         <Caption>
-        If this is set to no, respondents cannot go back to this section and change their answers.
+        If this is off, respondents cannot go back to this section and change their answers.
         </Caption>
       </Collapsible>
   );

--- a/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.js
@@ -21,8 +21,6 @@ const InlineField = styled(Field)`
 
 const ToggleWrapper = styled.div`
   display: flex;
-  margin-left: 11em;
-  position: absolute;
   margin-top: -0.3em;
 `;
 
@@ -63,7 +61,7 @@ const HubSettings = ({ id, requiredCompleted, showOnHub }) => {
               onChange={({ value }) =>
                 updateSection({
                   variables: {
-                    input: { id, requiredCompleted: value },
+                    input: { id, requiredCompleted: value, showOnHub: true },
                   },
                 })
               }
@@ -72,11 +70,11 @@ const HubSettings = ({ id, requiredCompleted, showOnHub }) => {
             </ToggleWrapper>
           </InlineField>
           <Caption>
-          The respondent must complete pre-hub sections before they see the &quot;hub&quot;.
+          The respondent must complete pre-hub sections before they see the hub.
         </Caption>
         <EnableDisableWrapper data-test="toggle-wrapper" disabled={!requiredCompleted}>
           <InlineField>
-            <Label htmlFor-="show-onHub">Display section in hub</Label>
+            <Label htmlFor-="show-onHub">Show section on hub and summary pages</Label>
             <ToggleWrapper>
               <ToggleSwitch
                 id="show-onHub"
@@ -96,7 +94,7 @@ const HubSettings = ({ id, requiredCompleted, showOnHub }) => {
           </InlineField>
         </EnableDisableWrapper>
         <Caption>
-          You can choose to show this section in the &quot;hub&quot; so respondents could review their answers.
+        If this is set to no, respondents cannot go back to this section and change their answers.
         </Caption>
       </Collapsible>
   );

--- a/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/HubSettings/index.test.js
@@ -51,7 +51,7 @@ describe("Pre-hub section toggle", () => {
       expect(mockUseMutation).toBeCalledWith({
         variables: {
           input: {
-            id: props.id, requiredCompleted: true
+            id: props.id, requiredCompleted: true, showOnHub: true
           },
         },
       });
@@ -62,7 +62,7 @@ describe("Pre-hub section toggle", () => {
     it("should render Display section toggle ", async () => {
       const { getByText } = rtlRender(() => <HubSettings {...props} />);
     
-      expect(getByText("Display section in hub")).toBeInTheDocument();
+      expect(getByText("Show section on hub and summary pages")).toBeInTheDocument();
     });
 
     it("should render Display section toggle as disabled IF Pre-Hub toggle is OFF ", async () => {


### PR DESCRIPTION
Small changes to previous PR

### What is the context of this PR?
1) text changes...
OLD: The respondent must complete pre-hub sections before they see the "hub".
NEW: The respondent must complete pre-hub sections before they see the hub.
OLD: Display section in hub
NEW: Show section on hub and summary pages
OLD: You can choose to show this section in the "hub" so respondents could review their answers.
NEW: If this is set to no, respondents cannot go back to this section and change their answers.

2)Automatically turn showOnHub ON if it's off and user turns off 'Pre-hub section'

