### PR TITLE
EAR-1837 Only have one mutually exclusive q-code

### DIFF
--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -13,17 +13,20 @@ export const QCodeContext = createContext();
 // - (If present) Answer's embedded secondary answer
 export const flattenAnswer = (answer) =>
   [
-    answer.type !== MUTUALLY_EXCLUSIVE && answer,
-    ...(answer.options?.map((option) => ({
-      ...option,
-      type:
-        answer.type === RADIO
-          ? "RadioOption"
-          : answer.type === MUTUALLY_EXCLUSIVE
-          ? "MutuallyExclusiveOption"
-          : "CheckboxOption",
-      option: true,
-    })) ?? []),
+    answer,
+    ...(answer.options?.map(
+      (option) =>
+        answer.type !== MUTUALLY_EXCLUSIVE && {
+          ...option,
+          type:
+            answer.type === RADIO
+              ? "RadioOption"
+              : answer.type === MUTUALLY_EXCLUSIVE
+              ? "MutuallyExclusiveOption"
+              : "CheckboxOption",
+          option: true,
+        }
+    ) ?? []),
     answer.mutuallyExclusiveOption && {
       ...answer.mutuallyExclusiveOption,
       type: "MutuallyExclusiveOption",

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -22,6 +22,11 @@ export const flattenAnswer = (answer) =>
           option: true,
         }
     ) ?? []),
+    answer.mutuallyExclusiveOption && {
+      ...answer.mutuallyExclusiveOption,
+      type: "MutuallyExclusiveOption",
+      option: true,
+    },
     answer.secondaryLabel && {
       ...answer,
       label: answer.secondaryLabel,

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -18,20 +18,10 @@ export const flattenAnswer = (answer) =>
       (option) =>
         answer.type !== MUTUALLY_EXCLUSIVE && {
           ...option,
-          type:
-            answer.type === RADIO
-              ? "RadioOption"
-              : answer.type === MUTUALLY_EXCLUSIVE
-              ? "MutuallyExclusiveOption"
-              : "CheckboxOption",
+          type: answer.type === RADIO ? "RadioOption" : "CheckboxOption",
           option: true,
         }
     ) ?? []),
-    answer.mutuallyExclusiveOption && {
-      ...answer.mutuallyExclusiveOption,
-      type: "MutuallyExclusiveOption",
-      option: true,
-    },
     answer.secondaryLabel && {
       ...answer,
       label: answer.secondaryLabel,


### PR DESCRIPTION
### What is the context of this PR?

Update to ensure that the Q-Codes table do show Mutually Exclusive rows, but not Mutually Exclusive Options rows

### How to review

Generate a question with mutually exclusive answers. 
Visit the Q-Codes page
Ensure that there is a Mutually Exclusive row (previously removed), but no Mutually Exclusive Options

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
