### PR TITLE
filtered metadata options doesn't reset

### DIFF
--- a/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
@@ -39,17 +39,17 @@ class KeySelect extends Component {
   };
 
   handleStateChange = (changes) => {
-  const { name, onChange, onUpdate } = this.props;
+    const { name, onChange, onUpdate } = this.props;
     const { inputValue: value, selectedItem } = changes;
-    //isssue lies here
     if (selectedItem) {
       onChange({ name, value: selectedItem.value }, onUpdate);
     }
     if (/^[a-z0-9-_]+$/i.test(value) || value === "") {
-      if(value === undefined){
-        this.setState(() => ({selectedItem}))
+      if (value === undefined) {
+        this.setState(() => ({ selectedItem }));
+      } else {
+        this.setState(() => ({ value }));
       }
-      else{this.setState(() => ({ value }));}
     }
   };
 

--- a/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
@@ -39,14 +39,13 @@ class KeySelect extends Component {
   };
 
   handleStateChange = (changes) => {
-    const { name, onChange, onUpdate } = this.props;
+  const { name, onChange, onUpdate } = this.props;
     const { inputValue: value, selectedItem } = changes;
     //isssue lies here
     if (selectedItem) {
       onChange({ name, value: selectedItem.value }, onUpdate);
     }
     if (/^[a-z0-9-_]+$/i.test(value) || value === "") {
-      console.log('value :>> ', value);
       if(value === undefined){
         this.setState(() => ({selectedItem}))
       }

--- a/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
+++ b/eq-author/src/App/metadata/MetadataTable/Controls/KeySelect.js
@@ -41,12 +41,16 @@ class KeySelect extends Component {
   handleStateChange = (changes) => {
     const { name, onChange, onUpdate } = this.props;
     const { inputValue: value, selectedItem } = changes;
-
+    //isssue lies here
     if (selectedItem) {
       onChange({ name, value: selectedItem.value }, onUpdate);
     }
     if (/^[a-z0-9-_]+$/i.test(value) || value === "") {
-      this.setState(() => ({ value }));
+      console.log('value :>> ', value);
+      if(value === undefined){
+        this.setState(() => ({selectedItem}))
+      }
+      else{this.setState(() => ({ value }));}
     }
   };
 

--- a/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
+++ b/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import styled from "styled-components";
-import { radius } from "constants/theme";
+import { radius, colors } from "constants/theme";
 
 import { noop } from "lodash";
 
@@ -21,6 +21,7 @@ const MenuList = styled.ul`
   &:empty {
     padding: 0;
   }
+
 `;
 
 const MenuItem = styled.li`
@@ -41,8 +42,13 @@ const MenuItemText = styled.div`
   padding: 0.6em 1em;
   line-height: 1;
   &:hover {
-    background-color: #e4e8eb;
-  }
+      background-color: ${colors.lightMediumGrey};
+    }
+  ${({ isActive }) =>
+    isActive &&
+    `
+    background-color: ${colors.lightMediumGrey};
+  `}
 `;
 
 export const filterItemsByInputValue = (items, inputValue) =>
@@ -72,10 +78,12 @@ const TypeaheadMenu = ({
             })}
             // Overwrites onMouseMove to perform no operation - the default onMouseMove function breaks search
             onMouseMove={noop}
+            tabIndex={0}
           >
             <MenuItemText
               isActive={highlightedIndex === index}
               isSelected={selectedItem === item}
+              tabIndex={0}
             >
               {item.value}
             </MenuItemText>

--- a/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
+++ b/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
@@ -21,7 +21,6 @@ const MenuList = styled.ul`
   &:empty {
     padding: 0;
   }
-
 `;
 
 const MenuItem = styled.li`
@@ -42,8 +41,8 @@ const MenuItemText = styled.div`
   padding: 0.6em 1em;
   line-height: 1;
   &:hover {
-      background-color: ${colors.lightMediumGrey};
-    }
+    background-color: ${colors.lightMediumGrey};
+  }
   ${({ isActive }) =>
     isActive &&
     `

--- a/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
+++ b/eq-author/src/components/Forms/Typeahead/TypeaheadMenu.js
@@ -78,12 +78,10 @@ const TypeaheadMenu = ({
             })}
             // Overwrites onMouseMove to perform no operation - the default onMouseMove function breaks search
             onMouseMove={noop}
-            tabIndex={0}
           >
             <MenuItemText
               isActive={highlightedIndex === index}
               isSelected={selectedItem === item}
-              tabIndex={0}
             >
               {item.value}
             </MenuItemText>


### PR DESCRIPTION
### What is the context of this PR?

> Metadata key column gets reset when you press the arrow down key on filtered searches.
> Scrolling through the metadata with arrow down still works but the highlighted index is invisible.

### How to review

- Start up author aws/gcp
  - create a questionnaire and goto the metadata section of the questionnaire.
  - then, type in something to filter the metadata list e.g. 're'.
  - press arrow down and see if the list is reset (it shouldn't reset).
  - check you can scroll through the list with arrow down and you can see which key is highlighted.
  - check if hover still highlights key. 


