### PR TITLE
fix  folder move

### DIFF
--- a/eq-author/src/App/page/Design/MoveEntityModal/index.js
+++ b/eq-author/src/App/page/Design/MoveEntityModal/index.js
@@ -9,18 +9,16 @@ import { useQuestionnaire } from "components/QuestionnaireContext";
 export const buildPageList = (folders) => {
   const optionList = [];
   folders.forEach((folder) => {
-    const { id, enabled, pages } = folder;
-    if (enabled) {
-      optionList.push({
-        ...folder,
-        parentEnabled: false,
-      });
-    }
+    const { id, pages } = folder;
+    optionList.push({
+      ...folder,
+      parentEnabled: false,
+    });
     pages.forEach((page) => {
       optionList.push({
         ...page,
-        parentId: enabled ? id : null,
-        parentEnabled: enabled,
+        parentId: id,
+        parentEnabled: true,
       });
     });
   });
@@ -74,8 +72,7 @@ const MoveEntityModal = ({
     () =>
       entity === "Page"
         ? (folders) => buildPageList(folders)
-        : (folders) =>
-            folders.map((item) => (!item.enabled ? item.pages[0] : item)),
+        : (folders) => folders.map((item) => item),
     [entity]
   );
 

--- a/eq-author/src/App/page/Design/MoveEntityModal/index.test.js
+++ b/eq-author/src/App/page/Design/MoveEntityModal/index.test.js
@@ -124,15 +124,6 @@ describe("MoveEntityModal: entity === 'Folder'", () => {
   it("should show correct title", () => {
     expect(screen.getByText("Move folder")).toBeInTheDocument();
   });
-
-  it("should only list folders and disabled folder pages", () => {
-    fireEvent.click(screen.getByTestId("folder-modal-trigger"));
-    const options = screen.getAllByTestId("options");
-    expect(options).toHaveLength(3);
-    expect(options[0].textContent).toEqual("Page 1.1.1");
-    expect(options[1].textContent).toEqual("Folder 2");
-    expect(options[2].textContent).toEqual("Folder 3");
-  });
 });
 
 describe("MovePageModal: buildPageList", () => {
@@ -197,10 +188,5 @@ describe("MovePageModal: buildPageList", () => {
         }),
       ])
     );
-  });
-
-  it("should have null parentId for disabled folders", () => {
-    const [target] = output.filter(({ id }) => id.includes("folder-2"));
-    expect(target.parentId).toBeNull();
   });
 });


### PR DESCRIPTION
Fix for the manual moving of questions in folders following the removed of disabled folders.

To Check
Create several questions in a folder. Check you can move the questions in the folder without a new folder being created.
