### PR TITLE
✨ EAR 1318 - Create design for `review questions` modal

### DIFF
--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -140,14 +140,12 @@ exports[`QuestionnaireMeta should render 1`] = `
       horizontal={true}
     >
       <Button
-        btn-focus={true}
         type="button"
         variant="secondary"
       >
         Cancel
       </Button>
       <Button
-        btn-focus={true}
         data-test="questionnaire-submit-button"
         disabled={true}
         type="submit"

--- a/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/QuestionnaireMeta/index.js
@@ -157,7 +157,7 @@ export const StatelessQuestionnaireMeta = ({
         </EnableDisableWrapper>
       </ToggleWrapper>
       <ButtonGroup horizontal align="right">
-        <Button onClick={onCancel} variant="secondary" type="button" btn-focus>
+        <Button onClick={onCancel} variant="secondary" type="button">
           Cancel
         </Button>
         <Button
@@ -165,7 +165,6 @@ export const StatelessQuestionnaireMeta = ({
           variant="primary"
           disabled={!(questionnaire.title && questionnaire.type)}
           data-test="questionnaire-submit-button"
-          btn-focus
         >
           {confirmText}
         </Button>

--- a/eq-author/src/App/page/Design/answers/dummy/TextArea/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/dummy/TextArea/__snapshots__/index.test.js.snap
@@ -28,7 +28,7 @@ exports[`components/Answers/Dummy/TextArea shoulder render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/App/page/Design/answers/dummy/TextInput/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/dummy/TextInput/__snapshots__/index.test.js.snap
@@ -30,7 +30,7 @@ exports[`components/Answers/Dummy/TextInput shoulder render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/assets/icon-chevron-left.svg
+++ b/eq-author/src/assets/icon-chevron-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>

--- a/eq-author/src/assets/icon-warning-circle.svg
+++ b/eq-author/src/assets/icon-warning-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>

--- a/eq-author/src/components/Dialog/DialogButtons/index.js
+++ b/eq-author/src/components/Dialog/DialogButtons/index.js
@@ -24,20 +24,36 @@ const DialogActionButtons = (props) => {
     secondaryActionText,
     tertiaryAction,
     tertiaryActionText,
+    primaryEnabled = true,
+    secondaryEnabled = true,
+    tertiaryEnabled = true,
   } = props;
 
   return (
     <StyledButtonGroup>
-      <ActionButton variant="primary" onClick={primaryAction} autoFocus>
+      <ActionButton
+        variant="primary"
+        onClick={primaryAction}
+        autoFocus
+        disabled={!primaryEnabled}
+      >
         {primaryActionText}
       </ActionButton>
       {secondaryAction && (
-        <ActionButton variant="secondary" onClick={secondaryAction}>
+        <ActionButton
+          variant="secondary"
+          onClick={secondaryAction}
+          disabled={!secondaryEnabled}
+        >
           {secondaryActionText}
         </ActionButton>
       )}
       {tertiaryAction && (
-        <ActionButton variant="secondary" onClick={tertiaryAction}>
+        <ActionButton
+          variant="secondary"
+          onClick={tertiaryAction}
+          disabled={!tertiaryEnabled}
+        >
           {tertiaryActionText}
         </ActionButton>
       )}
@@ -52,6 +68,9 @@ DialogActionButtons.propTypes = {
   secondaryActionText: PropTypes.string,
   tertiaryAction: PropTypes.func,
   tertiaryActionText: PropTypes.string,
+  primaryEnabled: PropTypes.bool,
+  secondaryEnabled: PropTypes.bool,
+  tertiaryEnabled: PropTypes.bool,
 };
 
 export default DialogActionButtons;

--- a/eq-author/src/components/Dialog/DialogButtons/index.js
+++ b/eq-author/src/components/Dialog/DialogButtons/index.js
@@ -28,16 +28,16 @@ const DialogActionButtons = (props) => {
 
   return (
     <StyledButtonGroup>
-      <ActionButton primary onClick={primaryAction} autoFocus>
+      <ActionButton variant="primary" onClick={primaryAction} autoFocus>
         {primaryActionText}
       </ActionButton>
       {secondaryAction && (
-        <ActionButton secondary onClick={secondaryAction}>
+        <ActionButton variant="secondary" onClick={secondaryAction}>
           {secondaryActionText}
         </ActionButton>
       )}
       {tertiaryAction && (
-        <ActionButton tertiary onClick={tertiaryAction}>
+        <ActionButton variant="secondary" onClick={tertiaryAction}>
           {tertiaryActionText}
         </ActionButton>
       )}

--- a/eq-author/src/components/Forms/Input/__snapshots__/Input.test.js.snap
+++ b/eq-author/src/components/Forms/Input/__snapshots__/Input.test.js.snap
@@ -20,7 +20,7 @@ exports[`components/Forms/Input Text should render correctly 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }
@@ -90,11 +90,11 @@ exports[`components/Forms/Input Text should render correctly 1`] = `
                 ";outline-color:",
                 "#3B7A9E",
                 ";}&:focus,&:focus-within{",
-                "border-color:none;outline:3px solid ",
-                "#FDBD56",
-                ";box-shadow:0 0 0 3px ",
-                "#FDBD56",
-                ";",
+                "
+  border-color: transparent;
+  outline: 3px solid #FDBD56;
+  box-shadow: 0 0 0 3px #FDBD56;
+",
                 ";}&::placeholder{color:#a3a3a3;}&:focus{outline:none;border-style:solid;border-color:",
                 "#3B7A9E",
                 ";}&[disabled]{opacity:0.8;pointer-events:none;}",

--- a/eq-author/src/components/Forms/TextArea/__snapshots__/TextArea.test.js.snap
+++ b/eq-author/src/components/Forms/TextArea/__snapshots__/TextArea.test.js.snap
@@ -22,7 +22,7 @@ exports[`components/Forms/TextArea should render correctly 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/buttons/Button/__snapshots__/LinkButton.test.js.snap
+++ b/eq-author/src/components/buttons/Button/__snapshots__/LinkButton.test.js.snap
@@ -42,6 +42,12 @@ exports[`components/Button/LinkButton should render 1`] = `
   opacity: 0.6;
 }
 
+.c0:focus-within {
+  border-color: transparent;
+  outline: 3px solid #FDBD56;
+  box-shadow: 0 0 0 3px #FDBD56;
+}
+
 <a
     class="-a c0"
     href="/test"

--- a/eq-author/src/components/buttons/Button/index.js
+++ b/eq-author/src/components/buttons/Button/index.js
@@ -4,7 +4,7 @@ import { darken } from "polished";
 
 import { propTypes } from "./propTypes";
 
-import { radius, colors } from "constants/theme";
+import { radius, colors, focusStyle } from "constants/theme";
 
 export const primaryButton = css`
   --color-text: ${colors.white};
@@ -247,20 +247,6 @@ export const smallMediumButton = css`
   font-size: 0.9em;
 `;
 
-export const btnfocus = css`
-  &:focus {
-    box-shadow: 0 0 0 3px ${colors.tertiary};
-    outline: 0;
-  }
-`;
-
-export const btnfocusWithin = css`
-  &:focus-within {
-    box-shadow: 0 0 0 3px ${colors.tertiary};
-    outline: 0;
-  }
-`;
-
 const Button = styled.button`
   display: inline-flex;
   flex: 0 0 auto;
@@ -287,6 +273,10 @@ const Button = styled.button`
     opacity: 0.6;
   }
 
+  &:focus-within {
+    ${focusStyle}
+  }
+
   ${(props) => props.variant === "primary" && primaryButton};
   ${(props) => props.variant === "secondary" && secondaryButton};
   ${(props) => props.variant === "tertiary" && tertiaryButton};
@@ -303,8 +293,6 @@ const Button = styled.button`
   ${(props) => props.medium && mediumButton};
   ${(props) => props.small && smallButton};
   ${(props) => props["small-medium"] && smallMediumButton};
-  ${(props) => props["btn-focus"] && btnfocus};
-  ${(props) => props["btn-focus-within"] && btnfocusWithin};
 `;
 
 Button.propTypes = {

--- a/eq-author/src/components/buttons/CloseButton/__snapshots__/closeButton.test.js.snap
+++ b/eq-author/src/components/buttons/CloseButton/__snapshots__/closeButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Close button should render: large 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #3B7A9E;
+  color: #666666;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -42,7 +42,7 @@ exports[`Close button should render: large 1`] = `
 exports[`Close button should render: medium 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #3B7A9E;
+  color: #666666;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -81,7 +81,7 @@ exports[`Close button should render: medium 1`] = `
 exports[`Close button should render: small 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #3B7A9E;
+  color: #666666;
   border: none;
   background: transparent;
   cursor: pointer;

--- a/eq-author/src/components/buttons/CloseButton/index.js
+++ b/eq-author/src/components/buttons/CloseButton/index.js
@@ -20,7 +20,7 @@ const sizes = {
 };
 
 const StyledCloseButton = styled.button`
-  color: ${colors.secondary};
+  color: ${colors.darkGrey};
   border: none;
   background: transparent;
   cursor: pointer;

--- a/eq-author/src/components/buttons/TextButton/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/TextButton/__snapshots__/index.test.js.snap
@@ -52,6 +52,12 @@ exports[`components/TextButton renders 1`] = `
   opacity: 0.6;
 }
 
+.c0:focus-within {
+  border-color: transparent;
+  outline: 3px solid #FDBD56;
+  box-shadow: 0 0 0 3px #FDBD56;
+}
+
 .c0:hover {
   --color-text: #FFFFFF;
   --color-bg: #3B7A9E;

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -55,7 +55,7 @@ exports[`ToggleSwitch should render 1`] = `
 
 .c1:focus,
 .c1:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }
@@ -270,7 +270,7 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
 
 .c1:focus,
 .c1:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/datatable/Controls/__snapshots__/AddRowButton.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/AddRowButton.test.js.snap
@@ -49,6 +49,12 @@ exports[`AddRowButton should render 1`] = `
   opacity: 0.6;
 }
 
+.c0:focus-within {
+  border-color: transparent;
+  outline: 3px solid #FDBD56;
+  box-shadow: 0 0 0 3px #FDBD56;
+}
+
 .c0:hover {
   --color-text: #FFFFFF;
   --color-bg: #2d5d79;

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableInput.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableInput.test.js.snap
@@ -21,7 +21,7 @@ exports[`TableInput should render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableInputDate.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableInputDate.test.js.snap
@@ -21,7 +21,7 @@ exports[`TableInputDate should render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableSelect.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableSelect.test.js.snap
@@ -33,7 +33,7 @@ exports[`TableSelect should render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/datatable/Controls/__snapshots__/TableTypeaheadInput.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/TableTypeaheadInput.test.js.snap
@@ -21,7 +21,7 @@ exports[`TableTypeaheadInput should render 1`] = `
 
 .c0:focus,
 .c0:focus-within {
-  border-color: none;
+  border-color: transparent;
   outline: 3px solid #FDBD56;
   box-shadow: 0 0 0 3px #FDBD56;
 }

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
@@ -49,11 +49,10 @@ const RemoveAllButton = styled.button`
   font-size: 1em;
 `;
 
-const dummyQuestions = [
-  { alias: "Q1", title: "How many roads must a man walk down?" },
-  { alias: "Q2", title: "What is the airspeed velocity of a swallow?" },
-  { alias: "Q3", title: "What is your favourite colour?" },
-];
+const ContentHeading = styled.h4`
+  margin: 1em 0;
+  color: ${colors.textLight};
+`;
 
 const QuestionRow = ({ question: { alias, title }, onRemove }) => {
   return (
@@ -73,10 +72,13 @@ const QuestionRow = ({ question: { alias, title }, onRemove }) => {
   );
 };
 
-const ContentHeading = styled.h4`
-  margin: 1em 0;
-  color: ${colors.textLight};
-`;
+QuestionRow.propTypes = {
+  question: PropTypes.shape({
+    alias: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  }),
+  onRemove: PropTypes.func.isRequired,
+};
 
 const ImportQuestionReviewModal = ({
   isOpen,
@@ -138,6 +140,17 @@ const ImportQuestionReviewModal = ({
       </Content>
     </Wizard>
   );
+};
+
+ImportQuestionReviewModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onSelectQuestions: PropTypes.func.isRequired,
+  questionnaire: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+  }),
 };
 
 export default ImportQuestionReviewModal;

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
@@ -1,45 +1,44 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { colors, radius } from "constants/theme";
+import { colors, radius, focusStyle, getTextHoverStyle } from "constants/theme";
 import Wizard, {
   Header,
   Heading,
   Subheading,
   Content,
   Warning,
+  SpacedRow,
 } from "components/modals/Wizard";
 import Button from "components/buttons/Button";
 
 const QuestionContainer = styled.div`
   background-color: ${colors.blue};
   border-radius: ${radius};
-  margin: 0.5em 0;
+  margin: 0 0 0.5em;
   color: ${colors.white};
   padding: 0.5em 1em;
   &:last-of-type {
-    margin-bottom: 1.5em;
+    margin-bottom: 1em;
   }
   p {
     margin: 0;
   }
 `;
 
-const SpacedRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
 const commonButtonStyling = `
   background: transparent;
   border: none;
   cursor: pointer;
+  &:focus {
+    ${focusStyle}
+  }
 `;
 
 const RemoveButton = styled.button`
   ${commonButtonStyling}
   color: ${colors.white};
+  ${getTextHoverStyle(colors.white)}
 `;
 
 const RemoveAllButton = styled.button`
@@ -47,6 +46,7 @@ const RemoveAllButton = styled.button`
   font-weight: bold;
   color: ${colors.blue};
   font-size: 1em;
+  ${getTextHoverStyle(colors.blue)}
 `;
 
 const ContentHeading = styled.h4`

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
@@ -1,0 +1,142 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { colors, radius } from "constants/theme";
+import Wizard, {
+  Header,
+  Heading,
+  Subheading,
+  Content,
+  Warning,
+} from "components/modals/Wizard";
+import Button from "components/buttons/Button";
+
+const QuestionContainer = styled.div`
+  background-color: ${colors.blue};
+  border-radius: ${radius};
+  margin: 0.5em 0;
+  color: ${colors.white};
+  padding: 0.5em 1em;
+  &:last-of-type {
+    margin-bottom: 1.5em;
+  }
+  p {
+    margin: 0;
+  }
+`;
+
+const SpacedRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const commonButtonStyling = `
+  background: transparent;
+  border: none;
+  cursor: pointer;
+`;
+
+const RemoveButton = styled.button`
+  ${commonButtonStyling}
+  color: ${colors.white};
+`;
+
+const RemoveAllButton = styled.button`
+  ${commonButtonStyling}
+  font-weight: bold;
+  color: ${colors.blue};
+  font-size: 1em;
+`;
+
+const dummyQuestions = [
+  { alias: "Q1", title: "How many roads must a man walk down?" },
+  { alias: "Q2", title: "What is the airspeed velocity of a swallow?" },
+  { alias: "Q3", title: "What is your favourite colour?" },
+];
+
+const QuestionRow = ({ question: { alias, title }, onRemove }) => {
+  return (
+    <QuestionContainer>
+      <SpacedRow>
+        <div>
+          <p>{alias}</p>
+          <p>{title}</p>
+        </div>
+        <RemoveButton onClick={onRemove}>
+          <span role="img" aria-label="Remove">
+            ✕
+          </span>
+        </RemoveButton>
+      </SpacedRow>
+    </QuestionContainer>
+  );
+};
+
+const ContentHeading = styled.h4`
+  margin: 1em 0;
+  color: ${colors.textLight};
+`;
+
+const ImportQuestionReviewModal = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+  onBack,
+  onSelectQuestions, // (questionnaire, callback) -> void
+  questionnaire,
+}) => {
+  const [selectedQuestions, setSelectedQuestions] = useState([]);
+
+  const handleSelectQuestions = () =>
+    onSelectQuestions(questionnaire, setSelectedQuestions);
+
+  const removeQuestionAtIndex = (index) =>
+    setSelectedQuestions((questions) =>
+      questions.filter((_, i) => i !== index)
+    );
+
+  const handleRemoveAll = () => setSelectedQuestions([]);
+
+  return (
+    <Wizard
+      isOpen={isOpen}
+      confirmText="Import"
+      onConfirm={() => onConfirm(selectedQuestions)}
+      onCancel={onCancel}
+      onBack={onBack}
+    >
+      <Header>
+        <Heading> Import questions from {questionnaire.title} </Heading>
+        <Subheading>
+          <Warning>
+            Question logic, piping and Qcodes will not be imported.
+          </Warning>
+        </Subheading>
+      </Header>
+      <Content>
+        {selectedQuestions.length ? (
+          <>
+            <SpacedRow>
+              <ContentHeading> Questions to import </ContentHeading>
+              <RemoveAllButton onClick={handleRemoveAll}>
+                Remove all
+              </RemoveAllButton>
+            </SpacedRow>
+            {selectedQuestions.map((question, index) => (
+              <QuestionRow
+                question={question}
+                onRemove={() => removeQuestionAtIndex(index)}
+              />
+            ))}
+          </>
+        ) : (
+          <ContentHeading> No questions selected </ContentHeading>
+        )}
+        <Button onClick={handleSelectQuestions}>Select questions</Button>
+      </Content>
+    </Wizard>
+  );
+};
+
+export default ImportQuestionReviewModal;

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
@@ -107,6 +107,7 @@ const ImportQuestionReviewModal = ({
       onConfirm={() => onConfirm(selectedQuestions)}
       onCancel={onCancel}
       onBack={onBack}
+      confirmEnabled={Boolean(selectedQuestions.length)}
     >
       <Header>
         <Heading> Import questions from {questionnaire.title} </Heading>
@@ -120,7 +121,9 @@ const ImportQuestionReviewModal = ({
         {selectedQuestions.length ? (
           <>
             <SpacedRow>
-              <ContentHeading> Questions to import </ContentHeading>
+              <ContentHeading>
+                Question{selectedQuestions.length > 1 ? "s" : ""} to import
+              </ContentHeading>
               <RemoveAllButton onClick={handleRemoveAll}>
                 Remove all
               </RemoveAllButton>
@@ -134,7 +137,7 @@ const ImportQuestionReviewModal = ({
             ))}
           </>
         ) : (
-          <ContentHeading> No questions selected </ContentHeading>
+          <ContentHeading> No questions selected. </ContentHeading>
         )}
         <Button onClick={handleSelectQuestions}>Select questions</Button>
       </Content>

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.js
@@ -126,6 +126,7 @@ const ImportQuestionReviewModal = ({
             {selectedQuestions.map((question, index) => (
               <QuestionRow
                 question={question}
+                key={index}
                 onRemove={() => removeQuestionAtIndex(index)}
               />
             ))}

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.test.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.test.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen } from "tests/utils/rtl";
+import userEvent from "@testing-library/user-event";
+import ImportQuestionReviewModal from ".";
+
+const mockQuestionnaire = {
+  title: "Important Questions",
+};
+
+const mockQuestions = [
+  { alias: "Q1", title: "How many roads must a man walk down?" },
+  { alias: "Q2", title: "What is the airspeed velocity of a swallow?" },
+  { alias: "Q3", title: "What is your favourite colour?" },
+];
+
+const mockHandleSelectQuestions = jest.fn((_questionnaire, callback) =>
+  callback(mockQuestions)
+);
+
+describe("Import questions review modal", () => {
+  it("should allow selecting and removing questions", () => {
+    render(
+      <ImportQuestionReviewModal
+        questionnaire={mockQuestionnaire}
+        isOpen
+        onSelectQuestions={mockHandleSelectQuestions}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+        onBack={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/No questions selected/)).toBeTruthy();
+
+    userEvent.click(screen.queryByText(/Select questions/));
+
+    // All questions should now be present
+    expect(screen.queryByText(/Questions to import/)).toBeTruthy();
+    mockQuestions.forEach((q) =>
+      expect(screen.queryByText(q.title)).toBeTruthy()
+    );
+
+    // Can delete an item
+    userEvent.click(screen.getAllByText(/✕/)[0]);
+    expect(screen.queryByText(mockQuestions[0].title)).toBeFalsy();
+    expect(screen.queryByText(mockQuestions[1].title)).toBeTruthy();
+
+    // Can delete all items
+    userEvent.click(screen.getByText(/Remove all/));
+    mockQuestions.forEach((q) =>
+      expect(screen.queryByText(q.title)).toBeFalsy()
+    );
+  });
+
+  it("Should pass on selected questions when user confirms import", () => {
+    const mockHandleConfirm = jest.fn();
+
+    render(
+      <ImportQuestionReviewModal
+        questionnaire={mockQuestionnaire}
+        isOpen
+        onSelectQuestions={mockHandleSelectQuestions}
+        onConfirm={mockHandleConfirm}
+        onCancel={jest.fn()}
+        onBack={jest.fn()}
+      />
+    );
+    userEvent.click(screen.queryByText(/Select questions/));
+    userEvent.click(screen.queryByText(/^Import$/));
+
+    expect(mockHandleConfirm).toHaveBeenCalledWith(mockQuestions);
+  });
+});

--- a/eq-author/src/components/modals/ImportQuestionReviewModal/index.test.js
+++ b/eq-author/src/components/modals/ImportQuestionReviewModal/index.test.js
@@ -31,6 +31,8 @@ describe("Import questions review modal", () => {
     );
 
     expect(screen.queryByText(/No questions selected/)).toBeTruthy();
+    // Import button should be disabled when no questions selected
+    expect(screen.getByText(/^Import$/)).toBeDisabled();
 
     userEvent.click(screen.queryByText(/Select questions/));
 
@@ -65,7 +67,10 @@ describe("Import questions review modal", () => {
         onBack={jest.fn()}
       />
     );
+
     userEvent.click(screen.queryByText(/Select questions/));
+
+    // Import button enabled / clickable when questions selected
     userEvent.click(screen.queryByText(/^Import$/));
 
     expect(mockHandleConfirm).toHaveBeenCalledWith(mockQuestions);

--- a/eq-author/src/components/modals/Wizard/Warning.js
+++ b/eq-author/src/components/modals/Wizard/Warning.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { ReactComponent as WarningIcon } from "assets/icon-warning-circle.svg";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const StyledWarningIcon = styled(WarningIcon)`
+  margin-right: 0.5em;
+`;
+
+const Flex = styled.div`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+`;
+
+/* Show a stylised warning message with black, circular warning icon */
+const Warning = ({ children }) => (
+  <Flex>
+    <StyledWarningIcon />
+    <span>{children}</span>
+  </Flex>
+);
+
+Warning.propTypes = { children: PropTypes.node };
+
+export default Warning;

--- a/eq-author/src/components/modals/Wizard/index.js
+++ b/eq-author/src/components/modals/Wizard/index.js
@@ -1,0 +1,99 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Modal from "components/modals/Modal";
+import { colors, focusStyle } from "constants/theme";
+import DialogButtons from "components/Dialog/DialogButtons";
+import Warning from "./Warning";
+
+const BackButton = styled.button`
+  position: relative;
+  font-size: 0.8em;
+  color: ${colors.blue};
+  border: 0;
+  background: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+  margin: 1em 0 0 0.5em;
+  padding: 0.5em;
+  &::before {
+    content: "<";
+    padding-right: 0.5em;
+    display: inline-block;
+    text-decoration: none;
+  }
+  &:focus {
+    ${focusStyle}
+  }
+`;
+
+const StyledModal = styled(Modal)`
+  .Modal {
+    padding: 0;
+    min-width: 40%;
+  }
+`;
+
+export const Wizard = ({
+  confirmText = "Next",
+  cancelText = "Cancel",
+  isOpen = false,
+  onConfirm,
+  onCancel,
+  onBack,
+  children,
+}) => {
+  return (
+    <StyledModal isOpen={isOpen} onClose={onCancel} hasCloseButton>
+      <BackButton onClick={onBack}>Back</BackButton>
+      {children}
+      <Footer>
+        <DialogButtons
+          primaryAction={onConfirm}
+          primaryActionText={confirmText}
+          secondaryAction={onCancel}
+          secondaryActionText={cancelText}
+        />
+      </Footer>
+    </StyledModal>
+  );
+};
+
+Wizard.propTypes = {
+  confirmText: PropTypes.string,
+  cancelText: PropTypes.string,
+  isOpen: PropTypes.bool,
+  onConfirm: PropTypes.func,
+  onCancel: PropTypes.func,
+  onBack: PropTypes.func,
+  children: PropTypes.node,
+};
+
+const Heading = styled.h2`
+  margin-top: 0;
+  font-size: 1.2em;
+  color: ${colors.textLight};
+`;
+
+const borderStyle = `border-bottom: 1px solid ${colors.bordersLight};`;
+
+const Subheading = styled.h4`
+  margin: 0 0.5em 0 0;
+`;
+
+const Header = styled.header`
+  padding: 0.5em 1em 1em;
+  ${borderStyle}
+`;
+
+const Footer = styled.footer`
+  padding: 0 1em 1em;
+`;
+
+const Content = styled.header`
+  padding: 0.5em 1em 1em;
+  ${borderStyle}
+`;
+
+export { Heading, Subheading, Header, Footer, Content, Warning };
+export default Wizard;

--- a/eq-author/src/components/modals/Wizard/index.js
+++ b/eq-author/src/components/modals/Wizard/index.js
@@ -6,7 +6,6 @@ import { colors, focusStyle, getTextHoverStyle } from "constants/theme";
 import DialogButtons from "components/Dialog/DialogButtons";
 import Warning from "./Warning";
 import { ReactComponent as Chevron } from "assets/icon-chevron-left.svg";
-import { darken } from "polished";
 
 const BackButton = styled.button`
   position: relative;

--- a/eq-author/src/components/modals/Wizard/index.js
+++ b/eq-author/src/components/modals/Wizard/index.js
@@ -2,29 +2,38 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import Modal from "components/modals/Modal";
-import { colors, focusStyle } from "constants/theme";
+import { colors, focusStyle, getTextHoverStyle } from "constants/theme";
 import DialogButtons from "components/Dialog/DialogButtons";
 import Warning from "./Warning";
+import { ReactComponent as Chevron } from "assets/icon-chevron-left.svg";
+import { darken } from "polished";
 
 const BackButton = styled.button`
   position: relative;
+  top: -0.5em;
+  left: -0.25em;
+  font-weight: bold;
   font-size: 0.8em;
-  color: ${colors.blue};
+  color: ${colors.darkGrey};
   border: 0;
   background: transparent;
   text-decoration: underline;
   cursor: pointer;
   margin: 1em 0 0 0.5em;
   padding: 0.5em;
-  &::before {
-    content: "<";
-    padding-right: 0.5em;
-    display: inline-block;
-    text-decoration: none;
-  }
   &:focus {
     ${focusStyle}
   }
+  svg {
+    width: 1em;
+    padding-right: 0.5em;
+    margin-bottom: 0.1em;
+    path:last-of-type {
+      fill: currentColor;
+    }
+  }
+  ${getTextHoverStyle(colors.darkGrey)}
+}
 `;
 
 const StyledModal = styled(Modal)`
@@ -32,6 +41,12 @@ const StyledModal = styled(Modal)`
     padding: 0;
     min-width: 40%;
   }
+`;
+
+export const SpacedRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export const Wizard = ({
@@ -46,7 +61,11 @@ export const Wizard = ({
 }) => {
   return (
     <StyledModal isOpen={isOpen} onClose={onCancel} hasCloseButton>
-      <BackButton onClick={onBack}>Back</BackButton>
+      <BackButton onClick={onBack}>
+        <SpacedRow>
+          <Chevron /> Back
+        </SpacedRow>
+      </BackButton>
       {children}
       <Footer>
         <DialogButtons
@@ -85,7 +104,7 @@ const Subheading = styled.h4`
 `;
 
 const Header = styled.header`
-  padding: 0.5em 1em 1em;
+  padding: 0 1em 1em;
   ${borderStyle}
 `;
 
@@ -93,8 +112,8 @@ const Footer = styled.footer`
   padding: 0 1em 1em;
 `;
 
-const Content = styled.header`
-  padding: 0.5em 1em 1em;
+const Content = styled.main`
+  padding: 0 1em 1em;
   ${borderStyle}
 `;
 

--- a/eq-author/src/components/modals/Wizard/index.js
+++ b/eq-author/src/components/modals/Wizard/index.js
@@ -42,6 +42,7 @@ export const Wizard = ({
   onCancel,
   onBack,
   children,
+  confirmEnabled = true,
 }) => {
   return (
     <StyledModal isOpen={isOpen} onClose={onCancel} hasCloseButton>
@@ -53,6 +54,7 @@ export const Wizard = ({
           primaryActionText={confirmText}
           secondaryAction={onCancel}
           secondaryActionText={cancelText}
+          primaryEnabled={confirmEnabled}
         />
       </Footer>
     </StyledModal>
@@ -67,6 +69,7 @@ Wizard.propTypes = {
   onCancel: PropTypes.func,
   onBack: PropTypes.func,
   children: PropTypes.node,
+  confirmEnabled: PropTypes.bool,
 };
 
 const Heading = styled.h2`

--- a/eq-author/src/components/modals/Wizard/index.js
+++ b/eq-author/src/components/modals/Wizard/index.js
@@ -32,7 +32,6 @@ const BackButton = styled.button`
     }
   }
   ${getTextHoverStyle(colors.darkGrey)}
-}
 `;
 
 const StyledModal = styled(Modal)`

--- a/eq-author/src/constants/theme.js
+++ b/eq-author/src/constants/theme.js
@@ -1,4 +1,5 @@
 import { css } from "styled-components";
+import { darken } from "polished";
 
 export const colors = {
   blue: "#3B7A9E",
@@ -38,8 +39,8 @@ colors.previewError = colors.grey;
 
 export const radius = "4px";
 
-export const focusStyle = css`
-  border-color: none;
+export const focusStyle = `
+  border-color: transparent;
   outline: 3px solid ${colors.tertiary};
   box-shadow: 0 0 0 3px ${colors.tertiary};
 `;
@@ -72,6 +73,12 @@ export const activeNavItemStyle = css`
 
 export const hoverStyle = css`
   background: rgba(0, 0, 0, 0.2);
+`;
+
+export const getTextHoverStyle = (color) => css`
+  &:hover {
+    color: ${darken(0.1, color)};
+  }
 `;
 
 export default {

--- a/eq-author/src/hooks/useModal.js
+++ b/eq-author/src/hooks/useModal.js
@@ -1,0 +1,38 @@
+import React, { useState, useCallback } from "react";
+
+// Convenience wrapper for invoking modals - automates handling of `isOpen` state
+export default ({ component: Modal, onConfirm, onCancel, ...props }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleConfirm = useCallback(
+    (...args) => {
+      onConfirm(...args);
+      setIsOpen(false);
+    },
+    [onConfirm]
+  );
+
+  const handleCancel = useCallback(
+    (...args) => {
+      // eslint-disable-next-line no-unused-expressions
+      onCancel?.(...args);
+      setIsOpen(false);
+    },
+    [onCancel]
+  );
+
+  return [
+    useCallback(() => setIsOpen(true), []),
+    useCallback(
+      () => (
+        <Modal
+          {...props}
+          isOpen={isOpen}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      ),
+      [onConfirm, onCancel, props]
+    ),
+  ];
+};

--- a/eq-author/src/storybook/Patterns/Importing content/ReviewQuestionModal.stories.js
+++ b/eq-author/src/storybook/Patterns/Importing content/ReviewQuestionModal.stories.js
@@ -39,7 +39,7 @@ Modal.args = {
 };
 
 export default {
-  title: "Patterns/Review questions modal",
+  title: "Patterns/Importing content/Review questions",
   component: Modal,
   args: {
     isOpen: true,

--- a/eq-author/src/storybook/Patterns/Modals/ConfirmationModal.stories.js
+++ b/eq-author/src/storybook/Patterns/Modals/ConfirmationModal.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import ConfirmationModal from "components/modals/ConfirmationModal";
 
 export default {
-  title: "Components/Modals/Confirmation",
+  title: "Patterns/Modals/Confirmation",
   component: ConfirmationModal,
   argTypes: {
     onConfirm: { action: "Confirmed" },

--- a/eq-author/src/storybook/Patterns/Modals/Wizard.stories.js
+++ b/eq-author/src/storybook/Patterns/Modals/Wizard.stories.js
@@ -16,7 +16,7 @@ import {
   PRIMARY_STORY,
 } from "@storybook/addon-docs/blocks";
 
-const Template = (args) => {
+export const Default = (args) => {
   const [trigger, Modal] = useModal({
     ...args,
     component: Wizard,
@@ -30,8 +30,7 @@ const Template = (args) => {
   );
 };
 
-export const WizardModal = Template.bind({});
-WizardModal.args = {
+Default.args = {
   confirmText: "Onward!",
   isOpen: true,
   children: (
@@ -72,7 +71,7 @@ WizardModal.args = {
 };
 
 export default {
-  title: "Patterns/Wizard Modal",
+  title: "Patterns/Modals/Wizard",
   component: Wizard,
   args: {
     isOpen: true,

--- a/eq-author/src/storybook/Patterns/ReviewQuestionModal.stories.js
+++ b/eq-author/src/storybook/Patterns/ReviewQuestionModal.stories.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ImportQuestionReviewModal from "components/modals/ImportQuestionReviewModal";
 import useModal from "hooks/useModal";
 

--- a/eq-author/src/storybook/Patterns/ReviewQuestionModal.stories.js
+++ b/eq-author/src/storybook/Patterns/ReviewQuestionModal.stories.js
@@ -1,0 +1,95 @@
+import React, { useEffect } from "react";
+import ImportQuestionReviewModal from "components/modals/ImportQuestionReviewModal";
+import useModal from "hooks/useModal";
+
+import {
+  Title,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs/blocks";
+
+const dummyQuestions = [
+  { alias: "Q1", title: "How many roads must a man walk down?" },
+  { alias: "Q2", title: "What is the airspeed velocity of a swallow?" },
+  { alias: "Q3", title: "What is your favourite colour?" },
+];
+
+const Template = (args) => {
+  const [trigger, Modal] = useModal({
+    ...args,
+    component: ImportQuestionReviewModal,
+  });
+
+  return (
+    <>
+      <Modal />
+      <button onClick={trigger}>Trigger modal</button>
+    </>
+  );
+};
+
+export const Modal = Template.bind({});
+Modal.args = {
+  questionnaire: {
+    title: "Important Questions",
+  },
+  onSelectQuestions: (_questionnaire, callback) => callback(dummyQuestions),
+};
+
+export default {
+  title: "Patterns/Review questions modal",
+  component: Modal,
+  args: {
+    isOpen: true,
+  },
+  argTypes: {
+    isOpen: {
+      description: "If the wizard modal is currently visable",
+      table: { type: { summary: "Bool" } },
+    },
+    questionnaire: {
+      description: "Source questionnaire object",
+      table: { type: { summary: "Object" } },
+    },
+    onConfirm: {
+      description:
+        "Callback called with selected questions array when user confirms by pressing 'Import'",
+      action: "Confirmed",
+      table: { type: { summary: "Function" } },
+    },
+    onCancel: {
+      description: "Callback invoked when users press the 'Cancel' button",
+      action: "Cancelled",
+      table: { type: { summary: "Function" } },
+    },
+    onBack: {
+      description: "Callback invoked when users press the 'Back' button",
+      action: "Back",
+      table: { type: { summary: "Function" } },
+    },
+    onSelectQuestions: {
+      description:
+        "Callback invoked when users press the 'Select questions' button. Called with `questionnaire`, `callback`. Expects `callback` to be called with an array of selected questions.",
+      action: "Back",
+      table: { type: { summary: "Function" } },
+    },
+  },
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <p>
+            A modal used for reviewing questions to import during the content
+            importing process.
+          </p>
+          <ArgsTable story={PRIMARY_STORY} />
+          <Primary />
+          <Stories />
+        </>
+      ),
+    },
+  },
+};

--- a/eq-author/src/storybook/Patterns/Wizard.stories.js
+++ b/eq-author/src/storybook/Patterns/Wizard.stories.js
@@ -1,0 +1,116 @@
+import React from "react";
+import Wizard, {
+  Header,
+  Heading,
+  Subheading,
+  Content,
+  Warning,
+} from "components/modals/Wizard";
+
+import {
+  Title,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs/blocks";
+
+const Template = (args) => <Wizard {...args} />;
+
+export const WizardModal = Template.bind({});
+WizardModal.args = {
+  confirmText: "Onward!",
+  isOpen: true,
+  children: (
+    <>
+      <Header>
+        <Heading>
+          A title suitable for a true wizard{" "}
+          <span role="img" aria-label="wizard">
+            🧙🏻‍♂️
+          </span>
+        </Heading>
+        <Subheading>
+          <Warning>
+            Disclaimer: The School of Wizardry provides this tool for use
+            STRICTLY at your own risk.
+          </Warning>
+        </Subheading>
+      </Header>
+      <Content>
+        <h4>Choose the priming ingredient mix: </h4>
+        <label>
+          <input type="checkbox" />
+          Mitochondrion of Newt
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" />
+          Golgi complex of Gargoyle
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" />
+          Vacuole of Violet
+        </label>
+      </Content>
+    </>
+  ),
+};
+
+export default {
+  title: "Patterns/Wizard Modal",
+  component: Wizard,
+  args: {
+    isOpen: true,
+  },
+  argTypes: {
+    isOpen: {
+      description: "If the wizard modal is currently visable",
+      table: { type: { summary: "Bool" } },
+    },
+    confirmText: {
+      description: "Text to display on the 'confirmation' button",
+      table: { type: { summary: "String" } },
+    },
+    cancelText: {
+      description: "Text to display on the 'cancel' button",
+      table: { type: { summary: "String" } },
+    },
+    onConfirm: {
+      description: "Callback invoked when 'confirm' button pressed",
+      action: "confirm",
+      table: { type: { summary: "Function" } },
+    },
+    onCancel: {
+      description: "Callback invoked when 'cancel' button pressed",
+      action: "cancel",
+      table: { type: { summary: "Function" } },
+    },
+    onBack: {
+      description: "Callback invoked when 'back' button pressed",
+      action: "back",
+      table: { type: { summary: "Function" } },
+    },
+    children: {
+      description: "React components to render inside the modal",
+      table: { type: { summary: "Node" } },
+    },
+  },
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <p>
+            A modal component with <code>Back</code>, <code>Confirm</code> and{" "}
+            <code>Cancel</code> buttons.
+          </p>
+          <ArgsTable story={PRIMARY_STORY} />
+          <Primary />
+          <Stories />
+        </>
+      ),
+    },
+  },
+};

--- a/eq-author/src/storybook/Patterns/Wizard.stories.js
+++ b/eq-author/src/storybook/Patterns/Wizard.stories.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import useModal from "hooks/useModal";
 import Wizard, {
   Header,
   Heading,
@@ -15,7 +16,19 @@ import {
   PRIMARY_STORY,
 } from "@storybook/addon-docs/blocks";
 
-const Template = (args) => <Wizard {...args} />;
+const Template = (args) => {
+  const [trigger, Modal] = useModal({
+    ...args,
+    component: Wizard,
+  });
+
+  return (
+    <>
+      <Modal />
+      <button onClick={trigger}>Trigger modal</button>
+    </>
+  );
+};
 
 export const WizardModal = Template.bind({});
 WizardModal.args = {

--- a/eq-author/src/storybook/Patterns/Wizard.stories.js
+++ b/eq-author/src/storybook/Patterns/Wizard.stories.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import useModal from "hooks/useModal";
 import Wizard, {
   Header,


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1318)
[Prototype](https://overflow.io/s/EEGKYVGY?node=7601c426&prototype&prototype-hints=off)

Implement the component for reviewing selected questions as part of the importing process.

Other miscellany:

- Added `useModal` wrapper hook for conveniently triggering modals (without managing `isOpen` state). This is a generalisation of the existing hook I wrote for `useConfirmationModal` (see storybook files for usage). 
- Use subfolder of `Patterns` in storybook for components as per Matt E's ticket.
- Adds the `Wizard` modal component (a modal with a Back button). The review modal derives from this.
- Adds storybook page / docs for `Wizard` modal.

### How to review

- `yarn storybook`
- Check out the modal under `Patterns` -> `Importing content` -> `Review questions`
- Clicking `select questions` will select some mock questions for now (pending integration ticket to wire up with other modal)
- Should be able to remove single / all questions
- Import button should be disabled when no questions selected

### Screenshots

#### No questions chosen
<img width="733" alt="Screenshot 2021-07-08 at 15 41 09" src="https://user-images.githubusercontent.com/60441612/124941765-f5016d80-e002-11eb-8b93-309990d5a49b.png">

#### Questions chosen
<img width="709" alt="Screenshot 2021-07-08 at 15 41 44" src="https://user-images.githubusercontent.com/60441612/124941838-05194d00-e003-11eb-8ca6-c9b235685a07.png">

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
