### PR TITLE
display or in preview

### DIFF
--- a/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
+++ b/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
@@ -144,7 +144,9 @@ Option.propTypes = {
 const MultipleChoiceAnswer = ({ answer }) => {
   return (
     <Field>
-      <Legend>{answer.label}</Legend>
+      <Legend>
+        {answer.options[0].mutuallyExclusive ? "Or" : answer.label}
+      </Legend>
       {answer.type === CHECKBOX && !answer.label && (
         <SelectAll>Select all that apply:</SelectAll>
       )}

--- a/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
+++ b/eq-author/src/components/preview/Answers/MultipleChoiceAnswer.js
@@ -66,9 +66,10 @@ export const OptionItem = styled.div`
   background: #fff;
   border: 1px solid ${colors.grey};
   border-radius: 0.2em;
-  width: 100%;
+  width: fit-content;
   min-width: 20em;
-  display: inline-block;
+  max-width: 100%;
+  display: block;
   overflow: hidden;
   position: relative;
   margin-bottom: 0.25em;

--- a/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/eq-author/src/components/preview/Answers/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -138,7 +138,7 @@ exports[`MultipleChoiceAnswer should render OptionItem 1`] = `
         "rules": Array [
           "font-size:1em;background:#fff;border:1px solid ",
           "#999999",
-          ";border-radius:0.2em;width:100%;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
+          ";border-radius:0.2em;width:fit-content;min-width:20em;max-width:100%;display:block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
           [Function],
           ";",
         ],
@@ -170,7 +170,7 @@ exports[`MultipleChoiceAnswer should render OptionItem with error 1`] = `
         "rules": Array [
           "font-size:1em;background:#fff;border:1px solid ",
           "#999999",
-          ";border-radius:0.2em;width:100%;min-width:20em;display:inline-block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
+          ";border-radius:0.2em;width:fit-content;min-width:20em;max-width:100%;display:block;overflow:hidden;position:relative;margin-bottom:0.25em;word-wrap:break-word;",
           [Function],
           ";",
         ],

--- a/eq-author/src/components/preview/Answers/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/preview/Answers/__snapshots__/index.test.js.snap
@@ -11,6 +11,7 @@ exports[`Answers should render a component for each answer type: Checkbox 1`] = 
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -25,6 +26,7 @@ exports[`Answers should render a component for each answer type: Currency 1`] = 
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -39,6 +41,7 @@ exports[`Answers should render a component for each answer type: Number 1`] = `
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -53,6 +56,7 @@ exports[`Answers should render a component for each answer type: Percentage 1`] 
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -67,6 +71,7 @@ exports[`Answers should render a component for each answer type: Radio 1`] = `
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -81,6 +86,7 @@ exports[`Answers should render a component for each answer type: TextArea 1`] = 
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -95,6 +101,7 @@ exports[`Answers should render a component for each answer type: TextField 1`] =
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 
@@ -109,6 +116,7 @@ exports[`Answers should render a component for each answer type: Unit 1`] = `
       }
     }
   />
+  0
 </Answers__AnswerWrapper>
 `;
 

--- a/eq-author/src/components/preview/Answers/index.js
+++ b/eq-author/src/components/preview/Answers/index.js
@@ -49,6 +49,11 @@ export const Answer = ({ answer }) => {
   return (
     <AnswerWrapper>
       <Component answer={answer} />
+      {answer.options &&
+        answer.options.length &&
+        answer.options[0].mutuallyExclusive && (
+          <MultipleChoiceAnswer answer={answer} />
+        )}
     </AnswerWrapper>
   );
 };


### PR DESCRIPTION
Ticket: https://collaborate2.ons.gov.uk/jira/browse/EAR-1498

### What is the context of this PR?

> Allow the or option to show up in the preview page when turned on for the following answer types: 
     Number
    Currency
    Unit
    Percentage
    Duration
    Date
    TextArea
    Text


### How to review
1. Create a question for each answer type in the list above
2. Turn on advanced options 
3. Turn on "Or" option
4. Check the Or checkbox displays in the preview page

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
