### PR TITLE
EAR-1701 valid ons email

### DIFF
--- a/eq-author/README.md
+++ b/eq-author/README.md
@@ -14,7 +14,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 `yarn build` - Builds the app for production to the `build` folder. See [Creating a Production Build](https://facebook.github.io/create-react-app/docs/production-build) for more information.
 
-`yarn test` - Launches the test runner in the interactive watch mode.
+`yarn test` - Launches the test runner in the interactive watch mode
 
 `yarn test -- --coverage` - Collects code coverage in `./coverage` folder.
 

--- a/eq-author/README.md
+++ b/eq-author/README.md
@@ -14,7 +14,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 `yarn build` - Builds the app for production to the `build` folder. See [Creating a Production Build](https://facebook.github.io/create-react-app/docs/production-build) for more information.
 
-`yarn test` - Launches the test runner in the interactive watch mode
+`yarn test` - Launches the test runner in the interactive watch mode.
 
 `yarn test -- --coverage` - Collects code coverage in `./coverage` folder.
 

--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -73,6 +73,7 @@
       window.config.REACT_APP_GTM_AUTH = "";
       window.config.REACT_APP_GTM_PREVIEW = "";
       window.config.REACT_APP_FEATURE_FLAGS = "";
+      window.config.REACT_APP_DOMAINS = "";
     </script>
     <script type="text/javascript">
       if (window.config.REACT_APP_HOT_JAR_ID) {

--- a/eq-author/public/index.html
+++ b/eq-author/public/index.html
@@ -73,7 +73,8 @@
       window.config.REACT_APP_GTM_AUTH = "";
       window.config.REACT_APP_GTM_PREVIEW = "";
       window.config.REACT_APP_FEATURE_FLAGS = "";
-      window.config.REACT_APP_DOMAINS = "";
+      window.config.REACT_APP_VALID_EMAIL_DOMAINS = "";
+      window.config.REACT_APP_ORGANISATION_ABBR = "";
     </script>
     <script type="text/javascript">
       if (window.config.REACT_APP_HOT_JAR_ID) {

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -29,8 +29,9 @@ const CreateAccount = ({
   const [fullName, setFullName] = useState("");
   const [password, setPassword] = useState("");
   let errorRefCreateAcc = useRef();
+  
   const textValidEmailError = process.env.REACT_APP_ORGANISATION_ABBR
-    ? "Enter a valid " + process.env.REACT_APP_ORGANISATION_ABBR + " email"
+    ? "Only " + process.env.REACT_APP_ORGANISATION_ABBR + " email addresses allowed"
     : "Enter a valid authorised email";
   const textValidEmailErrorMessage = process.env.REACT_APP_ORGANISATION_ABBR
     ? "Enter a valid " +

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -29,10 +29,12 @@ const CreateAccount = ({
   const [fullName, setFullName] = useState("");
   const [password, setPassword] = useState("");
   let errorRefCreateAcc = useRef();
-  
+
   const textValidEmailError = process.env.REACT_APP_ORGANISATION_ABBR
-    ? "Only " + process.env.REACT_APP_ORGANISATION_ABBR + " email addresses allowed"
-    : "Enter a valid authorised email";
+    ? "Only " +
+      process.env.REACT_APP_ORGANISATION_ABBR +
+      " email addresses allowed"
+    : "Only authorised email addresses allowed";
   const textValidEmailErrorMessage = process.env.REACT_APP_ORGANISATION_ABBR
     ? "Enter a valid " +
       process.env.REACT_APP_ORGANISATION_ABBR +
@@ -112,7 +114,6 @@ const CreateAccount = ({
     }
   }
 
-  // Can use errorMessage.toLowerCase().includes("valid ONS email") (or similar) to conditionally render panel title
   return (
     <>
       <>

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -38,18 +38,21 @@ const CreateAccount = ({
     setErrorMessageEmail("");
   }
 
+  const endsWithAnyDomain = (email, domains) => {
+    return domains.some((domain) => email.endsWith(domain));
+  };
+
   const handleCreateAccount = (createEmail, fullName, password) => {
     isCommonPassword(password).then((commonPassword) => {
       if (createEmail === "") {
         setErrorMessage("Enter email");
-        setErrorMessageEmail("Enter a valid email address");
       } else if (
-        !(
-          createEmail.includes("@ext.ons.gov.uk") ||
-          createEmail.includes("@ons.gov.uk")
+        !endsWithAnyDomain(
+          createEmail,
+          process.env.REACT_APP_DOMAINS.split(",")
         )
       ) {
-        setErrorMessage("Only ONS email addresses allowed");
+        setErrorMessage("Enter a valid ONS Email");
         setErrorMessageEmail("Enter a valid ONS email address");
       } else if (fullName === "") {
         setErrorMessage("Enter full name");
@@ -92,6 +95,7 @@ const CreateAccount = ({
     }
   }
 
+  // Can use errorMessage.toLowerCase().includes("valid ONS email") (or similar) to conditionally render panel title
   return (
     <>
       <>

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -20,7 +20,9 @@ const CreateAccount = ({
   setCreateAccountFunction,
   setForgotPassword,
   errorMessage,
+  errorMessageEmail,
   setErrorMessage,
+  setErrorMessageEmail,
   setVerificationEmail,
 }) => {
   const [createEmail, setCreateEmail] = useState("");
@@ -33,12 +35,22 @@ const CreateAccount = ({
     setCreateAccountFunction(false);
     setForgotPassword(false);
     setErrorMessage("");
+    setErrorMessageEmail("");
   }
 
   const handleCreateAccount = (createEmail, fullName, password) => {
     isCommonPassword(password).then((commonPassword) => {
       if (createEmail === "") {
         setErrorMessage("Enter email");
+        setErrorMessageEmail("Enter a valid email address");
+      } else if (
+        !(
+          createEmail.includes("@ext.ons.gov.uk") ||
+          createEmail.includes("@ons.gov.uk")
+        )
+      ) {
+        setErrorMessage("Only ONS email addresses allowed");
+        setErrorMessageEmail("Enter a valid ONS email address");
       } else if (fullName === "") {
         setErrorMessage("Enter full name");
       } else if (password.length < 8 && password.length !== 0) {
@@ -59,6 +71,7 @@ const CreateAccount = ({
                 function () {
                   setVerificationEmail(createEmail);
                   setErrorMessage("");
+                  setErrorMessageEmail("");
                 },
                 function (error) {
                   setErrorMessage(error.message);
@@ -102,6 +115,8 @@ const CreateAccount = ({
           condition={errorMessage?.toLowerCase().includes("email")}
           dataTest="txt-create-email"
           innerRef={errorRefCreateAcc}
+          errorMessage={errorMessageEmail}
+          description="Only ONS email addresses allowed"
         />
         <InputWithConditionalError
           type="text"
@@ -127,6 +142,7 @@ const CreateAccount = ({
                   value={password}
                   onChange={({ value }) => setPassword(value)}
                   data-test="txt-create-password"
+                  description="Your password must be at least 8 characters"
                 />
               </Panel>
             </>
@@ -137,6 +153,7 @@ const CreateAccount = ({
                 value={password}
                 onChange={({ value }) => setPassword(value)}
                 data-test="txt-create-password"
+                description="Your password must be at least 8 characters"
               />
             </>
           )}
@@ -162,7 +179,9 @@ CreateAccount.propTypes = {
   setCreateAccountFunction: PropTypes.func,
   setForgotPassword: PropTypes.func,
   errorMessage: PropTypes.string,
+  errorMessageEmail: PropTypes.string,
   setErrorMessage: PropTypes.func,
+  setErrorMessageEmail: PropTypes.func,
   setVerificationEmail: PropTypes.func,
 };
 

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -49,11 +49,17 @@ const CreateAccount = ({
       } else if (
         !endsWithAnyDomain(
           createEmail,
-          process.env.REACT_APP_DOMAINS.split(",")
+          process.env.REACT_APP_VALID_EMAIL_DOMAINS.split(",")
         )
       ) {
-        setErrorMessage("Enter a valid ONS Email");
-        setErrorMessageEmail("Enter a valid ONS email address");
+        setErrorMessage(
+          "Enter a valid " + process.env.REACT_APP_ORGANISATION_ABBR + " Email"
+        );
+        setErrorMessageEmail(
+          "Enter a valid " +
+            process.env.REACT_APP_ORGANISATION_ABBR +
+            " email address"
+        );
       } else if (fullName === "") {
         setErrorMessage("Enter full name");
       } else if (password.length < 8 && password.length !== 0) {
@@ -120,7 +126,11 @@ const CreateAccount = ({
           dataTest="txt-create-email"
           innerRef={errorRefCreateAcc}
           errorMessage={errorMessageEmail}
-          description="Only ONS email addresses allowed"
+          description={
+            "Only " +
+            process.env.REACT_APP_ORGANISATION_ABBR +
+            " email addresses allowed"
+          }
         />
         <InputWithConditionalError
           type="text"

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -37,7 +37,9 @@ const CreateAccount = ({
       process.env.REACT_APP_ORGANISATION_ABBR +
       " email address"
     : "Enter a valid authorised email address";
-  const textValidEmailDescription = process.env.REACT_APP_ORGANISATION_ABBR
+  const textValidEmailDescription = !process.env.REACT_APP_VALID_EMAIL_DOMAINS
+    ? ""
+    : process.env.REACT_APP_ORGANISATION_ABBR
     ? "Only " +
       process.env.REACT_APP_ORGANISATION_ABBR +
       " email addresses allowed"
@@ -60,6 +62,7 @@ const CreateAccount = ({
       if (createEmail === "") {
         setErrorMessage("Enter email");
       } else if (
+        process.env.REACT_APP_VALID_EMAIL_DOMAINS &&
         !endsWithAnyDomain(
           createEmail,
           process.env.REACT_APP_VALID_EMAIL_DOMAINS.split(",")

--- a/eq-author/src/App/SignInPage/CreateAccount/index.js
+++ b/eq-author/src/App/SignInPage/CreateAccount/index.js
@@ -29,6 +29,19 @@ const CreateAccount = ({
   const [fullName, setFullName] = useState("");
   const [password, setPassword] = useState("");
   let errorRefCreateAcc = useRef();
+  const textValidEmailError = process.env.REACT_APP_ORGANISATION_ABBR
+    ? "Enter a valid " + process.env.REACT_APP_ORGANISATION_ABBR + " email"
+    : "Enter a valid authorised email";
+  const textValidEmailErrorMessage = process.env.REACT_APP_ORGANISATION_ABBR
+    ? "Enter a valid " +
+      process.env.REACT_APP_ORGANISATION_ABBR +
+      " email address"
+    : "Enter a valid authorised email address";
+  const textValidEmailDescription = process.env.REACT_APP_ORGANISATION_ABBR
+    ? "Only " +
+      process.env.REACT_APP_ORGANISATION_ABBR +
+      " email addresses allowed"
+    : "Only authorised email addresses allowed";
 
   function handleReturnToSignInPage(e) {
     e.preventDefault();
@@ -52,14 +65,8 @@ const CreateAccount = ({
           process.env.REACT_APP_VALID_EMAIL_DOMAINS.split(",")
         )
       ) {
-        setErrorMessage(
-          "Enter a valid " + process.env.REACT_APP_ORGANISATION_ABBR + " Email"
-        );
-        setErrorMessageEmail(
-          "Enter a valid " +
-            process.env.REACT_APP_ORGANISATION_ABBR +
-            " email address"
-        );
+        setErrorMessage(textValidEmailError);
+        setErrorMessageEmail(textValidEmailErrorMessage);
       } else if (fullName === "") {
         setErrorMessage("Enter full name");
       } else if (password.length < 8 && password.length !== 0) {
@@ -126,11 +133,7 @@ const CreateAccount = ({
           dataTest="txt-create-email"
           innerRef={errorRefCreateAcc}
           errorMessage={errorMessageEmail}
-          description={
-            "Only " +
-            process.env.REACT_APP_ORGANISATION_ABBR +
-            " email addresses allowed"
-          }
+          description={textValidEmailDescription}
         />
         <InputWithConditionalError
           type="text"

--- a/eq-author/src/App/SignInPage/index.js
+++ b/eq-author/src/App/SignInPage/index.js
@@ -35,6 +35,7 @@ const SignInPage = ({
   const [createAccount, setCreateAccount] = useState(false);
   const [recoveryEmail, setRecoveryEmail] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [errorMessageEmail, setErrorMessageEmail] = useState("");
   const [verificationEmail, setVerificationEmail] = useState("");
   const [emailNowVerified, setEmailNowVerified] = useState(false);
   const [recoverPassword, setRecoverPassword] = useState(false);
@@ -145,7 +146,9 @@ const SignInPage = ({
                     setCreateAccountFunction={setCreateAccountFunction}
                     setForgotPassword={setForgotPassword}
                     errorMessage={errorMessage}
+                    errorMessageEmail={errorMessageEmail}
                     setErrorMessage={setErrorMessage}
+                    setErrorMessageEmail={setErrorMessageEmail}
                     setVerificationEmail={setVerificationEmail}
                   />
                 )}

--- a/eq-author/src/App/SignInPage/index.test.js
+++ b/eq-author/src/App/SignInPage/index.test.js
@@ -272,7 +272,7 @@ describe("SignInPage", () => {
 
       userEvent.click(screen.getByText("Create account"));
       await waitFor(() =>
-        expect(getAllByText("Enter a valid ONS Email")).toBeTruthy()
+        expect(getAllByText("Enter a valid ONS email")).toBeTruthy()
       );
       await waitFor(() =>
         expect(getAllByText("Only ONS email addresses allowed")).toBeTruthy()

--- a/eq-author/src/App/SignInPage/index.test.js
+++ b/eq-author/src/App/SignInPage/index.test.js
@@ -272,9 +272,6 @@ describe("SignInPage", () => {
 
       userEvent.click(screen.getByText("Create account"));
       await waitFor(() =>
-        expect(getAllByText("Enter a valid ONS email")).toBeTruthy()
-      );
-      await waitFor(() =>
         expect(getAllByText("Only ONS email addresses allowed")).toBeTruthy()
       );
     });

--- a/eq-author/src/App/SignInPage/index.test.js
+++ b/eq-author/src/App/SignInPage/index.test.js
@@ -87,7 +87,7 @@ describe("SignInPage", () => {
       });
 
       const input = screen.getByLabelText("Email address");
-      userEvent.type(input, "testEmail@test.com");
+      userEvent.type(input, "testEmail@ons.gov.uk");
 
       const btn = getByTestId("signIn-button");
       userEvent.click(btn);
@@ -200,7 +200,7 @@ describe("SignInPage", () => {
       expect(getByTestId("txt-create-email")).toBeVisible();
 
       const input = screen.getByLabelText("Email address");
-      userEvent.type(input, "testEmail@test.com");
+      userEvent.type(input, "testEmail@ons.gov.uk");
 
       userEvent.click(screen.getByText("Create account"));
       await waitFor(() => expect(getAllByText("Enter full name")).toBeTruthy());
@@ -217,7 +217,7 @@ describe("SignInPage", () => {
       expect(getByTestId("txt-create-email")).toBeVisible();
 
       const input = screen.getByLabelText("Email address");
-      userEvent.type(input, "testEmail@test.com");
+      userEvent.type(input, "testEmail@ons.gov.uk");
       const input2 = screen.getByLabelText("First and last name");
       userEvent.type(input2, "My name is the best");
 
@@ -236,7 +236,7 @@ describe("SignInPage", () => {
       expect(getByTestId("txt-create-email")).toBeVisible();
 
       const input = screen.getByLabelText("Email address");
-      userEvent.type(input, "testEmail@test.com");
+      userEvent.type(input, "testEmail@ext.ons.gov.uk");
       const input2 = screen.getByLabelText("First and last name");
       userEvent.type(input2, "My name is the best");
       const input3 = screen.getByLabelText("Password");
@@ -262,7 +262,7 @@ describe("SignInPage", () => {
       expect(getByTestId("txt-create-email")).toBeVisible();
 
       const input = screen.getByLabelText("Email address");
-      userEvent.type(input, "testEmail@test.com");
+      userEvent.type(input, "testEmail@ons.gov.uk");
       const input2 = screen.getByLabelText("First and last name");
       userEvent.type(input2, "My name is the best");
       const input3 = screen.getByLabelText("Password");

--- a/eq-author/src/App/SignInPage/index.test.js
+++ b/eq-author/src/App/SignInPage/index.test.js
@@ -19,7 +19,7 @@ describe("SignInPage", () => {
       sentEmailVerification: false,
       searchParams: "",
     };
-    process.env.REACT_APP_DOMAINS = "";
+    process.env.REACT_APP_VALID_EMAIL_DOMAINS = "";
   });
 
   const renderSignIn = (props) =>
@@ -255,7 +255,8 @@ describe("SignInPage", () => {
       const { getByTestId, getByText, getAllByText } = renderSignIn({
         ...props,
       });
-      process.env.REACT_APP_DOMAINS = "@ons.gov.uk,@ext.ons.gov.uk";
+      process.env.REACT_APP_VALID_EMAIL_DOMAINS = "@ons.gov.uk,@ext.ons.gov.uk";
+      process.env.REACT_APP_ORGANISATION_ABBR = "ONS";
 
       const button = getByText("Create an Author account");
       userEvent.click(button);
@@ -273,13 +274,17 @@ describe("SignInPage", () => {
       await waitFor(() =>
         expect(getAllByText("Enter a valid ONS Email")).toBeTruthy()
       );
+      await waitFor(() =>
+        expect(getAllByText("Only ONS email addresses allowed")).toBeTruthy()
+      );
     });
 
     it("should not display error when email has valid domain", async () => {
       const { getByTestId, getByText, queryByText } = renderSignIn({
         ...props,
       });
-      process.env.REACT_APP_DOMAINS = "@ons.gov.uk,@ext.ons.gov.uk";
+      process.env.REACT_APP_VALID_EMAIL_DOMAINS = "@ons.gov.uk,@ext.ons.gov.uk";
+      process.env.REACT_APP_ORGANISATION_ABBR = "ONS";
 
       const button = getByText("Create an Author account");
       userEvent.click(button);

--- a/eq-author/src/components-themed/Input/PasswordInput/index.js
+++ b/eq-author/src/components-themed/Input/PasswordInput/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 
 import Input from "components-themed/Input";
 import Label from "components-themed/Label";
-import { ButtonLink } from "components-themed/Toolkit";
+import { ButtonLink, FieldDescription } from "components-themed/Toolkit";
 
 const PasswordContainer = styled.div`
   display: flex;
@@ -31,7 +31,7 @@ const PasswordButtonLink = styled(ButtonLink)`
   margin: 0.2rem 1.25rem 0;
 `;
 
-const PasswordInput = ({ id, dataTest, ...otherProps }) => {
+const PasswordInput = ({ id, dataTest, description, ...otherProps }) => {
   const [hidden, setHidden] = useState(true);
 
   function handlePasswordToggle(e) {
@@ -41,7 +41,14 @@ const PasswordInput = ({ id, dataTest, ...otherProps }) => {
 
   return (
     <>
-      <Label htmlFor={id}>Password</Label>
+      {description ? (
+        <Label htmlFor={id} hasDescription>
+          Password
+        </Label>
+      ) : (
+        <Label htmlFor={id}>Password</Label>
+      )}
+      {description && <FieldDescription>{description}</FieldDescription>}
       <PasswordContainer>
         <Password
           type={hidden ? "password" : "text"}
@@ -62,6 +69,7 @@ const PasswordInput = ({ id, dataTest, ...otherProps }) => {
 PasswordInput.propTypes = {
   id: PropTypes.string,
   dataTest: PropTypes.string,
+  description: PropTypes.string,
 };
 
 export default PasswordInput;

--- a/eq-author/src/components-themed/Label/__snapshots__/Label.test.js.snap
+++ b/eq-author/src/components-themed/Label/__snapshots__/Label.test.js.snap
@@ -3,6 +3,7 @@
 exports[`components-themed/Label should render correctly 1`] = `
 <Label__StyledLabel
   bold={true}
+  hasDescription={false}
 >
   Name
 </Label__StyledLabel>

--- a/eq-author/src/components-themed/Label/index.js
+++ b/eq-author/src/components-themed/Label/index.js
@@ -5,7 +5,8 @@ import { colors } from "constants/theme";
 
 const StyledLabel = styled.label`
   display: ${(props) => (props.inline ? "inline-block" : "block")};
-  margin-bottom: ${(props) => (props.inline ? "0" : "0.4em")};
+  margin-bottom: ${(props) =>
+    props.inline || props.hasDescription ? "0" : "0.4em"};
   font-weight: ${(props) => (props.bold ? "bold" : "normal")};
   vertical-align: middle;
   color: ${colors.text};
@@ -23,10 +24,12 @@ Label.propTypes = {
   htmlFor: PropTypes.string,
   children: PropTypes.node.isRequired,
   bold: PropTypes.bool,
+  hasDescription: PropTypes.bool,
 };
 
 Label.defaultProps = {
   bold: true,
+  hasDescription: false,
 };
 
 export default Label;

--- a/eq-author/src/components-themed/Toolkit/index.js
+++ b/eq-author/src/components-themed/Toolkit/index.js
@@ -54,7 +54,7 @@ export const ButtonLink = styled.button`
   padding: 0 !important;
   margin: 0 0 0.5rem;
   font-size: 1.125rem;
-  color: ${colors.blue};
+  color: ${colors.oceanBlue};
   text-decoration: underline;
   cursor: pointer;
   display: inline-block;

--- a/eq-author/src/components-themed/Toolkit/index.js
+++ b/eq-author/src/components-themed/Toolkit/index.js
@@ -24,6 +24,14 @@ export const Description = styled.p`
   color: ${colors.text};
 `;
 
+export const FieldDescription = styled.p`
+  margin: 0 0 0.55rem 0;
+  font-size: 0.7777777778rem;
+  font-weight: 400;
+  line-height: 1.4;
+  color: ${colors.text};
+`;
+
 export const InlineDescription = styled(Description)`
   display: inline-block;
 `;

--- a/eq-author/src/components/InputWithConditionalError/index.js
+++ b/eq-author/src/components/InputWithConditionalError/index.js
@@ -6,12 +6,15 @@ import Label from "components-themed/Label";
 import Input from "components-themed/Input";
 import Panel from "components-themed/panels";
 
+import { FieldDescription } from "components-themed/Toolkit";
+
 const InputWithConditionalError = ({
   type,
   id,
   title,
   name,
   value,
+  description,
   condition,
   handleChange,
   errorMessage,
@@ -26,7 +29,14 @@ const InputWithConditionalError = ({
       innerRef={innerRef}
     >
       <Field>
-        <Label htmlFor={id}>{title}</Label>
+        {description ? (
+          <Label htmlFor={id} hasDescription>
+            {title}
+          </Label>
+        ) : (
+          <Label htmlFor={id}>{title}</Label>
+        )}
+        {description && <FieldDescription>{description}</FieldDescription>}
         <Input
           type={type}
           name={name}
@@ -39,7 +49,14 @@ const InputWithConditionalError = ({
     </Panel>
   ) : (
     <Field>
-      <Label htmlFor={id}>{title}</Label>
+      {description ? (
+        <Label htmlFor={id} hasDescription>
+          {title}
+        </Label>
+      ) : (
+        <Label htmlFor={id}>{title}</Label>
+      )}
+      {description && <FieldDescription>{description}</FieldDescription>}
       <Input
         type={type}
         id={id}
@@ -57,6 +74,7 @@ InputWithConditionalError.propTypes = {
   title: PropTypes.string,
   name: PropTypes.string,
   value: PropTypes.string,
+  description: PropTypes.string,
   condition: PropTypes.bool.isRequired,
   handleChange: PropTypes.func,
   errorMessage: PropTypes.string,

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -29,6 +29,7 @@ const config = {
     window.config.REACT_APP_GTM_AUTH || process.env.REACT_APP_GTM_AUTH,
   REACT_APP_GTM_PREVIEW:
     window.config.REACT_APP_GTM_PREVIEW || process.env.REACT_APP_GTM_PREVIEW,
+  REACT_APP_DOMAINS: window.config.DOMAINS || process.env.DOMAINS,
   REACT_APP_FEATURE_FLAGS:
     window.config.REACT_APP_FEATURE_FLAGS ||
     process.env.REACT_APP_FEATURE_FLAGS ||

--- a/eq-author/src/config.js
+++ b/eq-author/src/config.js
@@ -29,7 +29,10 @@ const config = {
     window.config.REACT_APP_GTM_AUTH || process.env.REACT_APP_GTM_AUTH,
   REACT_APP_GTM_PREVIEW:
     window.config.REACT_APP_GTM_PREVIEW || process.env.REACT_APP_GTM_PREVIEW,
-  REACT_APP_DOMAINS: window.config.DOMAINS || process.env.DOMAINS,
+  REACT_APP_VALID_EMAIL_DOMAINS:
+    window.config.VALID_EMAIL_DOMAINS || process.env.VALID_EMAIL_DOMAINS,
+  REACT_APP_ORGANISATION_ABBR:
+    window.config.ORGANISATION_ABBR || process.env.ORGANISATION_ABBR,
   REACT_APP_FEATURE_FLAGS:
     window.config.REACT_APP_FEATURE_FLAGS ||
     process.env.REACT_APP_FEATURE_FLAGS ||


### PR DESCRIPTION
### PR Context

https://jira.ons.gov.uk/browse/EAR-1701

- Changes primarily to the SignIn > CreateAccount code.
- Changes allow for the enforcement of a set of 'valid domains' for the submitted email address, via a new environment variable REACT_APP_VALID_EMAIL_DOMAINS. A second new envar (REACT_APP_ORGANISATION_ABBR) allows to set the 'organisation abbreviation' for use in error messages (with a no value fall back). Both envars have fallback code if neither they are not present/have no value.
- Changes also introduce the ability to add a field description to InputWithContextError and Password inputs, with label spacing adjustments if a description is present, and specific error message on the email input field for errors
- Update to colour declaration on link in header error declaration to resolve colour contrast issue (change to existing oceanBlue from blue)
- Addition of new test, and update to existing tests to cope with needing a valid email address now

### How to review

- Run the updated code, navigating to the Create Account page.
- Run both with and without the new environment variables to confirm behaviour
  - If REACT_APP_ORGANISATION_ABBR is not set, the 2 error messages and the field description should use 'authorised' instead
  - If REACT_APP_VALID_EMAIL_DOMAINS is not set the new validation will not apply, so any email will be allowed as now. The new field description will not display, as it does not apply
  - if REACT_APP_VALID_EMAIL_DOMAINS is set with a comma separated list of email domains (@ons.gov.uk etc), the email field will limit to email addresses based on that list and should work with single and multiple entries. A field description should appear to tell the user of the restrictions, and using a non listed email domain should produce a specific error
  - The password field should also have a new field description, but only on the Create Account page - SignIn should not display it
