### PR TITLE
EAR 1771 fix toggling additional guidance bug

### DIFF
--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -281,6 +281,7 @@ export const IntroductionEditor = ({
                   id,
                   ...introduction,
                   additionalGuidancePanelSwitch: !additionalGuidancePanelSwitch,
+                  additionalGuidancePanel: "",
                 })
               }
               checked={additionalGuidancePanelSwitch}


### PR DESCRIPTION
Ticket: https://jira.ons.gov.uk/browse/EAR-1771

### What is the context of this PR?

> When using the additional guidance panel on the introduction page - if you decide to remove it by toggling it off, in view survey mode the panel will still display. You have to remove the text and toggle it off to get it to work as the string stored in additionalGuidancePanel is not deleted when toggling off.

### How to review

> Toggle additional guidance to ON
> Add content in additional guidance editor
> View the survey and check it's there
> Toggle Additional guidance to OFF
> View survey and check it is not there 

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
