### PR TITLE
Fix to publisher URL in API as well as Percentage Bug

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=dummy
       - NODE_ENV=development
       - RUNNER_SESSION_URL=http://localhost:5000/session?token=
-      - PUBLISHER_URL=http://host.docker.internal:4000/publish/
+      - PUBLISHER_URL=http://host.docker.internal:9000/publish/
       - SURVEY_REGISTER_URL=http://host.docker.internal:8080/submit
       - ENABLE_IMPORT=true
       - JAEGER_SERVICE_NAME=eq_author_api

--- a/eq-publisher/src/utils/convertPipes.js
+++ b/eq-publisher/src/utils/convertPipes.js
@@ -39,6 +39,7 @@ const FILTER_MAP = {
       ? `format_conditional_date (${value}, metadata['${key}'])`
       : `${value} | format_date`,
   Unit: (value, unit) => `format_unit('${unitConversion[unit]}',${value})`,
+  Percentage: (value) => `format_percentage(${value})`,
 };
 
 const PIPE_TYPES = {


### PR DESCRIPTION
### Context of PR ###

Fix to the publisher URL, and a fix to publisher for the percentage bug.

Ticket: https://collaborate2.ons.gov.uk/jira/secure/RapidBoard.jspa?rapidView=940&projectKey=EAR&view=detail&selectedIssue=EAR-466

Runner PR: https://github.com/ONSdigital/eq-survey-runner/pull/2904

### How to review ###

- [ ] Spin up Author v2.
- [ ] Create two questions and pipe a percentage answer into the second question.
- [ ] Test that in Runner, you get the percentage symbol appear.

### What to do after everything is green ###

    *  Bring this branch up-to-date with Origin/Master
    *  If there are a lot of commits or some are not helpful to read, squash them down
    *  Click the Merge button on this pull request
    *  Does this change mean the Capability examples questionnaire should be updated?
    *  Move the Jira ticket for this task into the next stage of the process
