### PR TITLE
EAR-1332-unique-label-validation not working-correctly

### DIFF
--- a/eq-author/src/graphql/validationsSubscription.graphql
+++ b/eq-author/src/graphql/validationsSubscription.graphql
@@ -105,6 +105,17 @@ subscription Validation($id: ID!) {
                 }
               }
               ... on MultipleChoiceAnswer {
+                options {
+                  id
+                  label
+                  qCode
+                  validationErrorInfo {
+                    ...ValidationErrorInfo
+                  }
+                  additionalAnswer {
+                    id
+                  }
+                }
                 id
                 validationErrorInfo {
                   ...ValidationErrorInfo

--- a/eq-author/src/graphql/validationsSubscription.graphql
+++ b/eq-author/src/graphql/validationsSubscription.graphql
@@ -107,8 +107,6 @@ subscription Validation($id: ID!) {
               ... on MultipleChoiceAnswer {
                 options {
                   id
-                  label
-                  qCode
                   validationErrorInfo {
                     ...ValidationErrorInfo
                   }


### PR DESCRIPTION
https://collaborate2.ons.gov.uk/jira/browse/EAR-1332

### What is the context of this PR

unique labels error messages on multiple radio / checkboxes do not clear correctly.
when 2 labels are the same, an error msg showing 'Option label must be unique' should show.
a change to either of the labels should clear the message

### How to review

1) create a radio or checkbox question
2) make sure there is more than one option
3) make the option labels the same - you should get the error - "Error: Option label must be unique" - for both labels
4) change one of the labels - both error messages should disappear

