### PR TITLE
Ear 1711 validate total title

### DIFF
--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -2264,7 +2264,7 @@ describe("schema validation", () => {
         pageType: "CalculatedSummaryPage",
         summaryAnswers: [],
         alias: null,
-        totalTitle: null,
+        totalTitle: "Test",
       };
     });
 

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -2291,6 +2291,29 @@ describe("schema validation", () => {
         expect(errors[0].errorCode).toBe(CALCSUM_MOVED);
       });
 
+      it("Should validate when the calculated summary total title is empty", () => {
+        const pages = questionnaire.sections[0].folders[0].pages;
+
+        mockCalcSum.summaryAnswers = [
+          pages[0].answers[0].id,
+          pages[1].answers[0].id,
+        ];
+
+        mockCalcSum.totalTitle = "";
+
+        const rearrangedFolders = [
+          { id: "folder_1", pages: [{ ...pages[0] }] },
+          { id: "folder_2", pages: [{ ...pages[1] }] },
+          { id: "folder_3", pages: [{ ...mockCalcSum }] },
+        ];
+
+        questionnaire.sections[0].folders = rearrangedFolders;
+        questionnaire.id = 2;
+        const errors = validation(questionnaire);
+
+        expect(errors).toHaveLength(1);
+      });
+
       it("Should not validate when the calc sum appears after the answers it uses", () => {
         const pages = questionnaire.sections[0].folders[0].pages;
 

--- a/eq-author-api/src/validation/schemas/page.json
+++ b/eq-author-api/src/validation/schemas/page.json
@@ -206,7 +206,9 @@
                   }
                 },
                 "totalTitle": {
-                  "$ref": "definitions.json#/definitions/populatedString"
+                  "type": "string",
+                  "pattern": "\\w+",
+                  "errorMessage": "ERR_VALID_TOTAL_TITLE_REQUIRED"
                 }
               }
             }

--- a/eq-author-api/src/validation/schemas/page.json
+++ b/eq-author-api/src/validation/schemas/page.json
@@ -187,6 +187,9 @@
         },
         "then": {
           "properties": {
+            "totalTitle": {
+              "$ref": "definitions.json#/definitions/populatedString"
+            },
             "summaryAnswers": {
               "type": "array",
               "items": {

--- a/eq-author-api/src/validation/schemas/page.json
+++ b/eq-author-api/src/validation/schemas/page.json
@@ -186,27 +186,31 @@
           }
         },
         "then": {
-          "properties": {
-            "totalTitle": {
-              "$ref": "definitions.json#/definitions/populatedString"
-            },
-            "summaryAnswers": {
-              "type": "array",
-              "items": {
-                "$ref": "answer.json"
-              },
-              "calculatedSummaryUnitConsistency": {
-                "$data": "/sections"
-              },
-              "calculatedSummaryPosition": {
-                "$data": "/sections"
-              },
-              "minItems": 2,
-              "errorMessage": {
-                "minItems": "ERR_NO_ANSWERS"
+          "allOf": [
+            {
+              "properties": {
+                "summaryAnswers": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "answer.json"
+                  },
+                  "calculatedSummaryUnitConsistency": {
+                    "$data": "/sections"
+                  },
+                  "calculatedSummaryPosition": {
+                    "$data": "/sections"
+                  },
+                  "minItems": 2,
+                  "errorMessage": {
+                    "minItems": "ERR_NO_ANSWERS"
+                  }
+                },
+                "totalTitle": {
+                  "$ref": "definitions.json#/definitions/populatedString"
+                }
               }
             }
-          },
+          ],
           "required": ["summaryAnswers"]
         }
       }

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -69,6 +69,17 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
       ),
     });
 
+  const findAnswersErrors = () => {
+    let result = false;
+    errors.forEach((error) => {
+      if (error.errorCode === "ERR_NO_ANSWERS") {
+        result = true;
+      }
+    });
+
+    return result;
+  };
+
   return (
     <>
       <Header>
@@ -89,7 +100,7 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
             />
           ))}
         </ErrorWrapper>
-        {errors.length > 0 && (
+        {errors.length > 0 && findAnswersErrors() && (
           <ValidationError>
             {calculatedSummaryErrors[errors[0].errorCode]}
           </ValidationError>

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -74,7 +74,8 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
       errors.some((error) => error.errorCode === "ERR_NO_ANSWERS") ||
       errors.some(
         (error) => error.errorCode === "ERR_CALCULATED_UNIT_INCONSISTENCY"
-      )
+      ) ||
+      errors.some((error) => error.errorCode === "CALCSUM_MOVED")
     );
   };
 

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -70,14 +70,12 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
     });
 
   const findAnswersErrors = () => {
-    let result = false;
-    errors.forEach((error) => {
-      if (error.errorCode === "ERR_NO_ANSWERS") {
-        result = true;
-      }
-    });
-
-    return result;
+    return (
+      errors.some((error) => error.errorCode === "ERR_NO_ANSWERS") ||
+      errors.some(
+        (error) => error.errorCode === "ERR_CALCULATED_UNIT_INCONSISTENCY"
+      )
+    );
   };
 
   return (

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -52,6 +52,16 @@ const ErrorWrapper = styled.div`
 
 const Footer = styled.div``;
 
+export const findAnswersErrors = (errors) => {
+  return (
+    errors.some((error) => error.errorCode === "ERR_NO_ANSWERS") ||
+    errors.some(
+      (error) => error.errorCode === "ERR_CALCULATED_UNIT_INCONSISTENCY"
+    ) ||
+    errors.some((error) => error.errorCode === "CALCSUM_MOVED")
+  );
+};
+
 const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
   const sectionTitle = page.section.displayName;
   const answerType = page.summaryAnswers[0].type;
@@ -69,16 +79,6 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
       ),
     });
 
-  const findAnswersErrors = () => {
-    return (
-      errors.some((error) => error.errorCode === "ERR_NO_ANSWERS") ||
-      errors.some(
-        (error) => error.errorCode === "ERR_CALCULATED_UNIT_INCONSISTENCY"
-      ) ||
-      errors.some((error) => error.errorCode === "CALCSUM_MOVED")
-    );
-  };
-
   return (
     <>
       <Header>
@@ -90,7 +90,7 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
         </RemoveAllBtn>
       </Header>
       <Body>
-        <ErrorWrapper hasError={errors.length > 0 && findAnswersErrors()}>
+        <ErrorWrapper hasError={errors.length > 0 && findAnswersErrors(errors)}>
           {selectedAnswers.map((answer) => (
             <SelectedAnswer
               key={answer.id}
@@ -99,7 +99,7 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
             />
           ))}
         </ErrorWrapper>
-        {errors.length > 0 && findAnswersErrors() && (
+        {errors.length > 0 && findAnswersErrors(errors) && (
           <ValidationError>
             {calculatedSummaryErrors[errors[0].errorCode]}
           </ValidationError>

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -89,7 +89,7 @@ const Answers = ({ page, onUpdateCalculatedSummaryPage, onSelect }) => {
         </RemoveAllBtn>
       </Header>
       <Body>
-        <ErrorWrapper hasError={errors.length > 0}>
+        <ErrorWrapper hasError={errors.length > 0 && findAnswersErrors()}>
           {selectedAnswers.map((answer) => (
             <SelectedAnswer
               key={answer.id}

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.js
@@ -52,6 +52,7 @@ const ErrorWrapper = styled.div`
 
 const Footer = styled.div``;
 
+// Function exported for testing
 export const findAnswersErrors = (errors) => {
   return (
     errors.some((error) => error.errorCode === "ERR_NO_ANSWERS") ||

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.test.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/AnswerSelector/Answers.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "tests/utils/rtl";
 
-import Answers from "./Answers";
+import Answers, { findAnswersErrors } from "./Answers";
 
 describe("Answers", () => {
   let mockPage, mockOnUpdateCalculatedSummaryPage, mockOnSelect;
@@ -128,5 +128,31 @@ describe("Answers", () => {
     const errorMessage = getByText("Select another number answer");
 
     expect(errorMessage).toBeInTheDocument();
+  });
+
+  describe("findAnswersErrors", () => {
+    it("should return false if errorCode is not ERR_NO_ANSWERS, ERR_CALCULATED_UNIT_INCONSISTENCY or CALCSUM_MOVED", () => {
+      const errors = [{ errorCode: "TEST_ERROR_CODE" }];
+
+      expect(findAnswersErrors(errors)).toBeFalsy();
+    });
+
+    it("should return true if errorCode ERR_NO_ANSWERS is defined in errors", () => {
+      const errors = [{ errorCode: "ERR_NO_ANSWERS" }];
+
+      expect(findAnswersErrors(errors)).toBeTruthy();
+    });
+
+    it("should return true if errorCode ERR_CALCULATED_UNIT_INCONSISTENCY is defined in errors", () => {
+      const errors = [{ errorCode: "ERR_CALCULATED_UNIT_INCONSISTENCY" }];
+
+      expect(findAnswersErrors(errors)).toBeTruthy();
+    });
+
+    it("should return true if errorCode CALCSUM_MOVED is defined in errors", () => {
+      const errors = [{ errorCode: "CALCSUM_MOVED" }];
+
+      expect(findAnswersErrors(errors)).toBeTruthy();
+    });
   });
 });

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -53,7 +53,6 @@ const {
 } = richTextEditorErrors;
 
 const ERROR_SITUATIONS = [
-  // ! errorCode for title and total title are the same - the first some condition is true on total title, so first messsage is displayed
   {
     field: "title",
     condition: (errors) =>
@@ -104,7 +103,6 @@ export const CalculatedSummaryPageEditor = (props) => {
     section: page.section,
   });
 
-  // ! New error is happening because this function is not passed a parameter to handle which error is selected
   const getErrorMessage = (errorField) => {
     for (let i = 0; i < ERROR_SITUATIONS.length; ++i) {
       const { condition, message, field } = ERROR_SITUATIONS[i];

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -156,7 +156,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           size="large"
           fetchAnswers={fetchAnswers}
           metadata={get(page, "section.questionnaire.metadata", [])}
-          // errorValidationMsg={getErrorMessage()}
+          errorValidationMsg={getErrorMessage()}
           testSelector="txt-total-title"
         />
       </PageSegment>

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -53,7 +53,9 @@ const {
 } = richTextEditorErrors;
 
 const ERROR_SITUATIONS = [
+  // ! errorCode for title and total title are the same - the first some condition is true on total title, so first messsage is displayed
   {
+    field: "title",
     condition: (errors) =>
       some(errors, {
         errorCode: CALCSUM_TITLE_NOT_ENTERED.errorCode,
@@ -61,6 +63,7 @@ const ERROR_SITUATIONS = [
     message: () => CALCSUM_TITLE_NOT_ENTERED.message,
   },
   {
+    field: "title",
     condition: (errors) =>
       some(errors, {
         errorCode: PIPING_TITLE_MOVED.errorCode,
@@ -68,6 +71,7 @@ const ERROR_SITUATIONS = [
     message: () => PIPING_TITLE_MOVED.message,
   },
   {
+    field: "title",
     condition: (errors) =>
       some(errors, {
         errorCode: PIPING_TITLE_DELETED.errorCode,
@@ -75,6 +79,7 @@ const ERROR_SITUATIONS = [
     message: () => PIPING_TITLE_DELETED.message,
   },
   {
+    field: "totalTitle",
     condition: (errors) =>
       some(errors, {
         errorCode: CALCSUM_TOTAL_TITLE_NOT_ENTERED.errorCode,
@@ -99,12 +104,14 @@ export const CalculatedSummaryPageEditor = (props) => {
     section: page.section,
   });
 
-  console.log("props.page.validationErrorInfo", props.page.validationErrorInfo);
-
-  const getErrorMessage = () => {
+  // ! New error is happening because this function is not passed a parameter to handle which error is selected
+  const getErrorMessage = (errorField) => {
     for (let i = 0; i < ERROR_SITUATIONS.length; ++i) {
-      const { condition, message } = ERROR_SITUATIONS[i];
-      if (condition(props.page.validationErrorInfo.errors)) {
+      const { condition, message, field } = ERROR_SITUATIONS[i];
+      if (
+        errorField === field &&
+        condition(props.page.validationErrorInfo.errors)
+      ) {
         return message(props.page.validationErrorInfo.errors);
       }
     }
@@ -135,7 +142,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           testSelector="txt-summary-title"
           allowableTypes={[ANSWER, METADATA, VARIABLES]}
           defaultTab="variables"
-          errorValidationMsg={getErrorMessage()}
+          errorValidationMsg={getErrorMessage("title")}
           autoFocus={!page.title}
         />
         <div>
@@ -156,7 +163,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           size="large"
           fetchAnswers={fetchAnswers}
           metadata={get(page, "section.questionnaire.metadata", [])}
-          errorValidationMsg={getErrorMessage()}
+          errorValidationMsg={getErrorMessage("totalTitle")}
           testSelector="txt-total-title"
         />
       </PageSegment>

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -45,8 +45,12 @@ const SelectorTitle = styled.h2`
   margin: 0 0 0.4em;
 `;
 
-const { CALCSUM_TITLE_NOT_ENTERED, PIPING_TITLE_MOVED, PIPING_TITLE_DELETED } =
-  richTextEditorErrors;
+const {
+  CALCSUM_TITLE_NOT_ENTERED,
+  PIPING_TITLE_MOVED,
+  PIPING_TITLE_DELETED,
+  CALCSUM_TOTAL_TITLE_NOT_ENTERED,
+} = richTextEditorErrors;
 
 const ERROR_SITUATIONS = [
   {
@@ -70,6 +74,13 @@ const ERROR_SITUATIONS = [
       }),
     message: () => PIPING_TITLE_DELETED.message,
   },
+  {
+    condition: (errors) =>
+      some(errors, {
+        errorCode: CALCSUM_TOTAL_TITLE_NOT_ENTERED.errorCode,
+      }),
+    message: () => CALCSUM_TOTAL_TITLE_NOT_ENTERED.message,
+  },
 ];
 
 export const CalculatedSummaryPageEditor = (props) => {
@@ -87,6 +98,8 @@ export const CalculatedSummaryPageEditor = (props) => {
     folder: page.folder,
     section: page.section,
   });
+
+  console.log("props.page.validationErrorInfo", props.page.validationErrorInfo);
 
   const getErrorMessage = () => {
     for (let i = 0; i < ERROR_SITUATIONS.length; ++i) {
@@ -143,6 +156,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           size="large"
           fetchAnswers={fetchAnswers}
           metadata={get(page, "section.questionnaire.metadata", [])}
+          // errorValidationMsg={getErrorMessage()}
           testSelector="txt-total-title"
         />
       </PageSegment>

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -59,7 +59,7 @@ export const richTextEditorErrors = {
     message: "Enter a calculated summary title",
   },
   CALCSUM_TOTAL_TITLE_NOT_ENTERED: {
-    errorCode: "ERR_VALID_REQUIRED",
+    errorCode: "ERR_VALID_TOTAL_TITLE_REQUIRED",
     message: "Enter a total title",
   },
   CONFIRMATION_TITLE_NOT_ENTERED: "Enter a confirmation question title",

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -58,6 +58,10 @@ export const richTextEditorErrors = {
     errorCode: "ERR_VALID_REQUIRED",
     message: "Enter a calculated summary title",
   },
+  CALCSUM_TOTAL_TITLE_NOT_ENTERED: {
+    errorCode: "ERR_VALID_REQUIRED",
+    message: "Enter a total title",
+  },
   CONFIRMATION_TITLE_NOT_ENTERED: "Enter a confirmation question title",
   PIPING_TITLE_MOVED: {
     errorCode: "PIPING_TITLE_MOVED",


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Validate that calculated summary total title data is not empty

https://collaborate2.ons.gov.uk/jira/browse/EAR-1711

This PR also fixes a previous bug which caused an empty validation error to be incorrectly displayed under the "Answers to calculate" selector when two valid answers are selected but the calculated summary page has a different validation error unrelated to the "Answers to calculate" selector (e.g. calculated summary title is empty)

### How to review

**Check:**
- [ ] "Enter a total title" validation error is displayed when a total title has not been entered
- [ ] "Enter a total title" validation error is not displayed when a total title has been entered
- [ ] "Enter a calculated summary title" validation error is displayed when calculated summary title has not been entered
- [ ] "Enter a calculated summary title" validation error is not displayed when calculated summary title has been entered
- [ ] "Enter a calculated summary title" and "Enter a total title" validation errors are both displayed when both calculated summary title and total title are empty
- [ ] "Select at least two answers to be calculated" validation error message is displayed when no answers to calculate are selected
- [ ] "Select at least two answers to be calculated" validation error message is displayed when one answer to calculate is selected
- [ ] A validation error message is not displayed under the answer selector when two valid answers are selected
- [ ] An empty validation error message is not displayed under the answer selector when two valid answers are selected and the calculated summary page has other validation errors
- [ ] "The calculated summary must appear after the answers it uses" validation error message is displayed when the calculated summary page is moved before one of the answers selected in the "Answers to calculate" selector

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
