### PR TITLE
EAR 1552 - allow comments on locked questionnaire

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -976,7 +976,6 @@ const Resolvers = {
     createComment: async (_, { input }, ctx) => {
       const { componentId, commentText } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
@@ -1005,7 +1004,6 @@ const Resolvers = {
     deleteComment: async (_, { input }, ctx) => {
       const { componentId, commentId } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
@@ -1022,7 +1020,6 @@ const Resolvers = {
     updateComment: async (_, { input }, ctx) => {
       const { componentId, commentId, commentText } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
@@ -1045,7 +1042,6 @@ const Resolvers = {
     createReply: async (_, { input }, ctx) => {
       const { componentId, commentText, commentId } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
@@ -1076,7 +1072,6 @@ const Resolvers = {
     updateReply: async (_, { input }, ctx) => {
       const { componentId, commentId, replyId, commentText } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id
@@ -1100,7 +1095,6 @@ const Resolvers = {
     deleteReply: async (_, { input }, ctx) => {
       const { componentId, commentId, replyId } = input;
       const questionnaire = ctx.questionnaire;
-      enforceQuestionnaireLocking(ctx.questionnaire); // throws ForbiddenError
 
       const questionnaireComments = await getCommentsForQuestionnaire(
         questionnaire.id

--- a/eq-author-api/schema/tests/comments.test.js
+++ b/eq-author-api/schema/tests/comments.test.js
@@ -152,17 +152,24 @@ describe("comments", () => {
   });
 
   describe("locking", () => {
-    it("should prevent adding comments to a locked questionnaire", async () => {
-      expect(
-        createComment(
-          { ...ctx, questionnaire: { ...ctx.questionnaire, locked: true } },
-          {
-            componentId,
-            commentText: "a new comment is created",
-          }
-        )
-      ).rejects.toThrow();
+    it("should create a comment on a locked questionnaire and then query that comment", async () => {
+      await createComment(
+        { ...ctx, questionnaire: { ...ctx.questionnaire, locked: true } },
+        {
+          componentId,
+          commentText: "a new comment is created",
+        }
+      );
 
+      const queryNewComments = await queryComments(ctx, componentId);
+
+      expect(queryNewComments).toMatchObject({
+        comments: [
+          {
+            commentText: "a new comment is created",
+          },
+        ],
+      });
       questionnaire.locked = false;
     });
   });


### PR DESCRIPTION
Ticket: https://collaborate2.ons.gov.uk/jira/browse/EAR-1552

### What is the context of this PR?

>Allows comments and replies to comments to be created/updated/deleted on locked questionnaires
>

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Import the **Capability examples** questionnaire from pre-prod Author into your local environment and:
  - ensure it can be opened in Author;
  - then, ensure it can be viewed in Runner by pressing the **view survey** button
- Does this require a migration? We need one if existing JSON schema properties change

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
