### PR TITLE
Moved error message outside of box

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/index.js
@@ -37,12 +37,11 @@ const PopoutLayer = styled(Layer)`
 
 const ErrorContext = styled.div`
   position: relative;
-  margin-bottom: 1em;
 
   ${(props) =>
     props.isInvalid &&
     css`
-      border: 2px solid ${colors.errorPrimary};
+      border: 1px solid ${colors.errorPrimary};
       padding: 1em;
     `}
 `;
@@ -112,24 +111,26 @@ class AnswerTypeSelector extends React.Component {
     );
 
     return (
-      <ErrorContext isInvalid={isInvalid}>
-        <Popout
-          open={this.state.open}
-          transition={PopupTransition}
-          trigger={trigger}
-          container={PopoutContainer}
-          layer={PopoutLayer}
-          onToggleOpen={this.handleOpenToggle}
-          onEntered={this.handleEntered}
-        >
-          <AnswerTypeGrid
-            onSelect={this.handleSelect}
-            ref={this.saveGridRef}
-            doNotShowDR={hasOtherAnswerType}
-          />
-        </Popout>
+      <>
+        <ErrorContext isInvalid={isInvalid}>
+          <Popout
+            open={this.state.open}
+            transition={PopupTransition}
+            trigger={trigger}
+            container={PopoutContainer}
+            layer={PopoutLayer}
+            onToggleOpen={this.handleOpenToggle}
+            onEntered={this.handleEntered}
+          >
+            <AnswerTypeGrid
+              onSelect={this.handleSelect}
+              ref={this.saveGridRef}
+              doNotShowDR={hasOtherAnswerType}
+            />
+          </Popout>
+        </ErrorContext>
         {isInvalid && <ValidationError>{errorValidationMsg}</ValidationError>}
-      </ErrorContext>
+      </>
     );
   }
 }


### PR DESCRIPTION

### What is the context of this PR?

When we updated the styles to the error messages, the following was done incorrectly: 

![image](https://user-images.githubusercontent.com/15129656/129900602-9fd6e8f2-93a5-497a-b63a-03677741bde8.png)

Where the error message should be outside the box.

This PR fixes this.

### How to review

Ensure that the error message resides outside the box, and that the width of the line is consistent with the one above when the focus is not on that element.

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
