### PR TITLE
EAR 1462 Add validation error to date modal

### DIFF
--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
@@ -6,23 +6,28 @@ import { ERR_NO_VALUE } from "constants/validationMessages";
 import ValidationError from "components/ValidationError";
 import { DateInput } from "./components.js";
 
-const CustomEditor = ({ validation, onChange, onUpdate }) => (
-  <>
-    <DateInput
-      name="customDate"
-      type="date"
-      value={validation.customDate}
-      onChange={onChange}
-      onBlur={onUpdate}
-      max="9999-12-30"
-      min="1000-01-01"
-      data-test="custom-date-input"
-    />
-    {validation.validationErrorInfo.errors.some(
-      (error) => error.errorCode === "ERR_NO_VALUE"
-    ) && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
-  </>
-);
+const CustomEditor = ({ validation, onChange, onUpdate }) => {
+  const hasError = validation.validationErrorInfo.errors.some(
+    (error) => error.errorCode === "ERR_NO_VALUE"
+  );
+
+  return (
+    <>
+      <DateInput
+        name="customDate"
+        type="date"
+        value={validation.customDate}
+        onChange={onChange}
+        onBlur={onUpdate}
+        max="9999-12-30"
+        min="1000-01-01"
+        invalid={hasError}
+        data-test="custom-date-input"
+      />
+      {hasError && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+    </>
+  );
+};
 
 CustomEditor.propTypes = {
   validation: PropTypes.shape({

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
@@ -16,6 +16,7 @@ const CustomEditor = ({ validation, onChange, onUpdate }) => (
       onBlur={onUpdate}
       max="9999-12-30"
       min="1000-01-01"
+      data-test="custom-date-input"
     />
     {validation.validationErrorInfo.errors.some(
       (error) => error.errorCode === "ERR_NO_VALUE"

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
@@ -1,18 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { ERR_NO_VALUE } from "constants/validationMessages";
+
+import ValidationError from "components/ValidationError";
 import { DateInput } from "./components.js";
 
 const CustomEditor = ({ validation, onChange, onUpdate }) => (
-  <DateInput
-    name="customDate"
-    type="date"
-    value={validation.customDate}
-    onChange={onChange}
-    onBlur={onUpdate}
-    max="9999-12-30"
-    min="1000-01-01"
-  />
+  <>
+    <DateInput
+      name="customDate"
+      type="date"
+      value={validation.customDate}
+      onChange={onChange}
+      onBlur={onUpdate}
+      max="9999-12-30"
+      min="1000-01-01"
+    />
+    {validation.validationErrorInfo.errors.some(
+      (error) => error.errorCode === "ERR_NO_VALUE"
+    ) && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+  </>
 );
 
 CustomEditor.propTypes = {

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { ERR_NO_VALUE } from "constants/validationMessages";
+import { DATE_REQUIRED } from "constants/validationMessages";
 
 import ValidationError from "components/ValidationError";
 import { DateInput } from "./components.js";
@@ -24,7 +24,7 @@ const CustomEditor = ({ validation, onChange, onUpdate }) => {
         invalid={hasError}
         data-test="custom-date-input"
       />
-      {hasError && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+      {hasError && <ValidationError>{DATE_REQUIRED}</ValidationError>}
     </>
   );
 };

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.js
@@ -24,7 +24,11 @@ const CustomEditor = ({ validation, onChange, onUpdate }) => {
         invalid={hasError}
         data-test="custom-date-input"
       />
-      {hasError && <ValidationError>{DATE_REQUIRED}</ValidationError>}
+      {hasError && (
+        <ValidationError data-test="date-required-error">
+          {DATE_REQUIRED}
+        </ValidationError>
+      )}
     </>
   );
 };

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.test.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.test.js
@@ -11,6 +11,9 @@ describe("Custom Editor", () => {
       onUpdate: jest.fn(),
       validation: {
         customDate: null,
+        validationErrorInfo: {
+          errors: [],
+        },
       },
     };
 
@@ -22,7 +25,7 @@ describe("Custom Editor", () => {
   });
 
   it("should trigger update answer validation when the custom value changes", () => {
-    const customDateField = wrapper.first();
+    const customDateField = wrapper.find("[data-test='custom-date-input']");
     customDateField.simulate("change", "event");
     expect(props.onChange).toHaveBeenCalledWith("event");
     customDateField.simulate("blur", "event");

--- a/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.test.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/CustomEditor.test.js
@@ -31,4 +31,35 @@ describe("Custom Editor", () => {
     customDateField.simulate("blur", "event");
     expect(props.onUpdate).toHaveBeenCalledWith("event");
   });
+
+  it("should not display validation error in the modal when there are no errors", () => {
+    const validationMessage = wrapper.find("[data-test='date-required-error']");
+    expect(validationMessage.exists()).toBeFalsy();
+  });
+
+  it("should display validation error in the modal when there is an error", () => {
+    const props = {
+      validation: {
+        validationErrorInfo: {
+          errors: [{ id: "1", errorCode: "ERR_NO_VALUE" }],
+        },
+      },
+    };
+    wrapper = shallow(<CustomEditor {...props} />);
+    const validationMessage = wrapper.find("[data-test='date-required-error']");
+    expect(validationMessage.exists()).toBeTruthy();
+  });
+
+  it("should only display validation errors with the error code `ERR_NO_VALUE`", () => {
+    const props = {
+      validation: {
+        validationErrorInfo: {
+          errors: [{ id: "1", errorCode: "NOT_ERR_NO_VALUE" }],
+        },
+      },
+    };
+    wrapper = shallow(<CustomEditor {...props} />);
+    const validationMessage = wrapper.find("[data-test='date-required-error']");
+    expect(validationMessage.exists()).toBeFalsy();
+  });
 });

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -2,16 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import { get } from "lodash";
 
+import { ERR_NO_VALUE } from "constants/validationMessages";
+
+import ValidationError from "components/ValidationError";
 import MetadataContentPicker from "../MetadataContentPicker.js";
 
 const MetadataEditor = ({ onChangeUpdate, answer, validation }) => (
-  <MetadataContentPicker
-    answerId={answer.id}
-    onSubmit={onChangeUpdate}
-    selectedContentDisplayName={get(validation.previousAnswer, "displayName")}
-    selectedMetadataDisplayName={get(validation.metadata, "displayName")}
-    selectedId={get(validation.previousAnswer, "id")}
-  />
+  <>
+    <MetadataContentPicker
+      answerId={answer.id}
+      onSubmit={onChangeUpdate}
+      selectedContentDisplayName={get(validation.previousAnswer, "displayName")}
+      selectedMetadataDisplayName={get(validation.metadata, "displayName")}
+      selectedId={get(validation.previousAnswer, "id")}
+    />
+    {validation.validationErrorInfo.errors.some(
+      (error) => error.errorCode === "ERR_NO_VALUE"
+    ) && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+  </>
 );
 
 MetadataEditor.propTypes = {

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -7,21 +7,29 @@ import { ERR_NO_VALUE } from "constants/validationMessages";
 import ValidationError from "components/ValidationError";
 import MetadataContentPicker from "../MetadataContentPicker.js";
 
-const MetadataEditor = ({ onChangeUpdate, answer, validation }) => (
-  <>
-    <MetadataContentPicker
-      answerId={answer.id}
-      onSubmit={onChangeUpdate}
-      selectedContentDisplayName={get(validation.previousAnswer, "displayName")}
-      selectedMetadataDisplayName={get(validation.metadata, "displayName")}
-      selectedId={get(validation.previousAnswer, "id")}
-      data-test="metadata-date-editor"
-    />
-    {validation.validationErrorInfo.errors.some(
-      (error) => error.errorCode === "ERR_NO_VALUE"
-    ) && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
-  </>
-);
+const MetadataEditor = ({ onChangeUpdate, answer, validation }) => {
+  const hasError = validation.validationErrorInfo.errors.some(
+    (error) => error.errorCode === "ERR_NO_VALUE"
+  );
+
+  return (
+    <>
+      <MetadataContentPicker
+        answerId={answer.id}
+        onSubmit={onChangeUpdate}
+        selectedContentDisplayName={get(
+          validation.previousAnswer,
+          "displayName"
+        )}
+        selectedMetadataDisplayName={get(validation.metadata, "displayName")}
+        selectedId={get(validation.previousAnswer, "id")}
+        data-test="metadata-date-editor"
+        hasError={hasError}
+      />
+      {hasError && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+    </>
+  );
+};
 
 MetadataEditor.propTypes = {
   validation: PropTypes.shape({

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -26,7 +26,11 @@ const MetadataEditor = ({ onChangeUpdate, answer, validation }) => {
         data-test="metadata-date-editor"
         hasError={hasError}
       />
-      {hasError && <ValidationError>{METADATA_REQUIRED}</ValidationError>}
+      {hasError && (
+        <ValidationError data-test="metadata-required-error">
+          {METADATA_REQUIRED}
+        </ValidationError>
+      )}
     </>
   );
 };

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { get } from "lodash";
 
-import { ERR_NO_VALUE } from "constants/validationMessages";
+import { METADATA_REQUIRED } from "constants/validationMessages";
 
 import ValidationError from "components/ValidationError";
 import MetadataContentPicker from "../MetadataContentPicker.js";
@@ -26,7 +26,7 @@ const MetadataEditor = ({ onChangeUpdate, answer, validation }) => {
         data-test="metadata-date-editor"
         hasError={hasError}
       />
-      {hasError && <ValidationError>{ERR_NO_VALUE}</ValidationError>}
+      {hasError && <ValidationError>{METADATA_REQUIRED}</ValidationError>}
     </>
   );
 };

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.js
@@ -15,6 +15,7 @@ const MetadataEditor = ({ onChangeUpdate, answer, validation }) => (
       selectedContentDisplayName={get(validation.previousAnswer, "displayName")}
       selectedMetadataDisplayName={get(validation.metadata, "displayName")}
       selectedId={get(validation.previousAnswer, "id")}
+      data-test="metadata-date-editor"
     />
     {validation.validationErrorInfo.errors.some(
       (error) => error.errorCode === "ERR_NO_VALUE"

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.test.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.test.js
@@ -49,4 +49,49 @@ describe("Metadata Editor", () => {
       value: metadata,
     });
   });
+
+  it("should not display validation error in the modal when there are no errors", () => {
+    const validationMessage = wrapper.find("[data-test='date-required-error']");
+    expect(validationMessage.exists()).toBeFalsy();
+  });
+
+  it("should display validation error in the modal when there is an error", () => {
+    const props = {
+      onChangeUpdate: jest.fn(),
+      validation: {
+        id: "1",
+        validationErrorInfo: {
+          errors: [{ id: "1", errorCode: "ERR_NO_VALUE" }],
+        },
+      },
+      answer: {
+        id: "1",
+      },
+    };
+    wrapper = shallow(<MetadataEditor {...props} />);
+    const validationMessage = wrapper.find(
+      "[data-test='metadata-required-error']"
+    );
+    expect(validationMessage.exists()).toBeTruthy();
+  });
+
+  it("should only display validation errors with the error code `ERR_NO_VALUE`", () => {
+    const props = {
+      onChangeUpdate: jest.fn(),
+      validation: {
+        id: "1",
+        validationErrorInfo: {
+          errors: [{ id: "1", errorCode: "NOT_ERR_NO_VALUE" }],
+        },
+      },
+      answer: {
+        id: "1",
+      },
+    };
+    wrapper = shallow(<MetadataEditor {...props} />);
+    const validationMessage = wrapper.find(
+      "[data-test='metadata-required-error']"
+    );
+    expect(validationMessage.exists()).toBeFalsy();
+  });
 });

--- a/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.test.js
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/MetadataEditor.test.js
@@ -13,6 +13,9 @@ describe("Metadata Editor", () => {
         previousAnswer: {
           displayName: "test",
         },
+        validationErrorInfo: {
+          errors: [],
+        },
       },
       answer: {
         id: "1",
@@ -28,11 +31,15 @@ describe("Metadata Editor", () => {
   });
 
   it("should correctly handle metadata change", () => {
+    const metadataDateField = wrapper.find(
+      "[data-test='metadata-date-editor']"
+    );
+
     const metadata = {
       id: 1,
     };
 
-    wrapper.simulate("submit", {
+    metadataDateField.simulate("submit", {
       name: "metadata",
       value: metadata,
     });

--- a/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/CustomEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/CustomEditor.test.js.snap
@@ -1,13 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Custom Editor should render 1`] = `
-<components__DateInput
-  max="9999-12-30"
-  min="1000-01-01"
-  name="customDate"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  type="date"
-  value={null}
-/>
+<Fragment>
+  <components__DateInput
+    data-test="custom-date-input"
+    max="9999-12-30"
+    min="1000-01-01"
+    name="customDate"
+    onBlur={[MockFunction]}
+    onChange={[MockFunction]}
+    type="date"
+    value={null}
+  />
+</Fragment>
 `;

--- a/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/CustomEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/CustomEditor.test.js.snap
@@ -4,6 +4,7 @@ exports[`Custom Editor should render 1`] = `
 <Fragment>
   <components__DateInput
     data-test="custom-date-input"
+    invalid={false}
     max="9999-12-30"
     min="1000-01-01"
     name="customDate"

--- a/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/MetadataEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/MetadataEditor.test.js.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Metadata Editor Should render 1`] = `
-<MetadataContentPicker
-  answerId="1"
-  onSubmit={[MockFunction]}
-  selectedContentDisplayName="test"
-/>
+<Fragment>
+  <MetadataContentPicker
+    answerId="1"
+    data-test="metadata-date-editor"
+    onSubmit={[MockFunction]}
+    selectedContentDisplayName="test"
+  />
+</Fragment>
 `;

--- a/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/MetadataEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/DateValidation/__snapshots__/MetadataEditor.test.js.snap
@@ -5,6 +5,7 @@ exports[`Metadata Editor Should render 1`] = `
   <MetadataContentPicker
     answerId="1"
     data-test="metadata-date-editor"
+    hasError={false}
     onSubmit={[MockFunction]}
     selectedContentDisplayName="test"
   />

--- a/eq-author/src/App/page/Design/Validation/PreviousAnswerEditor.js
+++ b/eq-author/src/App/page/Design/Validation/PreviousAnswerEditor.js
@@ -12,7 +12,7 @@ import {
 } from "constants/validationMessages";
 
 export const errorMessages = {
-  ERR_NO_VALUE: "Answer required",
+  ERR_NO_VALUE: "Answer is required",
   ERR_REFERENCE_DELETED,
   ERR_REFERENCE_MOVED,
 };

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/PreviousAnswerEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/PreviousAnswerEditor.test.js.snap
@@ -20,7 +20,7 @@ exports[`Custom Editor should render 1`] = `
     />
   </FieldWithInclude>
   <ValidationError>
-    Answer required
+    Answer is required
   </ValidationError>
 </Fragment>
 `;

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -116,6 +116,9 @@ export const SELECTION_REQUIRED = "Selection required";
 
 export const OPERATOR_REQUIRED = "Choose an operator";
 
+export const METADATA_REQUIRED = "Metadata is required";
+export const DATE_REQUIRED = "Date is required";
+
 export const binaryExpressionErrors = {
   ANSWER_DELETED: "The answer used in this condition has been deleted",
   NO_ROUTABLE_ANSWERS_AVAILABLE:


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Add validation error message to the date modal when a custom date or metadata date has not been entered

### How to review

**Check:**
- [x] Modal shows an error message when before/after custom date has not been entered (date range and date answers)
- [x] Modal shows an error message when before/after metadata date has not been entered (date range and date answers)

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
