### PR TITLE
EAR-1417-fix for OR option description

### DIFF
--- a/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
@@ -14,12 +14,7 @@ jest.mock("@apollo/react-hooks", () => ({
 }));
 
 describe("BasicAnswer", () => {
-  let answer;
-  let onChange;
-  let onUpdate;
-  let children;
-  let props;
-  let multipleAnswers;
+  let answer, onChange, onUpdate, children, props, multipleAnswers;
 
   const createWrapper = (props, render = shallow) => {
     return render(<StatelessBasicAnswer {...props} />);
@@ -37,6 +32,7 @@ describe("BasicAnswer", () => {
           id: "option-1",
           label: "option-label",
           mutuallyExclusive: false,
+          description: "option description",
         },
       ],
     };
@@ -51,7 +47,11 @@ describe("BasicAnswer", () => {
       onUpdate,
       multipleAnswers,
       type: "text field",
-      children: <div>This is the child component</div>,
+      children: (
+        <>
+          <div>This is the child component</div>
+        </>
+      ),
     };
   });
 
@@ -128,6 +128,18 @@ describe("BasicAnswer", () => {
     });
 
     expect(getByTestId("option-label")).toBeInTheDocument();
+  });
+
+  it("should show option label when it exists", () => {
+    props.answer.options[0].mutuallyExclusive = true;
+
+    const { getByTestId } = rtlRender(() => (
+      <StatelessBasicAnswer {...props} type="Percentage" />
+    ));
+    fireEvent.click(getByTestId("toggle-or-option-input"), {
+      target: { type: "checkbox", checked: true },
+    });
+    expect(screen.getByText(/option description/)).toBeInTheDocument();
   });
 
   describe("event handling behaviour", () => {

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/BasicAnswer.test.js
@@ -47,11 +47,7 @@ describe("BasicAnswer", () => {
       onUpdate,
       multipleAnswers,
       type: "text field",
-      children: (
-        <>
-          <div>This is the child component</div>
-        </>
-      ),
+      children: <div>This is the child component</div>,
     };
   });
 

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/graphql/createMutuallyExclusiveOption.graphql
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/graphql/createMutuallyExclusiveOption.graphql
@@ -11,6 +11,7 @@ mutation createMutuallyExclusiveOption(
           id
           mutuallyExclusive
           label
+          description
         }
       }
     }

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -72,15 +72,23 @@ export const StatelessBasicAnswer = ({
   const getMutuallyExclusive = ({ options }) =>
     options?.find(({ mutuallyExclusive }) => mutuallyExclusive === true);
 
+  const getMutuallyExclusiveDesc = ({ options }) =>
+    options?.find(({ description }) => description);
+
   const [createMutuallyExclusive] = useMutation(CREATE_MUTUALLY_EXCLUSIVE);
   const [updateOption] = useMutation(UPDATE_OPTION_MUTATION);
   const [deleteOption] = useMutation(DELETE_OPTION);
 
   const [mutuallyExclusiveLabel, setMutuallyExclusiveLabel] = useState("");
+  const [mutuallyExclusiveDesc, setMutuallyExclusiveDesc] = useState("");
 
   useEffect(() => {
     const { label } = getMutuallyExclusive(answer) || { label: "" };
     setMutuallyExclusiveLabel(label);
+    const { description } = getMutuallyExclusiveDesc(answer) || {
+      description: "",
+    };
+    setMutuallyExclusiveDesc(description);
   }, [answer]);
 
   const onChangeToggle = () => {
@@ -98,6 +106,12 @@ export const StatelessBasicAnswer = ({
     const { id } = getMutuallyExclusive(answer) || {};
 
     updateOption({ variables: { input: { id, label } } });
+  };
+
+  const onUpdateOptionDesc = (description) => {
+    const { id } = getMutuallyExclusive(answer) || {};
+
+    updateOption({ variables: { input: { id, description } } });
   };
 
   return (
@@ -185,10 +199,10 @@ export const StatelessBasicAnswer = ({
             <WrappingInput
               id={`option-description-${answer.id}`}
               name="description"
-              value={answer.description}
+              value={mutuallyExclusiveDesc}
               placeholder={descriptionPlaceholder}
-              onChange={onChange}
-              onBlur={onUpdate}
+              onChange={({ value }) => setMutuallyExclusiveDesc(value)}
+              onBlur={({ target: { value } }) => onUpdateOptionDesc(value)}
               data-test="option-description"
             />
           </OptionField>
@@ -235,6 +249,7 @@ StatelessBasicAnswer.fragments = {
         id
         mutuallyExclusive
         label
+        description
       }
       validation {
         ... on NumberValidation {


### PR DESCRIPTION
ticket - https://collaborate2.ons.gov.uk/jira/browse/EAR-1417

### What is the context of this PR?
OR option description in basic answer types is currently using answer.description but should be using answer options description
incorrect behaviour

1 - Create an answer with a description property (any numeric answer)
2 - Click the "Or" option toggle to enable an "Or" option
3 - Add a description to the original answer
4 - The "Or" option's description copies the original answer's description
5 - Add a description to the "Or" option
6 - The original answer's description copies the "Or" option's description

### How to review

**Expected behaviour**

1 - Create an answer with a description property (any numeric answer)
2 - Click the "Or" option toggle to enable an "Or" option
3 - Add a description to the original answer
4 - The "Or" option's description does not copy the original answer's description
5 - Add a description to the "Or" option
6 - The original answer's description does not copy the "Or" option's description
