### PR TITLE
EAR-1680-remove-sticky-footer-and-make-scrollable

### DIFF
--- a/eq-author/src/App/SignInPage/RecoverPassword/index.js
+++ b/eq-author/src/App/SignInPage/RecoverPassword/index.js
@@ -121,9 +121,11 @@ const RecoverPassword = ({
               Send
             </Button>
           </Field>
-          <ButtonLink onClick={handleReturnToSignInPage}>
-            Return to the sign in page
-          </ButtonLink>
+          <Field>
+            <ButtonLink onClick={handleReturnToSignInPage}>
+              Return to the sign in page
+            </ButtonLink>
+          </Field>
         </>
       )}
 

--- a/eq-author/src/App/SignInPage/SignInForm/index.js
+++ b/eq-author/src/App/SignInPage/SignInForm/index.js
@@ -185,9 +185,11 @@ const SignInForm = ({
           Sign in
         </Button>
       </Field>
-      <ButtonLink onClick={handleCreateAccount}>
-        Create an Author account
-      </ButtonLink>
+      <Field>
+        <ButtonLink onClick={handleCreateAccount}>
+          Create an Author account
+        </ButtonLink>
+      </Field>
     </>
   );
 };

--- a/eq-author/src/components-themed/Footer/index.js
+++ b/eq-author/src/components-themed/Footer/index.js
@@ -9,6 +9,7 @@ const DefaultFooter = styled.div`
   background-color: ${({ theme }) => theme.colors.textBannerLink};
   padding: ${({ centerCols }) =>
     centerCols === 9 ? "1.5rem 0 3rem 1rem" : "1.5rem 0 3rem 0"};
+  height: 95px;
 `;
 
 const Footer = ({ centerCols }) => {

--- a/eq-author/src/components/Layout/index.js
+++ b/eq-author/src/components/Layout/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Titled } from "react-titled";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 
 import ScrollPane from "components/ScrollPane";
 import BaseLayout from "components/BaseLayout";
@@ -10,6 +11,13 @@ import Header from "components-themed/Header/index.js";
 import { ReactComponent as Logo } from "assets/ons-logo.svg";
 import Footer from "components-themed/Footer";
 import { Grid, Column } from "components/Grid";
+
+const GridAuto = styled(Grid)`
+  height: auto;
+  min-height: 100%;
+  margin-bottom: -95px;
+  padding-bottom: 95px;
+`;
 
 const Layout = ({ title, children }) => (
   <Titled title={() => title}>
@@ -24,11 +32,11 @@ const Layout = ({ title, children }) => (
           {title}
         </Header>
         <ScrollPane>
-          <Grid horizontalAlign="center">
+          <GridAuto horizontalAlign="center">
             <Column cols={9}>{children}</Column>
-          </Grid>
+          </GridAuto>
+          <Footer centerCols={9} />
         </ScrollPane>
-        <Footer centerCols={9} />
       </Theme>
     </BaseLayout>
   </Titled>

--- a/eq-author/src/components/QuestionnairesView/PaginationNav/index.js
+++ b/eq-author/src/components/QuestionnairesView/PaginationNav/index.js
@@ -8,7 +8,7 @@ import PaginationNav from "./PaginationNav";
 
 const Wrapper = styled.div`
   display: flex;
-  padding-top: 1em;
+  padding: 1em 0;
   align-items: center;
 `;
 


### PR DESCRIPTION
ticket - https://collaborate2.ons.gov.uk/jira/browse/EAR-1680

### What is the context of this PR?

REmove the NEW sticky footer and make it scrollable (IE - out of view on longer pages, one needs to scroll to see the work of art!)

On pages that have less than full screen content - the footer should then stick to the bottom of the page

### How to review

1. View the questionnaire home page too see the new header and footer
Make sure to view on a list of questionnaires that is longer than the browser page (Or reduce your browser height)
The footer should only be visible when scrolled into view

2. view a non existent URL in Author - the "404 – Sorry, the page you were looking for was not found." page should have the footer at the bottom of the page
