### PR TITLE
Ear 1652 publisher not creating total validation

### DIFF
--- a/eq-publisher/src/eq_schema/Question.js
+++ b/eq-publisher/src/eq_schema/Question.js
@@ -177,7 +177,7 @@ class Question {
     const rightSide =
       totalValidation.entityType === "Custom"
         ? { value: totalValidation.custom }
-        : { answer_id: `answer${totalValidation.previousAnswer.id}` };
+        : { answer_id: `answer${totalValidation.previousAnswer}` };
 
     return {
       calculation_type: "sum",

--- a/eq-publisher/src/eq_schema/Question.test.js
+++ b/eq-publisher/src/eq_schema/Question.test.js
@@ -783,7 +783,7 @@ describe("Question", () => {
     it("should set the answer_id to the previous answer when entityType is PreviousAnswer", () => {
       validation.entityType = "PreviousAnswer";
       validation.custom = 10;
-      validation.previousAnswer = { id: 20 };
+      validation.previousAnswer = 20;
       const question = new Question(
         createQuestionJSON({
           totalValidation: validation,


### PR DESCRIPTION
### Context of PR ###
When adding a Total Number validation and referencing a previous question, in the Publisher Schema the ID of the previous question is undefined.

https://collaborate2.ons.gov.uk/jira/secure/RapidBoard.jspa?rapidView=940&projectKey=EAR&view=detail&selectedIssue=EAR-1652

### How to review ###
- [ ] Create  two number answers where the Total Number Validation is equal to a `Previous Answer`.
- [ ] Check the schema of Publisher and check in the calculations array of that question, that `answer_id` is not undefined, but equal to the id of the answer you're referencing.

### What to do after everything is green ###

    *  Bring this branch up-to-date with Origin/Master
    *  If there are a lot of commits or some are not helpful to read, squash them down
    *  Click the Merge button on this pull request
    *  Does this change mean the Capability examples questionnaire should be updated?
    *  Move the Jira ticket for this task into the next stage of the process
