### PR TITLE
Ear 1507 other section and folder duplication

### DIFF
--- a/eq-author/src/graphql/duplicateFolder.graphql
+++ b/eq-author/src/graphql/duplicateFolder.graphql
@@ -2,6 +2,7 @@
 #import "./fragments/folder.graphql"
 #import "./fragments/page.graphql"
 #import "./fragments/answer.graphql"
+#import "./fragments/option.graphql"
 
 mutation duplicateFolder($input: DuplicateFolderInput!) {
   duplicateFolder(input: $input) {
@@ -29,19 +30,7 @@ mutation duplicateFolder($input: DuplicateFolderInput!) {
               }
               ... on MultipleChoiceAnswer {
                 options {
-                  id
-                  displayName
-                  label
-                  description
-                  value
-                  qCode
-                  additionalAnswer {
-                    id
-                    description
-                    label
-                    qCode
-                    type
-                  }
+                  ...Option
                 }
                 mutuallyExclusiveOption {
                   id

--- a/eq-author/src/graphql/duplicateFolder.graphql
+++ b/eq-author/src/graphql/duplicateFolder.graphql
@@ -35,6 +35,13 @@ mutation duplicateFolder($input: DuplicateFolderInput!) {
                   description
                   value
                   qCode
+                  additionalAnswer {
+                    id
+                    description
+                    label
+                    qCode
+                    type
+                  }
                 }
                 mutuallyExclusiveOption {
                   id

--- a/eq-author/src/graphql/duplicateSection.graphql
+++ b/eq-author/src/graphql/duplicateSection.graphql
@@ -3,6 +3,7 @@
 #import "./fragments/folder.graphql"
 #import "./fragments/page.graphql"
 #import "./fragments/answer.graphql"
+#import "./fragments/option.graphql"
 
 mutation duplicateSection($input: DuplicateSectionInput!) {
   duplicateSection(input: $input) {
@@ -28,19 +29,7 @@ mutation duplicateSection($input: DuplicateSectionInput!) {
             }
             ... on MultipleChoiceAnswer {
               options {
-                id
-                displayName
-                label
-                description
-                value
-                qCode
-                additionalAnswer {
-                  id
-                  description
-                  label
-                  qCode
-                  type
-                }
+                ...Option
               }
               mutuallyExclusiveOption {
                 id

--- a/eq-author/src/graphql/duplicateSection.graphql
+++ b/eq-author/src/graphql/duplicateSection.graphql
@@ -34,6 +34,13 @@ mutation duplicateSection($input: DuplicateSectionInput!) {
                 description
                 value
                 qCode
+                additionalAnswer {
+                  id
+                  description
+                  label
+                  qCode
+                  type
+                }
               }
               mutuallyExclusiveOption {
                 id


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes a bug causing a duplicated section or folder not to be displayed until refresh when it includes a checkbox or radio answer with an "other" option

### How to review

**Check:**
- [ ] Duplicating a section which includes a checkbox or radio with an "other" answer displays the new section before refreshing the page
- [ ] Duplicating a folder which includes a checkbox or radio with an "other" answer displays the new folder before refreshing the page

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
