### PR TITLE
Ear 1419 comments reply circle gets squashed

### DIFF
--- a/eq-author/src/components/Collapsible/index.js
+++ b/eq-author/src/components/Collapsible/index.js
@@ -45,8 +45,6 @@ export const Title = styled.h2`
 export const Body = styled.div`
   display: ${(props) => (props.isOpen ? "block" : "none")};
   margin-top: -1em;
-  margin-left: 0.1em;
-  padding-left: 0.5em;
   border-left: 3px solid ${colors.lightGrey};
 
   ${(props) =>

--- a/eq-author/src/components/Collapsible/index.js
+++ b/eq-author/src/components/Collapsible/index.js
@@ -9,8 +9,7 @@ import { darken } from "polished";
 import Button from "components/buttons/Button";
 
 const Wrapper = styled.div`
-  margin: ${(props) =>
-    props.variant === "default" ? `0 0em 0em` : `0 2em 1em`};
+  margin: ${(props) => (props.variant === "default" ? `0` : `0 2em 1em`)};
   border: ${(props) =>
     props.variant === "content" && ` 1px solid ${colors.grey}`};
 `;

--- a/eq-author/src/components/Collapsible/index.js
+++ b/eq-author/src/components/Collapsible/index.js
@@ -10,7 +10,7 @@ import Button from "components/buttons/Button";
 
 const Wrapper = styled.div`
   margin: ${(props) =>
-    props.variant === "default" ? `0 2.5em 1em` : `0 2em 1em`};
+    props.variant === "default" ? `0 0em 0em` : `0 2em 1em`};
   border: ${(props) =>
     props.variant === "content" && ` 1px solid ${colors.grey}`};
 `;


### PR DESCRIPTION
What is the context of this PR?

Removed some padding and margin that was causing the avatar to squash. Though the entire side bar does get squashed when the screen size is decreased significantly. But on larger sizes it shouldn't do it now.

How to review

- Add a comment to a question
- Add a reply to the comment and check that it doesn't squash

What to do after everything is green
    *   Bring this branch up-to-date with Origin/Master
    *   If there are a lot of commits or some are not helpful to read, squash them down
    *   Click the Merge button on this pull request
    *   Does this change mean the Capability examples questionnaire should be updated?
    *   Move the Jira ticket for this task into the next stage of the process
