### PR TITLE
EAR 1758 Section or folder requires refresh with list collector page

### DIFF
--- a/eq-author/src/graphql/duplicateFolder.graphql
+++ b/eq-author/src/graphql/duplicateFolder.graphql
@@ -65,6 +65,13 @@ mutation duplicateFolder($input: DuplicateFolderInput!) {
               ...Comment
             }
           }
+          ... on ListCollectorPage {
+            id
+            alias
+            comments {
+              ...Comment
+            }
+          }
           validationErrorInfo {
             ...ValidationErrorInfo
           }

--- a/eq-author/src/graphql/duplicateSection.graphql
+++ b/eq-author/src/graphql/duplicateSection.graphql
@@ -63,6 +63,12 @@ mutation duplicateSection($input: DuplicateSectionInput!) {
             ...Comment
           }
         }
+        ... on ListCollectorPage {
+          id
+          comments {
+            ...Comment
+          }
+        }
         validationErrorInfo {
           ...ValidationErrorInfo
         }


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?
https://collaborate2.ons.gov.uk/jira/browse/EAR-1758

Fixes a bug preventing new sections or folders being displayed on Author's navigation bar when the section or folder includes a list collector page.

### How to review

**Folder**
Add a list collector question to a folder
Duplicate the folder
Check the new folder is displayed in the navigation bar without refresh

**Section**
Add a list collector question to a folder in the section
Duplicate the section
Check the new section is displayed in the navigation bar without refresh

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
