### PR TITLE
EAR 1658 Fix duplicated page created in new folder

### DIFF
--- a/eq-author-api/schema/resolvers/pages/index.js
+++ b/eq-author-api/schema/resolvers/pages/index.js
@@ -93,17 +93,7 @@ Resolvers.Mutation = {
     const { previous } = getMovePosition(section, input.id, input.position);
     const previousFolder = section.folders[previous.folderIndex];
 
-    if (previousFolder.enabled) {
-      previousFolder.pages.splice(input.position, 0, remappedPage);
-    } else {
-      section.folders.splice(
-        previous.folderIndex + 1,
-        0,
-        createFolder({
-          pages: [remappedPage],
-        })
-      );
-    }
+    previousFolder.pages.splice(input.position, 0, remappedPage);
 
     return remappedPage;
   }),

--- a/eq-author-api/schema/resolvers/pages/index.js
+++ b/eq-author-api/schema/resolvers/pages/index.js
@@ -91,9 +91,9 @@ Resolvers.Mutation = {
     const duplicatedPage = createQuestionPage(cloneDeep(newpage));
     const remappedPage = remapAllNestedIds(duplicatedPage);
     const { previous } = getMovePosition(section, input.id, input.position);
-    const previousFolder = section.folders[previous.folderIndex];
+    const folder = section.folders[previous.folderIndex];
 
-    previousFolder.pages.splice(input.position, 0, remappedPage);
+    folder.pages.splice(input.position, 0, remappedPage);
 
     return remappedPage;
   }),

--- a/eq-author-api/schema/tests/duplication.test.js
+++ b/eq-author-api/schema/tests/duplication.test.js
@@ -22,8 +22,6 @@ const {
   duplicatePage,
 } = require("../../tests/utils/contextBuilder/page");
 
-const { getFolderByPageId } = require("../resolvers/utils");
-
 const { getQuestionnaire } = require("../../db/datastore");
 
 describe("Duplication", () => {
@@ -98,13 +96,7 @@ describe("Duplication", () => {
       expect(pageCopy.title).toEqual(`Copy of ${page.title}`);
     });
 
-    it("should be created in new folder if parent folder disabled", () => {
-      expect(pageCopy.position).toEqual(0);
-    });
-
     it("should be created in same folder if parent folder enabled", async () => {
-      const folder = getFolderByPageId(ctx, page.id);
-      folder.enabled = true;
       let { id } = await duplicatePage(ctx, page);
       pageCopy = await queryPage(ctx, id);
 


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

https://collaborate2.ons.gov.uk/jira/browse/EAR-1658

Fix bug creating duplicated pages inside of a separate folder

### How to review

**Check:**
- [ ] Duplicating a page displays the new page inside of the same folder

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
