### PR TITLE
EAR-1671 Toggle Switch Button Bug

### DIFF
--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/__snapshots__/index.test.js.snap
@@ -203,8 +203,8 @@ Array [
   height: 1em;
   width: 1em;
   background: #FFFFFF;
-  top: calc(50% - 1em / 2);
-  left: calc(33% - 1em / 2);
+  top: calc(41% - 1em / 2);
+  left: calc(32% - 1em / 2);
   position: relative;
   will-change: transform;
   -webkit-transform: translateX( 0em );
@@ -1064,8 +1064,8 @@ Array [
   height: 1em;
   width: 1em;
   background: #FFFFFF;
-  top: calc(50% - 1em / 2);
-  left: calc(33% - 1em / 2);
+  top: calc(41% - 1em / 2);
+  left: calc(32% - 1em / 2);
   position: relative;
   will-change: transform;
   -webkit-transform: translateX( 0em );

--- a/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
+++ b/eq-author/src/components/buttons/ToggleSwitch/__snapshots__/index.test.js.snap
@@ -115,8 +115,8 @@ exports[`ToggleSwitch should render 1`] = `
   height: 1em;
   width: 1em;
   background: #FFFFFF;
-  top: calc(50% - 1em / 2);
-  left: calc(33% - 1em / 2);
+  top: calc(41% - 1em / 2);
+  left: calc(32% - 1em / 2);
   position: relative;
   will-change: transform;
   -webkit-transform: translateX( 0em );
@@ -330,8 +330,8 @@ exports[`ToggleSwitch should render a large toggle button 1`] = `
   height: 1em;
   width: 1em;
   background: #FFFFFF;
-  top: calc(50% - 1em / 2);
-  left: calc(33% - 1em / 2);
+  top: calc(41% - 1em / 2);
+  left: calc(32% - 1em / 2);
   position: relative;
   will-change: transform;
   -webkit-transform: translateX( 0em );

--- a/eq-author/src/components/buttons/ToggleSwitch/index.js
+++ b/eq-author/src/components/buttons/ToggleSwitch/index.js
@@ -55,8 +55,8 @@ const ToggleSwitchKnob = styled.div`
   height: ${knobSize}em;
   width: ${knobSize}em;
   background: ${colors.white};
-  top: calc(50% - ${knobSize}em / 2);
-  left: calc(33% - ${knobSize}em / 2);
+  top: calc(41% - ${knobSize}em / 2);
+  left: calc(32% - ${knobSize}em / 2);
   position: relative;
   will-change: transform;
   transform: translateX(


### PR DESCRIPTION
JIRA ticket: https://collaborate2.ons.gov.uk/jira/browse/EAR-1671

### What is the context of this PR?

> Changing Author's default font has caused toggle switches to be displayed incorrectly, with part of the toggle switch's button falling below its container. (See in screenshots on the ticket)

### How to review

> Navigate to a page in author with a toggle switch (e.g. settings page) and check the toggle switch buttons are now inside the containers when toggling on/off 


