### PR TITLE
Ear 1401 collapsible sections requires section titles

### DIFF
--- a/eq-author-api/src/validation/schemas/section.json
+++ b/eq-author-api/src/validation/schemas/section.json
@@ -14,6 +14,9 @@
         },
         {
           "requiredWhenQuestionnaireSetting": "hub"
+        },
+        {
+          "requiredWhenQuestionnaireSetting": "collapsibleSummary"
         }
       ],
       "errorMessage": "ERR_REQUIRED_WHEN_SETTING"

--- a/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionEditor.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import { shallow } from "enzyme";
 import { render as rtlRender } from "tests/utils/rtl";
 
-
 import { SectionEditor } from "App/section/Design/SectionEditor";
 import RichTextEditor from "components/RichTextEditor";
 import { sectionErrors } from "constants/validationMessages";
@@ -19,7 +18,8 @@ describe("SectionEditor", () => {
     questionnaire: {
       id: "2",
       navigation: true,
-      hub: false
+      hub: false,
+      collapsibleSummary: false,
     },
     validationErrorInfo: {
       id: "3",
@@ -39,7 +39,8 @@ describe("SectionEditor", () => {
     questionnaire: {
       id: "2",
       navigation: true,
-      hub: false
+      hub: false,
+      collapsibleSummary: false,
     },
     validationErrorInfo: {
       id: "3",
@@ -107,7 +108,7 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: true,
-        hub: false
+        hub: false,
       },
     };
     const wrapper = render({ section });
@@ -122,7 +123,7 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: false,
-        hub: false
+        hub: false,
       },
     };
     const wrapper = render({ section });
@@ -135,7 +136,7 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: false,
-        hub: true
+        hub: true,
       },
     };
     const wrapper = render({ section });
@@ -144,22 +145,70 @@ describe("SectionEditor", () => {
     );
   });
 
+  it("should enable the section title when Collapsible sections is enabled and hub is disabled", () => {
+    const section = {
+      ...section1,
+      title: "",
+      questionnaire: {
+        id: "2",
+        navigation: false,
+        hub: false,
+        collapsibleSummary: true,
+      },
+    };
+    const getValidationError = jest.fn().mockReturnValue("Validation error");
+
+    const wrapper = render({ section, getValidationError });
+    expect(wrapper.find(RichTextEditor).first().prop("disabled")).toEqual(
+      false
+    );
+  });
+
+  it("should validate the section title when Collapsible sections is enabled and hub is disabled", () => {
+    const section = {
+      ...section1,
+      title: "",
+      questionnaire: {
+        id: "2",
+        navigation: false,
+        hub: false,
+        collapsibleSummary: true,
+      },
+    };
+    const getValidationError = jest.fn().mockReturnValue("Validation error");
+
+    const wrapper = render({ section, getValidationError });
+
+    expect(
+      wrapper
+        .find("[testSelector='txt-section-title']")
+        .prop("errorValidationMsg")
+    ).toBe("Validation error");
+
+    expect(getValidationError).toHaveBeenCalledWith({
+      field: "title",
+      message: sectionErrors.SECTION_TITLE_NOT_ENTERED,
+    });
+  });
+
   it("should enable the hub settings collapsible section when Hub is enabled", () => {
     const section = {
       ...section1,
       questionnaire: {
         id: "2",
         navigation: false,
-        hub: true
+        hub: true,
       },
     };
-    const { getByText } = rtlRender(() => <SectionEditor
-      section={section}
-      showDeleteConfirmDialog={false}
-      showMoveSectionDialog={false}
-      match={match}
-      {...mockHandlers}
-    />);
+    const { getByText } = rtlRender(() => (
+      <SectionEditor
+        section={section}
+        showDeleteConfirmDialog={false}
+        showMoveSectionDialog={false}
+        match={match}
+        {...mockHandlers}
+      />
+    ));
 
     expect(getByText("Hub settings")).toBeVisible();
   });
@@ -170,19 +219,20 @@ describe("SectionEditor", () => {
       questionnaire: {
         id: "2",
         navigation: false,
-        hub: true
+        hub: true,
       },
     };
-    const { getByTestId } = rtlRender(() => <SectionEditor
-      section={section}
-      showDeleteConfirmDialog={false}
-      showMoveSectionDialog={false}
-      match={match}
-      {...mockHandlers}
-    />);
+    const { getByTestId } = rtlRender(() => (
+      <SectionEditor
+        section={section}
+        showDeleteConfirmDialog={false}
+        showMoveSectionDialog={false}
+        match={match}
+        {...mockHandlers}
+      />
+    ));
 
-  expect(getByTestId("collapsible-body")).toBeVisible();
-    
+    expect(getByTestId("collapsible-body")).toBeVisible();
   });
 
   it("should not autofocus the section title when its empty and navigation has just been turned on", () => {
@@ -193,7 +243,7 @@ describe("SectionEditor", () => {
         questionnaire: {
           id: "2",
           navigation: false,
-          hub: false
+          hub: false,
         },
       },
     });
@@ -205,7 +255,7 @@ describe("SectionEditor", () => {
         questionnaire: {
           id: "2",
           navigation: true,
-          hub: false
+          hub: false,
         },
       },
     });

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -109,11 +109,6 @@ export class SectionEditor extends React.Component {
       onDeleteSectionConfirm,
       match,
     } = this.props;
-    console.log(
-      "collapsibleSummary :>> ",
-      section.questionnaire.collapsibleSummary
-    );
-    console.log("this.props :>> ", this.props);
 
     const handleUpdate = partial(flip(onChange), onUpdate);
 
@@ -126,7 +121,6 @@ export class SectionEditor extends React.Component {
     const hasNav = section.questionnaire.navigation;
     const hasHub = section.questionnaire.hub;
     const hasCollapsibleSummary = section.questionnaire.collapsibleSummary;
-    console.log("hasCollapsibleSummary :>> ", hasCollapsibleSummary);
 
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -109,6 +109,12 @@ export class SectionEditor extends React.Component {
       onDeleteSectionConfirm,
       match,
     } = this.props;
+    console.log(
+      "collapsibleSummary :>> ",
+      section.questionnaire.collapsibleSummary
+    );
+    console.log("this.props :>> ", this.props);
+
     const handleUpdate = partial(flip(onChange), onUpdate);
 
     const navHasChanged =
@@ -119,6 +125,8 @@ export class SectionEditor extends React.Component {
 
     const hasNav = section.questionnaire.navigation;
     const hasHub = section.questionnaire.hub;
+    const hasCollapsibleSummary = section.questionnaire.collapsibleSummary;
+    console.log("hasCollapsibleSummary :>> ", hasCollapsibleSummary);
 
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>
@@ -136,7 +144,11 @@ export class SectionEditor extends React.Component {
         </MoveSectionQuery>
 
         {hasHub && (
-          <HubSettings id={section.id} requiredCompleted={section.requiredCompleted} showOnHub={section.showOnHub}/>
+          <HubSettings
+            id={section.id}
+            requiredCompleted={section.requiredCompleted}
+            showOnHub={section.showOnHub}
+          />
         )}
 
         <Padding>
@@ -156,7 +168,7 @@ export class SectionEditor extends React.Component {
               ))
             }
             value={section.title}
-            disabled={!hasNav && !hasHub}
+            disabled={!hasNav && !hasHub && !hasCollapsibleSummary}
             onUpdate={handleUpdate}
             controls={titleControls}
             size="large"

--- a/eq-author/src/App/section/Design/index.js
+++ b/eq-author/src/App/section/Design/index.js
@@ -214,6 +214,7 @@ export const SECTION_QUERY = gql`
         questionnaireInfo {
           totalSectionCount
         }
+        collapsibleSummary
       }
     }
   }

--- a/eq-author/src/App/section/Design/index.test.js
+++ b/eq-author/src/App/section/Design/index.test.js
@@ -70,6 +70,7 @@ const section = {
       __typename: "QuestionnaireInfo",
       totalSectionCount: 1,
     },
+    collapsibleSummary: false,
   },
   validationErrorInfo: {
     id: "1",

--- a/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
+++ b/eq-author/src/App/section/Preview/SectionIntroPreview.test.js
@@ -18,6 +18,7 @@ describe("SectionIntroPreview", () => {
       questionnaire: {
         id: "1",
         navigation: true,
+        hub: true,
       },
       validationErrorInfo: {
         id: "vei1",


### PR DESCRIPTION
### What is the context of this PR?

As an author
when I have answer summary and collapsible sections turned on
I want to able to add a section title
so they can be populated and also be visible in Runner

1. Section title enabled

GIVEN I have turned off section/hub navigation and turned on answer summary and collapsible sections
WHEN I am on a section page
THEN the section title field is enabled and can be populated and validated if empty

### How to review

Create a new Questionnaire
in settings:
Make sure Hub or Section Nav is NOT enabled 
make sure answer summary and collapsible sections is turned on
you should be able to enter a section title on any section
An empty section title should have a validation message

Turn collapsible sections off in settings
section title should be disabled in all sections


