### PR TITLE
fix second page link redirecting to first and extra error condition

### DIFF
--- a/eq-author/src/App/page/Design/index.js
+++ b/eq-author/src/App/page/Design/index.js
@@ -103,7 +103,6 @@ export const UnwrappedPageRoute = (props) => {
   };
 
   const redirectPage = () => {
-    //need this questionnaire != null otherwise TypeError when recompile and run author.
     if (page === null) {
       return (
         <RedirectRoute

--- a/eq-author/src/App/page/Design/index.js
+++ b/eq-author/src/App/page/Design/index.js
@@ -97,10 +97,14 @@ export const UnwrappedPageRoute = (props) => {
     if (error) {
       return <Error>Something went wrong</Error>;
     }
+    if (isEmpty(page)) {
+      return <Error>Oops! Page could not be found</Error>;
+    }
   };
 
   const redirectPage = () => {
-    if (isEmpty(page)) {
+    //need this questionnaire != null otherwise TypeError when recompile and run author.
+    if (page === null) {
       return (
         <RedirectRoute
           from={"/q/:questionnaireId/page/:pageId/design"}


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

https://collaborate2.ons.gov.uk/jira/browse/EAR-1645

fix all question pages redirecting to the first page when questionnaire is first opened.


### How to review

- open the questionnaire with more than one question
- select any question other than the first question 
- check that this doesn't redirect you to the first question

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
