### PR TITLE
Update to pass an error if meta data has been deleted in `Additional …

### DIFF
--- a/eq-author-api/src/validation/customKeywords/validatePipingMetadataInTitle.js
+++ b/eq-author-api/src/validation/customKeywords/validatePipingMetadataInTitle.js
@@ -18,7 +18,7 @@ module.exports = (ajv) =>
     keyword: "validatePipingMetadataInTitle",
     validate: function isValid(
       _schema,
-      title,
+      textString,
       _parentSchema,
       { parentDataProperty: fieldName, instancePath, rootData: questionnaire }
     ) {
@@ -26,8 +26,10 @@ module.exports = (ajv) =>
       const pipedIdList = [];
 
       let matches;
+
       do {
-        matches = pipedAnswerIdRegex.exec(title);
+        matches = pipedAnswerIdRegex.exec(textString);
+
         if (matches && matches.length > 1) {
           const [, answerId] = matches;
           pipedIdList.push(trimDateRangeId(answerId));

--- a/eq-author-api/src/validation/schemas/answer.json
+++ b/eq-author-api/src/validation/schemas/answer.json
@@ -165,38 +165,40 @@
       }
     },
     "dateRangeAnswer": {
-      "allOf": [{
-        "type": "object",
-        "properties": {
-          "secondaryLabel": {
-            "$ref": "definitions.json#/definitions/populatedString"
-          }
-        },
-        "if": {
+      "allOf": [
+        {
           "type": "object",
           "properties": {
-            "advancedProperties": {
-              "const": true
+            "secondaryLabel": {
+              "$ref": "definitions.json#/definitions/populatedString"
             }
-          }
-        },
-        "then": {
-          "type": "object",
-          "properties": {
-            "validation": {
-              "$ref": "validation.json#/definitions/dateRangeValidations"
-            },
+          },
+          "if": {
+            "type": "object",
             "properties": {
-              "type": "object",
+              "advancedProperties": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "type": "object",
+            "properties": {
+              "validation": {
+                "$ref": "validation.json#/definitions/dateRangeValidations"
+              },
               "properties": {
-                "fallback":{
-                  "$ref": "#/definitions/fallback"
+                "type": "object",
+                "properties": {
+                  "fallback": {
+                    "$ref": "#/definitions/fallback"
+                  }
                 }
               }
             }
           }
         }
-      }]
+      ]
     },
     "properties": {
       "type": "object",

--- a/eq-author-api/src/validation/schemas/page.json
+++ b/eq-author-api/src/validation/schemas/page.json
@@ -18,6 +18,13 @@
         }
       ]
     },
+    "description": {
+      "allOf": [
+        {
+          "validatePipingMetadataInTitle": true
+        }
+      ]
+    },
     "confirmation": {
       "$ref": "confirmationPage.json"
     },

--- a/eq-author/src/App/page/Design/QuestionPageEditor/validationUtils.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/validationUtils.js
@@ -38,6 +38,7 @@ const situations = {
   },
   description: {
     [DESCRIPTION_NOT_ENTERED.errorCode]: DESCRIPTION_NOT_ENTERED.message,
+    [PIPING_METADATA_DELETED.errorCode]: PIPING_METADATA_DELETED.message,
   },
   additionalInfoLabel: {
     [ADDITIONAL_INFO_LABEL_NOT_ENTERED.errorCode]:


### PR DESCRIPTION
### Context of PR ###

When piping in MetaData into the `Additional Contents` `Question Description`, if that MetaData was then deleted, the errors don't pass down meaning it isn't obvious to the user that there's an error.

### How to review ###

- Create a question and answer.
- Add a `Question Description` text.
- Create a custom MetaData.
- Pipe that MetaData into the  `Question Description`.
-  Then delete that MetaData tag and you should see the errors appear in the Design Page.

What to do after everything is green
    *   Bring this branch up-to-date with Origin/Master
    *   If there are a lot of commits or some are not helpful to read, squash them down
    *   Click the Merge button on this pull request
    *   Does this change mean the Capability examples questionnaire should be updated?
    *   Move the Jira ticket for this task into the next stage of the process
