### PR TITLE
EAR 202 Fix Viewing Survey

### DIFF
--- a/eq-author-api/middleware/loadQuestionnaire.js
+++ b/eq-author-api/middleware/loadQuestionnaire.js
@@ -19,7 +19,7 @@ module.exports = async (req, res, next) => {
 
   if (questionnaire && questionnaire.isPublic === false) {
     const userId = req.user.id;
-    const authorizedUsers = [questionnaire.createdBy, ...questionnaire.editors];
+    const authorizedUsers = [questionnaire.createdBy, ...questionnaire.editors, "publisher"];
 
     if (!authorizedUsers.includes(userId)) {
       res.status(403).send("Unauthorized questionnaire access");
@@ -30,3 +30,4 @@ module.exports = async (req, res, next) => {
   req.questionnaire = questionnaire;
   next();
 };
+     


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

> When a survey is made private in v2 and you click View Survey a tab opens showing an error instead of the survey.
>
> E.g. _"Currently, if you add a new question to Author the entire app crashed. This is because..."_

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Run v2 Author, Publisher and Runner
- Set your survey to private
- Click View Survey and check the survey starts

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
