### PR TITLE
Fix to showing two inputs for mutally exclusive

### DIFF
--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -13,7 +13,7 @@ export const QCodeContext = createContext();
 // - (If present) Answer's embedded secondary answer
 export const flattenAnswer = (answer) =>
   [
-    answer,
+    answer.type !== MUTUALLY_EXCLUSIVE && answer,
     ...(answer.options?.map((option) => ({
       ...option,
       type:


### PR DESCRIPTION
### Context of PR ###
Fix to mutually exclusive double inputs in the qCode.

### How to review ###
- [ ] Create an answer with a mutually exclusive answer type.
- [ ] Go into the qCode table and check there aren't multiple inputs for mutually exclusive.

### What to do after everything is green ###

    *  Bring this branch up-to-date with Origin/Master
    *  If there are a lot of commits or some are not helpful to read, squash them down
    *  Click the Merge button on this pull request
    *  Does this change mean the Capability examples questionnaire should be updated?
    *  Move the Jira ticket for this task into the next stage of the process
