### PR TITLE
EAR 1754 Cannot Set List Collector As Routing Dest

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu/AddMenu.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/AddMenu/AddMenu.js
@@ -189,7 +189,7 @@ AddMenu.propTypes = {
   canImportContent: PropTypes.bool,
   onStartImportingContent: PropTypes.func.isRequired,
   onAddListCollectorPage: PropTypes.func.isRequired,
-  canAddListCollectorPage: PropTypes.func.isRequired,
+  canAddListCollectorPage: PropTypes.bool.isRequired,
 };
 
 export default AddMenu;

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/index.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/index.js
@@ -16,6 +16,7 @@ const DESTINATION_TYPE = {
   Section: "Section",
   QuestionPage: "QuestionPage",
   CalculatedSummaryPage: "CalculatedSummaryPage",
+  ListCollectorPage: "ListCollectorPage",
 };
 
 const RoutingRuleResult = styled.div`
@@ -47,6 +48,7 @@ const typeToPropertyName = {
   [DESTINATION_TYPE.Section]: "sectionId",
   [DESTINATION_TYPE.QuestionPage]: "pageId",
   [DESTINATION_TYPE.CalculatedSummaryPage]: "pageId",
+  [DESTINATION_TYPE.ListCollectorPage]: "pageId",
 };
 
 export const UnwrappedDestinationSelector = ({


### PR DESCRIPTION

### What is the context of this PR?

> An error occurred when trying to set a list collector page as a routing destination.
> https://collaborate2.ons.gov.uk/jira/browse/EAR-1754
>
> The fix was to extend the the routing destination types to include List Collector Page.

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Create a survey with a list collector page that's not the first question
- Go to first question and add logic to navigate to the list collector page

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
