### PR TITLE
fix for comments caching issue

### DIFF
--- a/eq-author/src/App/Comments/index.js
+++ b/eq-author/src/App/Comments/index.js
@@ -82,6 +82,7 @@ const CommentsPanel = ({ componentId }) => {
     variables: {
       componentId,
     },
+    fetchPolicy: "network-only",
   });
 
   useSubscription(COMMENT_SUBSCRIPTION, {


### PR DESCRIPTION
Comments have a caching issue when there are duplicate page id in different questionnaires. 
