### PR TITLE
EAR-1657-new-legal-basis-option-Fuels

### DIFF
--- a/eq-author-api/constants/legalBases.js
+++ b/eq-author-api/constants/legalBases.js
@@ -1,4 +1,5 @@
 module.exports.NOTICE_1 = "NOTICE_1";
 module.exports.NOTICE_2 = "NOTICE_2";
 module.exports.NOTICE_3 = "NOTICE_3";
+module.exports.NOTICE_FUELS = "NOTICE_FUELS";
 module.exports.VOLUNTARY = "VOLUNTARY";

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -119,6 +119,7 @@ enum LegalBasisCode {
   NOTICE_2
   NOTICE_3
   NOTICE_NI
+  NOTICE_FUELS
   VOLUNTARY
 }
 

--- a/eq-author/src/App/settings/LegalBasisSelect/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/settings/LegalBasisSelect/__snapshots__/index.test.js.snap
@@ -53,6 +53,17 @@ exports[`LegalBasisField should render 1`] = `
     </Radio__RadioDescription>
   </LegalOption>
   <LegalOption
+    key="NOTICE_FUELS"
+    name="default"
+    onChange={[Function]}
+    selected={false}
+    value="NOTICE_FUELS"
+  >
+    <Radio__RadioDescription>
+      Petroleum Act 1998 and Section 1 of the Statistics of Trade Act 1947.
+    </Radio__RadioDescription>
+  </LegalOption>
+  <LegalOption
     key="VOLUNTARY"
     name="default"
     onChange={[Function]}

--- a/eq-author/src/App/settings/LegalBasisSelect/index.js
+++ b/eq-author/src/App/settings/LegalBasisSelect/index.js
@@ -30,6 +30,11 @@ export const LEGAL_BASIS_OPTIONS = [
     value: "NOTICE_NI",
   },
   {
+    description:
+      "Petroleum Act 1998 and Section 1 of the Statistics of Trade Act 1947.",
+    value: "NOTICE_FUELS",
+  },
+  {
     description: "Voluntary",
     value: "VOLUNTARY",
   },

--- a/eq-publisher/src/constants/legalBases.js
+++ b/eq-publisher/src/constants/legalBases.js
@@ -7,6 +7,8 @@ module.exports = {
     "Notice is given under sections 3 and 4 of the Statistics of Trade Act 1947.",
   NOTICE_NI:
     "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+  NOTICE_FUELS:
+    "Notice is given under the Petroleum Act 1998 and Section 1 of the Statistics of Trade Act 1947.",
   VOLUNTARY: undefined,
   types: {},
 };


### PR DESCRIPTION
https://collaborate2.ons.gov.uk/jira/browse/EAR-1657

### What is the context of this PR?

GIVEN I am creating a questionnaire

WHEN I am choosing the legal basis on the settings page

THEN I am presented with a 'Petroleum Act 1998 and Section 1 of the Statistics of Trade Act 1947' option

### How to review
1. Make sure the new "Fuels option" is available on the settings page on the themes tab area
2. make sure that the new Fuels option is visible on the preview Introduction page, when selected
3. make sure the new Fuels option is generated into runner