### PR TITLE
Ear 1229 nested validation dont work with pubsub disabled

### DIFF
--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -15,48 +15,46 @@ const {
   UNPUBLISHED,
 } = require("../../constants/publishStatus");
 
-const createMutation = (mutation, { ignoreLockStatus = false } = {}) => async (
-  root,
-  args,
-  ctx
-) => {
-  let hasBeenUnpublished;
-  enforceHasWritePermission(ctx.questionnaire, ctx.user); // throws ForbiddenError
-  if (!ignoreLockStatus) {
-    enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
-  }
-  if (ctx.questionnaire.publishStatus === AWAITING_APPROVAL) {
-    throw new Error(
-      "User can not edit questionnaire while waiting for approval"
-    );
-  }
+const createMutation =
+  (mutation, { ignoreLockStatus = false } = {}) =>
+  async (root, args, ctx) => {
+    let hasBeenUnpublished;
+    enforceHasWritePermission(ctx.questionnaire, ctx.user); // throws ForbiddenError
+    if (!ignoreLockStatus) {
+      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
+    }
+    if (ctx.questionnaire.publishStatus === AWAITING_APPROVAL) {
+      throw new Error(
+        "User can not edit questionnaire while waiting for approval"
+      );
+    }
 
-  const result = await mutation(root, args, ctx);
-  if (ctx.questionnaire.publishStatus === PUBLISHED) {
-    ctx.questionnaire.publishStatus = UNPUBLISHED;
-    ctx.questionnaire.surveyVersion++;
-    hasBeenUnpublished = true;
-    await createHistoryEvent(ctx.questionnaire.id, publishStatusEvent(ctx));
-  }
+    const result = await mutation(root, args, ctx);
+    if (ctx.questionnaire.publishStatus === PUBLISHED) {
+      ctx.questionnaire.publishStatus = UNPUBLISHED;
+      ctx.questionnaire.surveyVersion++;
+      hasBeenUnpublished = true;
+      await createHistoryEvent(ctx.questionnaire.id, publishStatusEvent(ctx));
+    }
 
-  await saveQuestionnaire(ctx.questionnaire);
-  ctx.validationErrorInfo = validateQuestionnaire({
-    ...ctx.questionnaire,
-    updatedAt: new Date(),
-  });
-
-  if (hasBeenUnpublished) {
-    pubsub.publish("publishStatusUpdated", {
-      questionnaire: ctx.questionnaire,
+    await saveQuestionnaire(ctx.questionnaire);
+    ctx.validationErrorInfo = validateQuestionnaire({
+      ...ctx.questionnaire,
+      updatedAt: new Date(),
     });
-  }
-  pubsub.publish("validationUpdated", {
-    questionnaire: ctx.questionnaire,
-    validationErrorInfo: ctx.validationErrorInfo,
-    user: ctx.user,
-  });
-  return result;
-};
+
+    if (hasBeenUnpublished) {
+      pubsub.publish("publishStatusUpdated", {
+        questionnaire: ctx.questionnaire,
+      });
+    }
+    // pubsub.publish("validationUpdated", {
+    //   questionnaire: ctx.questionnaire,
+    //   validationErrorInfo: ctx.validationErrorInfo,
+    //   user: ctx.user,
+    // });
+    return result;
+  };
 
 module.exports = {
   createMutation,

--- a/eq-author-api/schema/resolvers/createMutation.js
+++ b/eq-author-api/schema/resolvers/createMutation.js
@@ -48,11 +48,11 @@ const createMutation =
         questionnaire: ctx.questionnaire,
       });
     }
-    // pubsub.publish("validationUpdated", {
-    //   questionnaire: ctx.questionnaire,
-    //   validationErrorInfo: ctx.validationErrorInfo,
-    //   user: ctx.user,
-    // });
+    pubsub.publish("validationUpdated", {
+      questionnaire: ctx.questionnaire,
+      validationErrorInfo: ctx.validationErrorInfo,
+      user: ctx.user,
+    });
     return result;
   };
 

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withCreateBinaryExpression.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withCreateBinaryExpression.js
@@ -10,6 +10,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           expressionGroupId,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withCreateBinaryExpression.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withCreateBinaryExpression.test.js
@@ -17,6 +17,7 @@ describe("withCreateBinaryExpression", () => {
     it("should call mutate", () => {
       props.createBinaryExpression("id");
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { expressionGroupId: "id" } },
       });
     });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withDeleteBinaryExpression.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withDeleteBinaryExpression.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
         },
       },
       update: (_, result) => onCompleted(result?.data?.deleteBinaryExpression2),
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withDeleteBinaryExpression.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withDeleteBinaryExpression.test.js
@@ -17,6 +17,7 @@ describe("withDeleteBinaryExpression", () => {
     it("should call mutate", () => {
       props.deleteBinaryExpression("id");
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { id: "id" } },
         update: expect.any(Function),
       });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateBinaryExpression.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateBinaryExpression.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           condition,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateBinaryExpression.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateBinaryExpression.test.js
@@ -23,6 +23,7 @@ describe("withUpdateBinaryExpression", () => {
         "Equals"
       );
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { id: "id", condition: "Equals" } },
       });
     });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateLeftSide.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateLeftSide.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           answerId,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateLeftSide.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateLeftSide.test.js
@@ -23,6 +23,7 @@ describe("withUpdateLeftSide", () => {
         "answerId"
       );
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { expressionId: "id", answerId: "answerId" } },
       });
     });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateRightSide.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateRightSide.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           ...updateField,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateRightSide.test.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/withUpdateRightSide.test.js
@@ -23,6 +23,7 @@ describe("withUpdateRightSide", () => {
         { customValue: { number: 5 } }
       );
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: {
           input: { expressionId: "id", customValue: { number: 5 } },
         },
@@ -38,6 +39,7 @@ describe("withUpdateRightSide", () => {
         { selectedOptions: ["1", "2"] }
       );
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: {
           input: { expressionId: "id", selectedOptions: ["1", "2"] },
         },

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withDeleteRule.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withDeleteRule.js
@@ -10,6 +10,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           id,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withDeleteRule.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withDeleteRule.test.js
@@ -17,6 +17,7 @@ describe("withDeleteRule", () => {
     it("should call mutate", () => {
       props.deleteRule("id");
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { id: "id" } },
       });
     });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateExpressionGroup.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateExpressionGroup.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           operator,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateRule.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateRule.js
@@ -12,6 +12,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           destination: rule.destination,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateRule.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/RuleEditor/withUpdateRule.test.js
@@ -21,6 +21,7 @@ describe("withUpdateRule", () => {
         destination: { sectionId: "5" },
       });
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { id: "1", destination: { sectionId: "5" } } },
       });
     });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withCreateRule.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withCreateRule.js
@@ -10,6 +10,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           routingId,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withCreateRule.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withCreateRule.test.js
@@ -17,6 +17,7 @@ describe("withCreateRule", () => {
     it("should call mutate", () => {
       props.createRule("id");
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { routingId: "id" } },
       });
     });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withUpdateRouting.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withUpdateRouting.js
@@ -11,6 +11,7 @@ export const mapMutateToProps = ({ mutate }) => ({
           else: routing.else,
         },
       },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withUpdateRouting.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/RoutingEditor/withUpdateRouting.test.js
@@ -17,6 +17,7 @@ describe("withUpdateRouting", () => {
     it("should call mutate", () => {
       props.updateRouting({ id: "1", foo: "bar", else: { pageId: "3" } });
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { id: "1", else: { pageId: "3" } } },
       });
     });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/withCreateRouting.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/withCreateRouting.js
@@ -6,6 +6,7 @@ export const mapMutateToProps = ({ mutate }) => ({
   createRouting(pageId) {
     return mutate({
       variables: { input: { pageId } },
+      refetchQueries: ["GetQuestionnaire"],
     });
   },
 });

--- a/eq-author/src/App/page/Logic/Routing/RoutingPage/withCreateRouting.test.js
+++ b/eq-author/src/App/page/Logic/Routing/RoutingPage/withCreateRouting.test.js
@@ -17,6 +17,7 @@ describe("withCreateRouting", () => {
     it("should call mutate", () => {
       props.createRouting("id");
       expect(mutate).toHaveBeenCalledWith({
+        refetchQueries: ["GetQuestionnaire"],
         variables: { input: { pageId: "id" } },
       });
     });


### PR DESCRIPTION
### Context of PR ###

When PubSub is disabled. Error messages weren't updating due to not enough data being passed down in the GraphQL calls.

### How to review ###

- Go to `eq-author-api/schema/resolvers/createMutation.js`.
- Comment out lines `51-55`. This disables PubSub.
- Create a question with a Routing Rule.
- Check that the error messages disappear and update correctly.
- Create a some Skip Logic and check that the error messages disappear and update correctly.
- UnComment lines `51-55` in `createMutation.js` to reenable PubSub.

What to do after everything is green
    *   Bring this branch up-to-date with Origin/Master
    *   If there are a lot of commits or some are not helpful to read, squash them down
    *   Click the Merge button on this pull request
    *   Does this change mean the Capability examples questionnaire should be updated?
    *   Move the Jira ticket for this task into the next stage of the process
