### PR TITLE
fix for bug

### DIFF
--- a/eq-author-api/db/datastore/datastore-firestore.js
+++ b/eq-author-api/db/datastore/datastore-firestore.js
@@ -167,7 +167,9 @@ const getQuestionnaireMetaById = async (id) => {
       ...questionnaireSnapshot.data(),
       history: questionnaireSnapshot.data().history.map((historyItem) => ({
         ...historyItem,
-        time: historyItem.time.toDate(),
+        time: historyItem.time.seconds
+          ? historyItem.time.toDate()
+          : new Date(historyItem.time),
       })),
       updatedAt: questionnaireSnapshot.data().updatedAt.toDate(),
       createdAt: questionnaireSnapshot.data().createdAt.toDate(),


### PR DESCRIPTION
There is a bug in GCP at the moment that is breaking migrations for older questionnaires.
This will stop Authors having to duplicate questionnaires to fix it.
