### PR TITLE
update coverage output

### DIFF
--- a/eq-author-api/package.json
+++ b/eq-author-api/package.json
@@ -57,6 +57,7 @@
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": false,
+    "coverageReporters": ["json", "json-summary", "text", "text-summary"],
     "collectCoverageFrom": [
       "**/*.js",
       "!config/**/*",

--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -148,6 +148,7 @@
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": false,
+    "coverageReporters": ["json", "json-summary", "text", "text-summary"],
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!src/graphql/*.js",

--- a/eq-publisher/package.json
+++ b/eq-publisher/package.json
@@ -37,6 +37,7 @@
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": false,
+    "coverageReporters": ["json", "json-summary", "text", "text-summary"],
     "collectCoverageFrom": [
       "src/**/*.js",
       "!src/main.js"


### PR DESCRIPTION
Updated the coverage output to create summary files. These can be used in builds for reporting.
