### PR TITLE
Add Calc Summary to answer picker

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -35,6 +35,7 @@ const migrations = [
   require("./updateEnabledHubAWSFix"),
   require("./updateEnabledHubAWSFixTwo"),
   require("./convertMutuallyExclusiveOptions"),
+  require("./updateCalculatedSummary"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateCalculatedSummary.js
+++ b/eq-author-api/migrations/updateCalculatedSummary.js
@@ -1,0 +1,27 @@
+const { getPages } = require("../schema/resolvers/utils");
+const { v4: uuidv4 } = require("uuid");
+
+module.exports = (questionnaire) => {
+  const ctx = {
+    questionnaire,
+  };
+  const pages = getPages(ctx);
+
+  pages.forEach((page) => {
+    if (page.pageType === "CalculatedSummaryPage") {
+      if (page.answers?.length > 0) {
+        return;
+      }
+      page.answers = [
+        {
+          id: uuidv4(),
+          label: page.totalTitle ? page.totalTitle : "",
+          type: page.type ? page.type : "Number",
+          validation: {},
+          properties: {},
+        },
+      ];
+    }
+  });
+  return questionnaire;
+};

--- a/eq-author-api/migrations/updateCalculatedSummary.test.js
+++ b/eq-author-api/migrations/updateCalculatedSummary.test.js
@@ -1,0 +1,35 @@
+const updateCalculatedSummary = require("./updateCalculatedSummary");
+
+describe("Migration: set missing Contact Details", () => {
+  let questionnaire;
+  beforeEach(() => {
+    questionnaire = {
+      sections: [
+        {
+          folders: [
+            {
+              pages: [
+                {
+                  pageType: "CalculatedSummaryPage",
+                  type: "Currency",
+                  totalTitle: "Test Total",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  it("should add an answer to calulated summary", () => {
+    const result = updateCalculatedSummary(questionnaire);
+    expect(result.sections[0].folders[0].pages[0].answers.length).toEqual(1);
+    expect(result.sections[0].folders[0].pages[0].answers[0].label).toEqual(
+      "Test Total"
+    );
+    expect(result.sections[0].folders[0].pages[0].answers[0].type).toEqual(
+      "Currency"
+    );
+  });
+});

--- a/eq-author-api/schema/resolvers/pages/calculatedSummaryPage.js
+++ b/eq-author-api/schema/resolvers/pages/calculatedSummaryPage.js
@@ -82,6 +82,8 @@ Resolvers.Mutation = {
     }
 
     merge(page, input);
+    page.answers[0].label = page.totalTitle;
+    page.answers[0].type = page.type;
     page.summaryAnswers = input.summaryAnswers;
     return page;
   }),

--- a/eq-author-api/schema/resolvers/pages/calculatedSummaryPage.js
+++ b/eq-author-api/schema/resolvers/pages/calculatedSummaryPage.js
@@ -83,7 +83,9 @@ Resolvers.Mutation = {
 
     merge(page, input);
     page.answers[0].label = page.totalTitle;
-    page.answers[0].type = page.type;
+    if (page.type) {
+      page.answers[0].type = page.type;
+    }
     page.summaryAnswers = input.summaryAnswers;
     return page;
   }),

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -269,6 +269,7 @@ type CalculatedSummaryPage implements Page & Skippable & Routable {
   section: Section!
   folder: Folder!
   position: Int!
+  answers: [Answer]
   summaryAnswers: [Answer!]!
   type: String
   totalTitle: String

--- a/eq-author-api/src/businessLogic/createCalculatedSummary.js
+++ b/eq-author-api/src/businessLogic/createCalculatedSummary.js
@@ -5,6 +5,15 @@ const createCalculatedSummary = (input = {}) => ({
   id: uuidv4(),
   title: "",
   pageType: "CalculatedSummaryPage",
+  answers: [
+    {
+      id: uuidv4(),
+      label: "",
+      type: "",
+      validation: {},
+      properties: {},
+    },
+  ],
   summaryAnswers: [],
   totalTitle: "",
   type: "",

--- a/eq-author-api/src/businessLogic/createCalculatedSummary.js
+++ b/eq-author-api/src/businessLogic/createCalculatedSummary.js
@@ -9,7 +9,7 @@ const createCalculatedSummary = (input = {}) => ({
     {
       id: uuidv4(),
       label: "",
-      type: "",
+      type: "Number",
       validation: {},
       properties: {},
     },

--- a/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
+++ b/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
@@ -153,6 +153,9 @@ fragment Pages on Page {
   ... on CalculatedSummaryPage {
     totalTitle
     type
+    answers {
+      ...Answers
+    }
     summaryAnswers {
       id
     }

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -29,6 +29,7 @@ import withValidationError from "enhancers/withValidationError";
 
 import ValidationErrorInfoFragment from "graphql/fragments/validationErrorInfo.graphql";
 import CommentFragment from "graphql/fragments/comment.graphql";
+import AnswerFragment from "graphql/fragments/answer.graphql";
 
 const titleControls = {
   emphasis: true,
@@ -180,6 +181,12 @@ CalculatedSummaryPageEditor.fragments = {
       type
       position
       displayName
+      answers {
+        ...Answer
+        ... on BasicAnswer {
+          secondaryQCode
+        }
+      }
       folder {
         id
         position
@@ -197,6 +204,7 @@ CalculatedSummaryPageEditor.fragments = {
       }
     }
     ${CommentFragment}
+    ${AnswerFragment}
     ${AnswerSelector.fragments.AnswerSelector}
     ${ValidationErrorInfoFragment}
   `,

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/updateCalculatedSummaryPageMutation.graphql
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/updateCalculatedSummaryPageMutation.graphql
@@ -1,4 +1,5 @@
 #import "graphql/fragments/validationErrorInfo.graphql"
+#import "graphql/fragments/answer.graphql"
 
 mutation UpdateCalculatedSummaryPage(
   $input: UpdateCalculatedSummaryPageInput!
@@ -9,6 +10,9 @@ mutation UpdateCalculatedSummaryPage(
     totalTitle
     displayName
     alias
+    answers {
+      ...Answer
+    }
     summaryAnswers {
       id
       displayName

--- a/eq-author/src/graphql/createCalculatedSummaryPage.graphql
+++ b/eq-author/src/graphql/createCalculatedSummaryPage.graphql
@@ -1,5 +1,6 @@
 #import "graphql/fragments/validationErrorInfo.graphql"
 #import "./fragments/folder.graphql"
+#import "graphql/fragments/answer.graphql"
 mutation CreateCalculatedSummaryPage(
   $input: CreateCalculatedSummaryPageInput!
 ) {
@@ -9,6 +10,12 @@ mutation CreateCalculatedSummaryPage(
     alias
     displayName
     pageType
+    answers {
+      ...Answer
+      ... on BasicAnswer {
+        secondaryQCode
+      }
+    }
     section {
       id
       folders {


### PR DESCRIPTION
Jira: https://jira.ons.gov.uk/browse/EAR-1670

Details: This allows a calculated summary to be selected as a previous answer in both the answer validation and total validation

To review:

- Add 2 answers
- add a calc summary page and add those 2 answers
- Add a new question page and answer of same type and add a max value validation using the calc summary total as a previous answer.
- preview in runner
- Go wild testing other scenarios.
