### PR TITLE
Ear 1614 logic box sizing

### DIFF
--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/SecondaryConditionSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/SecondaryConditionSelector.js
@@ -18,7 +18,7 @@ const conditions = {
 };
 
 export const Selector = styled(Select)`
-  width: 195px;
+  width: 14em;
   padding: 0.3em 2em 0.3em 0.5em;
 `;
 

--- a/eq-author/src/App/page/Logic/BinaryExpressionEditor/SecondaryConditionSelector.js
+++ b/eq-author/src/App/page/Logic/BinaryExpressionEditor/SecondaryConditionSelector.js
@@ -18,7 +18,6 @@ const conditions = {
 };
 
 export const Selector = styled(Select)`
-  width: 14em;
   padding: 0.3em 2em 0.3em 0.5em;
 `;
 


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR

> Please ensure:
> All the operators (>=, <=) on routing/skip logic fits the box.

### What is the context of this PR?
> removed width of 200px on secondary condition selector (styled selector). So, it could have the default size which fits all operators. 14em on the width could give more space but the default size is more than enough for all operators.