### PR TITLE
EAR-1414-move-delete-options-not-visible-on-answer-options

### DIFF
--- a/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ exports[`CollapsibleEditor should render 1`] = `
 >
   <CollapsibleEditor__DetailHeader>
     <MoveButton
+      color="secondary"
       data-test="move-up-btn"
       disabled={true}
       onClick={[MockFunction]}
@@ -14,6 +15,7 @@ exports[`CollapsibleEditor should render 1`] = `
       <Component />
     </MoveButton>
     <MoveButton
+      color="secondary"
       data-test="move-down-btn"
       disabled={true}
       onClick={[MockFunction]}

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/__snapshots__/index.test.js.snap
@@ -114,6 +114,7 @@ exports[`Answer Editor should render Checkbox 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -132,6 +133,7 @@ exports[`Answer Editor should render Checkbox 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -151,6 +153,7 @@ exports[`Answer Editor should render Checkbox 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -218,6 +221,7 @@ exports[`Answer Editor should render Currency 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -236,6 +240,7 @@ exports[`Answer Editor should render Currency 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -255,6 +260,7 @@ exports[`Answer Editor should render Currency 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -317,6 +323,7 @@ exports[`Answer Editor should render Date 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -335,6 +342,7 @@ exports[`Answer Editor should render Date 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -354,6 +362,7 @@ exports[`Answer Editor should render Date 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -416,6 +425,7 @@ exports[`Answer Editor should render DateRange 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -434,6 +444,7 @@ exports[`Answer Editor should render DateRange 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -453,6 +464,7 @@ exports[`Answer Editor should render DateRange 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -513,6 +525,7 @@ exports[`Answer Editor should render Duration 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -531,6 +544,7 @@ exports[`Answer Editor should render Duration 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -550,6 +564,7 @@ exports[`Answer Editor should render Duration 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -615,6 +630,7 @@ exports[`Answer Editor should render Number 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -633,6 +649,7 @@ exports[`Answer Editor should render Number 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -652,6 +669,7 @@ exports[`Answer Editor should render Number 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -714,6 +732,7 @@ exports[`Answer Editor should render Percentage 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -732,6 +751,7 @@ exports[`Answer Editor should render Percentage 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -751,6 +771,7 @@ exports[`Answer Editor should render Percentage 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -813,6 +834,7 @@ exports[`Answer Editor should render Radio 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -831,6 +853,7 @@ exports[`Answer Editor should render Radio 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -850,6 +873,7 @@ exports[`Answer Editor should render Radio 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -918,6 +942,7 @@ exports[`Answer Editor should render TextArea 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -936,6 +961,7 @@ exports[`Answer Editor should render TextArea 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -955,6 +981,7 @@ exports[`Answer Editor should render TextArea 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -1016,6 +1043,7 @@ exports[`Answer Editor should render TextField 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -1034,6 +1062,7 @@ exports[`Answer Editor should render TextField 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -1053,6 +1082,7 @@ exports[`Answer Editor should render TextField 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"
@@ -1115,6 +1145,7 @@ exports[`Answer Editor should render Unit 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-up"
             disabled={false}
             onClick={[MockFunction]}
@@ -1133,6 +1164,7 @@ exports[`Answer Editor should render Unit 1`] = `
           place="top"
         >
           <MoveButton
+            color="white"
             data-test="btn-move-answer-down"
             disabled={false}
             onClick={[MockFunction]}
@@ -1152,6 +1184,7 @@ exports[`Answer Editor should render Unit 1`] = `
         >
           <DeleteButton
             aria-label="Delete answer"
+            color="white"
             data-test="btn-delete-answer"
             onClick={[Function]}
             size="medium"

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/index.js
@@ -159,6 +159,7 @@ class AnswerEditor extends React.Component {
                 offset={{ top: 0, bottom: 10 }}
               >
                 <MoveButton
+                  color="white"
                   disabled={!this.props.canMoveUp}
                   onClick={this.props.onMoveUp}
                   data-test="btn-move-answer-up"
@@ -172,6 +173,7 @@ class AnswerEditor extends React.Component {
                 offset={{ top: 0, bottom: 10 }}
               >
                 <MoveButton
+                  color="white"
                   disabled={!this.props.canMoveDown}
                   onClick={this.props.onMoveDown}
                   data-test="btn-move-answer-down"
@@ -185,6 +187,7 @@ class AnswerEditor extends React.Component {
                 offset={{ top: 0, bottom: 10 }}
               >
                 <DeleteButton
+                  color="white"
                   size="medium"
                   onClick={this.handleDeleteAnswer}
                   aria-label="Delete answer"

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -79,6 +79,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
         place="top"
       >
         <MoveButton
+          color="secondary"
           data-test="btn-move-answer-up"
           disabled={true}
         >
@@ -96,6 +97,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
         place="top"
       >
         <MoveButton
+          color="secondary"
           data-test="btn-move-answer-down"
           disabled={true}
         >
@@ -113,6 +115,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
       >
         <DeleteButton
           aria-label="Delete option"
+          color="secondary"
           data-test="btn-delete-option"
           disabled={true}
           onClick={[Function]}

--- a/eq-author/src/components/buttons/DeleteButton/__snapshots__/deletebutton.test.js.snap
+++ b/eq-author/src/components/buttons/DeleteButton/__snapshots__/deletebutton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`DeleteButton should render: large 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #FFFFFF;
+  color: #3B7A9E;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -31,6 +31,7 @@ exports[`DeleteButton should render: large 1`] = `
 <button
     aria-label="Delete"
     class="c0"
+    color="secondary"
     role="button"
     type="button"
   >
@@ -42,7 +43,7 @@ exports[`DeleteButton should render: large 1`] = `
 exports[`DeleteButton should render: medium 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #FFFFFF;
+  color: #3B7A9E;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -70,6 +71,7 @@ exports[`DeleteButton should render: medium 1`] = `
 <button
     aria-label="Delete"
     class="c0"
+    color="secondary"
     role="button"
     type="button"
   >
@@ -81,7 +83,7 @@ exports[`DeleteButton should render: medium 1`] = `
 exports[`DeleteButton should render: small 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #FFFFFF;
+  color: #3B7A9E;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -109,6 +111,7 @@ exports[`DeleteButton should render: small 1`] = `
 <button
     aria-label="Delete"
     class="c0"
+    color="secondary"
     role="button"
     type="button"
   >

--- a/eq-author/src/components/buttons/DeleteButton/index.js
+++ b/eq-author/src/components/buttons/DeleteButton/index.js
@@ -20,7 +20,7 @@ const sizes = {
 };
 
 const StyledDeleteButton = styled.button`
-  color: ${colors.white};
+  color: ${colors.secondary};
   border: none;
   background: transparent;
   cursor: pointer;

--- a/eq-author/src/components/buttons/DeleteButton/index.js
+++ b/eq-author/src/components/buttons/DeleteButton/index.js
@@ -72,7 +72,6 @@ DeleteButton.defaultProps = {
 DeleteButton.propTypes = {
   size: PropTypes.oneOf(["small", "medium", "large"]),
   color: PropTypes.oneOf(["white", "secondary"]), 
-  size: PropTypes.string,
   type: PropTypes.string,
 };
 

--- a/eq-author/src/components/buttons/DeleteButton/index.js
+++ b/eq-author/src/components/buttons/DeleteButton/index.js
@@ -20,7 +20,7 @@ const sizes = {
 };
 
 const StyledDeleteButton = styled.button`
-  color: ${colors.secondary};
+  color: ${(props) => props.color === 'white' ? colors.white : colors.secondary};
   border: none;
   background: transparent;
   cursor: pointer;
@@ -63,6 +63,7 @@ const DeleteButton = (props) => (
 );
 
 DeleteButton.defaultProps = {
+  color: "secondary", 
   size: "medium",
   type: "button",
   "aria-label": "Delete",
@@ -70,6 +71,9 @@ DeleteButton.defaultProps = {
 
 DeleteButton.propTypes = {
   size: PropTypes.oneOf(["small", "medium", "large"]),
+  color: PropTypes.oneOf(["white", "secondary"]), 
+  size: PropTypes.string,
+  type: PropTypes.string,
 };
 
 export default DeleteButton;

--- a/eq-author/src/components/buttons/MoveButton/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/MoveButton/__snapshots__/index.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`MoveButton should render 1`] = `
 <MoveButton__Button
+  color="secondary"
   onClick={[MockFunction]}
 >
   Some content

--- a/eq-author/src/components/buttons/MoveButton/index.js
+++ b/eq-author/src/components/buttons/MoveButton/index.js
@@ -11,7 +11,7 @@ export const IconDown = IconArrowDown;
 
 const Button = styled.button`
   display: block;
-  color: ${colors.white};
+  color: ${colors.secondary};
   border: none;
   padding: 0;
   padding-top: 0.3em;

--- a/eq-author/src/components/buttons/MoveButton/index.js
+++ b/eq-author/src/components/buttons/MoveButton/index.js
@@ -11,7 +11,7 @@ export const IconDown = IconArrowDown;
 
 const Button = styled.button`
   display: block;
-  color: ${colors.secondary};
+  color: ${(props) => props.color === 'white' ? colors.white : colors.secondary};
   border: none;
   padding: 0;
   padding-top: 0.3em;
@@ -59,10 +59,14 @@ const MoveButton = ({ disabled, onClick, children, ...otherProps }) => {
       onClick,
     };
   }
+
+
+
   return <Button {...props}>{children}</Button>;
 };
 
 MoveButton.propTypes = {
+  color: PropTypes.oneOf(["white", "secondary"]), 
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
@@ -70,6 +74,8 @@ MoveButton.propTypes = {
 
 MoveButton.defaultProps = {
   disabled: false,
+  color: "secondary", 
+
 };
 
 export default MoveButton;

--- a/eq-author/src/components/datatable/Controls/__snapshots__/DeleteRowButton.test.js.snap
+++ b/eq-author/src/components/datatable/Controls/__snapshots__/DeleteRowButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`DeleteRowButton should render 1`] = `
 <DocumentFragment>
   .c0 {
-  color: #FFFFFF;
+  color: #3B7A9E;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -37,6 +37,7 @@ exports[`DeleteRowButton should render 1`] = `
 <button
     aria-label="Delete"
     class="c0 c1"
+    color="secondary"
     role="button"
     type="button"
   >


### PR DESCRIPTION
What is the context of this PR?

Fix for the button not appearing until it was hovered over. The problem was that the colour has been changed to white. Have changed it back to what it was, but it looks like there was a design change. Don’t know if this matches what the current design is supposed to me. But it’s a temporary fix until Monday.

How to review

Launch Author and double check that the button are visible and functioning when adding Checkbox Answers.

What to do after everything is green
    *   Bring this branch up-to-date with Origin/Master
    *   If there are a lot of commits or some are not helpful to read, squash them down
    *   Click the Merge button on this pull request
    *   Does this change mean the Capability examples questionnaire should be updated?
    *   Move the Jira ticket for this task into the next stage of the process
