### PR TITLE
EAR 1260 remove current section and later sections from routing destinations

### DIFF
--- a/eq-author/src/components/ContentPickerv2/DestinationPicker/Menu.js
+++ b/eq-author/src/components/ContentPickerv2/DestinationPicker/Menu.js
@@ -65,7 +65,21 @@ const Menu = ({ data, onSelected, isSelected }) => {
 
   const { current, later, other } = buildTabs(data);
 
-  const tabs = later.destinations ? [current, later, other] : [current, other];
+  const getRequiredTabs = () => {
+    const requiredTabs = [];
+
+    if (current.destinations.length !== 0) {
+      requiredTabs.push(current);
+    }
+    if (later.destinations.length !== 0) {
+      requiredTabs.push(later);
+    }
+    requiredTabs.push(other);
+
+    return requiredTabs;
+  };
+
+  const tabs = getRequiredTabs();
 
   return (
     <ColumnContainer data-test="destination-picker-menu">

--- a/eq-author/src/components/ContentPickerv2/DestinationPicker/Menu.js
+++ b/eq-author/src/components/ContentPickerv2/DestinationPicker/Menu.js
@@ -71,7 +71,7 @@ const Menu = ({ data, onSelected, isSelected }) => {
     if (current.destinations.length !== 0) {
       requiredTabs.push(current);
     }
-    if (later.destinations.length !== 0) {
+    if (later?.destinations?.length !== 0 && later.destinations) {
       requiredTabs.push(later);
     }
     requiredTabs.push(other);


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Remove "Current section" option from routing content picker for the last question in a section

Remove "Later sections" option from routing content picker for questions in the last section

### How to review

> Add to the list below as appropriate, including screenshots when necessary

**Check:**
- [ ] Opening the last question in a section and selecting a routing rule destination does not display "Current sections" in the destination list
- [ ] Opening a question in the last section and selecting a routing rule destination does not display "Later sections" in the destination list
- [ ] The "Else" destination picker opens correctly and does not display "Later sections"

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
