### PR TITLE
EAR 1487 Add answer type to screen reader

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ exports[`Answer Editor should correctly calculates date format 3`] = `null`;
 
 exports[`Answer Editor should render Checkbox 1`] = `
 <AnswerEditor__Answer
+  aria-label="Checkbox answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -125,6 +126,7 @@ exports[`Answer Editor should render Checkbox 1`] = `
 
 exports[`Answer Editor should render Currency 1`] = `
 <AnswerEditor__Answer
+  aria-label="Currency answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -236,6 +238,7 @@ exports[`Answer Editor should render Currency 1`] = `
 
 exports[`Answer Editor should render Date 1`] = `
 <AnswerEditor__Answer
+  aria-label="Date answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -349,6 +352,7 @@ exports[`Answer Editor should render Date 1`] = `
 
 exports[`Answer Editor should render DateRange 1`] = `
 <AnswerEditor__Answer
+  aria-label="DateRange answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -457,6 +461,7 @@ exports[`Answer Editor should render DateRange 1`] = `
 
 exports[`Answer Editor should render Duration 1`] = `
 <AnswerEditor__Answer
+  aria-label="Duration answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -571,6 +576,7 @@ exports[`Answer Editor should render Duration 1`] = `
 
 exports[`Answer Editor should render Number 1`] = `
 <AnswerEditor__Answer
+  aria-label="Number answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -682,6 +688,7 @@ exports[`Answer Editor should render Number 1`] = `
 
 exports[`Answer Editor should render Percentage 1`] = `
 <AnswerEditor__Answer
+  aria-label="Percentage answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -793,6 +800,7 @@ exports[`Answer Editor should render Percentage 1`] = `
 
 exports[`Answer Editor should render Radio 1`] = `
 <AnswerEditor__Answer
+  aria-label="Radio answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -911,6 +919,7 @@ exports[`Answer Editor should render Radio 1`] = `
 
 exports[`Answer Editor should render TextArea 1`] = `
 <AnswerEditor__Answer
+  aria-label="TextArea answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -1021,6 +1030,7 @@ exports[`Answer Editor should render TextArea 1`] = `
 
 exports[`Answer Editor should render TextField 1`] = `
 <AnswerEditor__Answer
+  aria-label="TextField answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>
@@ -1131,6 +1141,7 @@ exports[`Answer Editor should render TextField 1`] = `
 
 exports[`Answer Editor should render Unit 1`] = `
 <AnswerEditor__Answer
+  aria-label="Unit answer"
   data-test="answer-editor"
 >
   <AnswerEditor__AnswerHeader>

--- a/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/AnswersEditor/AnswerEditor/index.js
@@ -146,7 +146,10 @@ class AnswerEditor extends React.Component {
 
   render() {
     return (
-      <Answer data-test="answer-editor">
+      <Answer
+        aria-label={`${this.props.answer.type} answer`}
+        data-test="answer-editor"
+      >
         <AnswerHeader>
           <AnswerTypePanel>
             <AnswerType data-test="answer-type">


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Read out the answer type on the first element when tab is used to view an answer

### How to review

Open the screen reader (_Command+F5_ on Mac)

**Check:**

- [ ] Using tab to view the first element of an answer reads out "<Answer type> answer" on the screen reader

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
