### PR TITLE
EAR 1711 Fix total title validation before selecting total title text editor

### DIFF
--- a/eq-author-api/schema/tests/calculatedSummary.test.js
+++ b/eq-author-api/schema/tests/calculatedSummary.test.js
@@ -346,11 +346,12 @@ describe("calculated Summary", () => {
 
     const calSumPage = questionnaire.sections[0].folders[0].pages[1];
     const result = await queryPage(ctx, calSumPage.id);
-    expect(result.validationErrorInfo.totalCount).toEqual(2);
+    expect(result.validationErrorInfo.totalCount).toEqual(3);
 
     await updateCalculatedSummaryPage(ctx, {
       id: calSumPage.id,
       title: "calc sum title",
+      totalTitle: "Test",
     });
 
     const validResult = await queryPage(ctx, calSumPage.id);
@@ -397,6 +398,7 @@ describe("calculated Summary", () => {
     await updateCalculatedSummaryPage(ctx, {
       id: calSumPage.id,
       title: "Goo",
+      totalTitle: "Test",
       summaryAnswers: [answers[0].id, answers[1].id],
     });
     const validResult = await queryPage(ctx, calSumPage.id);

--- a/eq-author-api/src/businessLogic/createCalculatedSummary.js
+++ b/eq-author-api/src/businessLogic/createCalculatedSummary.js
@@ -6,6 +6,7 @@ const createCalculatedSummary = (input = {}) => ({
   title: "",
   pageType: "CalculatedSummaryPage",
   summaryAnswers: [],
+  totalTitle: "",
   ...omit(input, "folderId"),
 });
 


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes a bug in total title validation causing the validation error message only to be displayed after the total title text area has been clicked

https://collaborate2.ons.gov.uk/jira/browse/EAR-1711

### How to review

**Check:**
- [ ] "Enter a total title" validation message is displayed when total title is empty before selecting the total title text editor

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
