### PR TITLE
Ear 927 date range zero

### DIFF
--- a/eq-author/src/App/page/Design/Validation/DurationPreview.js
+++ b/eq-author/src/App/page/Design/Validation/DurationPreview.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const DurationPreview = ({ duration: { unit, value } }) => {
-  if (!value) {
+  if (value === null || value === undefined) {
     return;
   }
   return (

--- a/eq-author/src/App/page/Design/Validation/DurationPreview.test.js
+++ b/eq-author/src/App/page/Design/Validation/DurationPreview.test.js
@@ -24,10 +24,25 @@ describe("Duration Error", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("should not render when value 0", () => {
+  it("should render when value 0", () => {
     const duration = {
       unit: DAYS,
       value: 0,
+    };
+    expect(render({ duration })).toMatchSnapshot();
+  });
+
+  it("should not render when value is null", () => {
+    const duration = {
+      unit: DAYS,
+      value: null,
+    };
+    expect(render({ duration })).toMatchSnapshot();
+  });
+
+  it("should not render when value is undefined", () => {
+    const duration = {
+      unit: DAYS,
     };
     expect(render({ duration })).toMatchSnapshot();
   });

--- a/eq-author/src/App/page/Design/Validation/__snapshots__/DurationPreview.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/__snapshots__/DurationPreview.test.js.snap
@@ -1,11 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Duration Error should not render when value 0 1`] = `""`;
+exports[`Duration Error should not render when value is null 1`] = `""`;
+
+exports[`Duration Error should not render when value is undefined 1`] = `""`;
 
 exports[`Duration Error should render 1`] = `
 <Fragment>
   <div>
     5 days
+  </div>
+</Fragment>
+`;
+
+exports[`Duration Error should render when value 0 1`] = `
+<Fragment>
+  <div>
+    0 days
   </div>
 </Fragment>
 `;


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Change date range duration validation to display "0 days" instead of empty data

### How to review

**Check: **
- [ ] Empty data is displayed when value is undefined or null for both min and max duration
- [ ] "0 days" is displayed when value is 0 for min and max duration
- [ ] "x days" is displayed when value is x for min and max duration

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
