### PR TITLE
EAR 1406 Fix section separator displayed twice when email confirmation selected

### DIFF
--- a/eq-author/src/App/Submission/Preview/SubmissionPreview/index.js
+++ b/eq-author/src/App/Submission/Preview/SubmissionPreview/index.js
@@ -149,10 +149,10 @@ const SubmissionEditor = ({ submission, questionnaireTitle }) => {
         </PanelSection>
       </Panel>
       <Section dangerouslySetInnerHTML={{ __html: furtherContent }} />
-      <SectionSeparator />
       {viewPrintAnswers && (
         <>
           <Section>
+            <SectionSeparator />
             <PageTitle
               title={getCopyOfAnswers}
               missingText={missingTitleText}


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes bug displaying two section separators in preview page when only Email confirmation is selected

### How to review

- Open preview page with only Email confirmation selected
- Check only one section separator horizontal line is displayed

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
