### PR TITLE
EAR-1460-radio-chip-width-broken

### DIFF
--- a/eq-author/src/components/buttons/ToggleChip/index.js
+++ b/eq-author/src/components/buttons/ToggleChip/index.js
@@ -45,7 +45,7 @@ const Field = styled.div`
   display: inline-block;
   position: relative;
   margin: 0.25em 0.5em 0.25em 0;
-  width: 100%;
+  max-width: 100%;
 `;
 
 export const Label = styled.label`


### PR DESCRIPTION
### What is the context of this PR?

Following recent update the Radio chip on the logic page expressions is now displaying incorrectly.

### How to review

Double  check that the chips now appear after the 'Match <Select>" and do not take up more width than their content.