### PR TITLE
EAR 1639 theme settings reset

### DIFF
--- a/eq-author/src/App/settings/index.js
+++ b/eq-author/src/App/settings/index.js
@@ -50,6 +50,7 @@ export default [
         variables={{
           input: { questionnaireId: props.match.params.questionnaireId },
         }}
+        fetchPolicy="cache-and-network"
       >
         {({ loading, error, data }) => {
           if (loading) {


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

https://collaborate2.ons.gov.uk/jira/browse/EAR-1639
Fix theme data being reset to a different questionnaire's theme data after opening a different questionnaire

### How to review

1 - Create questionnaire
2 - Edit questionnaire's theme data for two different themes
3 - Edit both themes' eQ ID, Form type and legal basis - take a note of all edited values
4 - Open the theme settings page of a different questionnaire
5 - Edit theme data on two themes (the same themes selected in step 2)
6- Return to the original questionnaire's theme settings page
7 - The original questionnaire's theme settings data should be able to be edited, and its data should match the data entered in steps 2 and 3

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
