### PR TITLE
EAR 880 Fix answer types read twice

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/AnswerTypeButton.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/AnswerTypeButton.js
@@ -54,6 +54,7 @@ export default class AnswerTypeButton extends React.Component {
         iconSrc={icons[this.props.type]}
         onClick={this.handleClick}
         title={this.props.title}
+        titleAriaHidden
         order={this.props.order}
         data-test={`btn-answer-type-${this.props.type.toLowerCase()}`}
       />

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/__snapshots__/AnswerTypeButton.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswerTypeSelector/__snapshots__/AnswerTypeButton.test.js.snap
@@ -6,5 +6,6 @@ exports[`components/AnswerTypeButton should render 1`] = `
   iconSrc="SvgrURL"
   onClick={[Function]}
   title="Text field"
+  titleAriaHidden={true}
 />
 `;

--- a/eq-author/src/components/IconGrid/IconGridButton.js
+++ b/eq-author/src/components/IconGrid/IconGridButton.js
@@ -44,6 +44,7 @@ const Title = styled.h3`
 const IconGridButton = ({
   iconSrc,
   title,
+  titleAriaHidden = false,
   disabled,
   order,
   onClick,
@@ -64,7 +65,7 @@ const IconGridButton = ({
       {...otherProps}
     >
       <img src={iconSrc} alt={title} />
-      <Title aria-hidden>{title}</Title>
+      <Title aria-hidden={titleAriaHidden}>{title}</Title>
     </Button>
   );
 };
@@ -72,6 +73,7 @@ const IconGridButton = ({
 IconGridButton.propTypes = {
   iconSrc: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  titleAriaHidden: PropTypes.bool,
   disabled: PropTypes.bool,
   order: PropTypes.number,
   onClick: PropTypes.func,

--- a/eq-author/src/components/IconGrid/IconGridButton.js
+++ b/eq-author/src/components/IconGrid/IconGridButton.js
@@ -64,7 +64,7 @@ const IconGridButton = ({
       {...otherProps}
     >
       <img src={iconSrc} alt={title} />
-      <Title>{title}</Title>
+      <Title aria-hidden>{title}</Title>
     </Button>
   );
 };

--- a/eq-author/src/components/IconGrid/__snapshots__/IconGridButton.test.js.snap
+++ b/eq-author/src/components/IconGrid/__snapshots__/IconGridButton.test.js.snap
@@ -23,7 +23,9 @@ exports[`components/IconGrid should render 1`] = `
     alt="Checkbox"
     src="checkbox.svg"
   />
-  <IconGridButton__Title>
+  <IconGridButton__Title
+    aria-hidden={true}
+  >
     Checkbox
   </IconGridButton__Title>
 </IconGridButton__Button>

--- a/eq-author/src/components/IconGrid/__snapshots__/IconGridButton.test.js.snap
+++ b/eq-author/src/components/IconGrid/__snapshots__/IconGridButton.test.js.snap
@@ -24,7 +24,7 @@ exports[`components/IconGrid should render 1`] = `
     src="checkbox.svg"
   />
   <IconGridButton__Title
-    aria-hidden={true}
+    aria-hidden={false}
   >
     Checkbox
   </IconGridButton__Title>


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes screen reader reading answer types twice when adding a new answer

### How to review

- [ ] Open a screen reader

**Check:**
- [ ] Creating a new answer does not read out the answer type twice when the answer is selected on the screen reader

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
