### PR TITLE
EAR-1801 - Fix for importing duplicate sections

### DIFF
--- a/eq-author-api/schema/resolvers/importing.js
+++ b/eq-author-api/schema/resolvers/importing.js
@@ -117,21 +117,23 @@ module.exports = {
 
         // Re-create UUIDs, strip QCodes, routing and skip conditions from imported pages
         // Keep piping intact for now - will show "[Deleted answer]" to users when piped ID not resolvable
-        remapAllNestedIds(
-          stripQCodes(
-            sourceSections.forEach((section) => {
-              section.displayConditions = null;
-              section.folders.forEach((folder) => {
-                folder.skipConditions = null;
-                folder.pages.forEach((page) => {
-                  page.routing = null;
-                  page.skipConditions = null;
-                });
+
+        sourceSections.forEach((section) => {
+          remapAllNestedIds(section);
+          section.questionnaireId = ctx.questionnaire.id;
+          section.folders.forEach((folder) => {
+            folder.skipConditions = null;
+            folder.pages.forEach((page) => {
+              page.routing = null;
+              page.skipConditions = null;
+              page.answers.forEach((answer) => {
+                return stripQCodes(answer);
               });
-              sectionsWithoutLogic.push(section);
-            })
-          )
-        );
+            });
+          });
+
+          sectionsWithoutLogic.push(section);
+        });
 
         const section = getSectionById(ctx, sectionId);
         if (!section) {

--- a/eq-author-api/schema/resolvers/utils/helpers.js
+++ b/eq-author-api/schema/resolvers/utils/helpers.js
@@ -123,8 +123,10 @@ const getMovePosition = (section, pageId, position) => {
 };
 
 const stripQCodes = (entity) =>
-  deepMap(entity, (value, key) =>
-    ["qCode", "secondaryQCode"].includes(key) ? null : value
+  deepMap(
+    entity,
+    (value, key) => (["qCode", "secondaryQCode"].includes(key) ? null : value),
+    { inPlace: true }
   );
 
 module.exports = {

--- a/eq-author/src/App/section/Logic/Display/index.js
+++ b/eq-author/src/App/section/Logic/Display/index.js
@@ -25,11 +25,7 @@ const DisplayLogicPage = ({ match }) => {
   }
 
   if (error || !data) {
-    return (
-      <Logic>
-        <Error>Something went wrong</Error>
-      </Logic>
-    );
+    return <Error>Something went wrong</Error>;
   }
 
   const { section } = data;


### PR DESCRIPTION
Signed-off-by: sudeep <sudeep.kunhikannan@ons.gov.uk>

> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

This change is to fix the bug caused while importing the same sections multiple times - https://jira.ons.gov.uk/browse/EAR-1801

### How to review

In a questionnaire, please import the same sections from another questionnaire multiple times.
Then click on any question inside the imported section, each section and the question selection should be independent.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
