### PR TITLE
🛠 UI: Fix 'sign out' tooltip not showing

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/MainNavigation/index.js
@@ -78,7 +78,7 @@ export const UnwrappedMainNavigation = ({
   formTypeErrorCount,
   title,
   children,
-  hasSurveyID
+  hasSurveyID,
 }) => {
   const params = useParams();
   const { hasQCodeError } = useQCodeContext();
@@ -93,8 +93,8 @@ export const UnwrappedMainNavigation = ({
   const totalErrorCountNoFormType = totalErrorCount - formTypeErrorCount;
 
   if (!hasSurveyID) {
-    totalErrorCount = totalErrorCount-1
-  };
+    totalErrorCount = totalErrorCount - 1;
+  }
 
   const previewUrl = `${config.REACT_APP_LAUNCH_URL}/${params.questionnaireId}`;
 
@@ -197,7 +197,7 @@ export const UnwrappedMainNavigation = ({
                     <SmallBadge data-test="small-badge" />
                   )}
                 </RouteButton>
-                {me && <UserProfile nav signOut left />}
+                {me && <UserProfile nav />}
               </ButtonGroup>
             )}
           </UtilityBtns>

--- a/eq-author/src/components/Layout/Header.js
+++ b/eq-author/src/components/Layout/Header.js
@@ -45,7 +45,7 @@ const StyledUserProfile = styled(UserProfile)`
   margin-right: 0.5em;
 `;
 
-const UserProfileWrapper = styled("div")`
+const UserProfileWrapper = styled.div`
   height: 100%;
   display: flex;
   align-items: center;

--- a/eq-author/src/components/UserProfile/index.js
+++ b/eq-author/src/components/UserProfile/index.js
@@ -1,13 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { flowRight } from "lodash";
-import { withApollo } from "react-apollo";
-import { withRouter } from "react-router-dom";
-
-import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
 
-import { withMe } from "App/MeContext";
+import { useMe } from "App/MeContext";
 
 import Tooltip from "components/Forms/Tooltip";
 import { colors } from "constants/theme";
@@ -56,56 +51,37 @@ export const NavLogoutButton = styled(Button)`
   text-align: centre;
 `;
 
-const UserProfile = ({ me, nav, signOut }) => {
+const UserProfile = ({ nav }) => {
+  const { me, signOut } = useMe();
+
   if (!me) {
     return null;
   }
+
   return (
     <Tooltip content="Sign Out">
-      <>
-        {nav && (
-          <NavLogoutButton
-            onClick={() => {
-              signOut();
-            }}
-            variant="navigation"
-            small
-          >
-            <IconText nav icon={signOutIcon}>
-              Sign out
-            </IconText>
-          </NavLogoutButton>
-        )}
-
-        {!nav && (
-          <LogoutButton
-            onClick={() => {
-              signOut();
-            }}
-            variant="tertiary-light"
-            small
-          >
-            <UserAvatar
-              src={me.picture || guestAvatar}
-              alt=""
-              role="presentation"
-            />
-            <UserName data-test="username">{me.displayName}</UserName>
-          </LogoutButton>
-        )}
-      </>
+      {nav ? (
+        <NavLogoutButton onClick={signOut} variant="navigation" small>
+          <IconText nav icon={signOutIcon}>
+            Sign out
+          </IconText>
+        </NavLogoutButton>
+      ) : (
+        <LogoutButton onClick={signOut} variant="tertiary-light" small>
+          <UserAvatar
+            src={me.picture || guestAvatar}
+            alt="Avatar"
+            role="presentation"
+          />
+          <UserName data-test="username">{me.displayName}</UserName>
+        </LogoutButton>
+      )}
     </Tooltip>
   );
 };
 
 UserProfile.propTypes = {
-  client: PropTypes.shape({
-    resetStore: PropTypes.func.isRequired,
-  }).isRequired,
-  me: CustomPropTypes.user,
-  left: PropTypes.bool,
-  signOut: PropTypes.func.isRequired,
   nav: PropTypes.bool,
 };
 
-export default flowRight(withApollo, withMe, withRouter)(UserProfile);
+export default UserProfile;


### PR DESCRIPTION
### What is the context of this PR?

The tooltip for the "sign out" button wasn't showing. Seems to have been caused by the usage of `styled("div")` instead of `styled.div`... Don't ask me why ;-)

Also took the opportunity to refactor the sign out button a bit.

### How to review

- Spin 'er up
- Check the `Sign out` tooltip appears when you hover over the button on the homepage
- Check the `Sign out` tooltip appears when you hover over the button on the main navigation menu

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
