### PR TITLE
EAR 1412 - 🛠 Fix sorting keys for Firestore

### DIFF
--- a/eq-author-api/schema/resolvers/utils/helpers.js
+++ b/eq-author-api/schema/resolvers/utils/helpers.js
@@ -1,6 +1,8 @@
 const deepMap = require("deep-map");
 const { v4: uuidv4 } = require("uuid");
 
+const collator = new Intl.Collator("en", { numeric: true });
+
 // Transforms questionnaire into a hash map, mapping IDs to absolute positions
 // Thereafter allows O(1) lookup to check if IDs exist & get their positions
 const generateOrderedIdMap = ({ questionnaire }) => {
@@ -12,7 +14,7 @@ const generateOrderedIdMap = ({ questionnaire }) => {
     }
 
     Object.keys(obj)
-      .sort()
+      .sort(collator.compare)
       .forEach((key) => traverseIds(obj[key]));
 
     if (obj.id && typeof obj.id === "string") {


### PR DESCRIPTION
### What is the context of this PR?

Firestore's object property names need sorting prior to calculating relative positions of entities since Firestore returns keys in a nondeterministic order.

Previous attempt to fix this was bitten by javascript's sorting array keys as strings - this PR uses `Intl` to sensibly sort numbers and strings together.

### How to review

- Check you can route to a question later in a section (in a section with many questions)
- Check validation for routing expressions works
- Check validation for previous answers in validation rules works

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
