### PR TITLE
EAR-1837 Migration update

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -36,6 +36,7 @@ const migrations = [
   require("./updateEnabledHubAWSFixTwo"),
   require("./convertMutuallyExclusiveOptions"),
   require("./updateCalculatedSummary"),
+  require("./updateMutuallyExclusive"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateMutuallyExclusive.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.js
@@ -9,10 +9,7 @@ module.exports = (questionnaire) => {
 
   answers.map((answer) => {
     if (answer.type === MUTUALLY_EXCLUSIVE) {
-      if (
-        answer.options[0].qcode !== undefined ||
-        answer.options[0].qcode !== null
-      ) {
+      if (answer.options[0].qcode) {
         if (answer.qcode === undefined || answer.qcode === null) {
           answer.qcode = answer.options[0].qcode.value;
         }

--- a/eq-author-api/migrations/updateMutuallyExclusive.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.js
@@ -1,5 +1,4 @@
 const { getAnswers } = require("../schema/resolvers/utils");
-const { MUTUALLY_EXCLUSIVE } = require("../constants/answerTypes");
 
 module.exports = (questionnaire) => {
   const ctx = {
@@ -8,12 +7,16 @@ module.exports = (questionnaire) => {
   const answers = getAnswers(ctx);
 
   answers.map((answer) => {
-    if (answer.type === MUTUALLY_EXCLUSIVE) {
-      if (answer.options[0].qcode) {
-        if (answer.qcode === undefined || answer.qcode === null) {
-          answer.qcode = answer.options[0].qcode.value;
-        }
-        delete answer.options[0].qcode;
+    if (answer.type === "MutuallyExclusive") {
+      if (answer.options !== undefined && answer.options !== null) {
+        answer.options.forEach((option) => {
+          if (option.qCode) {
+            if (!answer.qCode) {
+              answer.qCode = option.qCode;
+            }
+            option.qCode = undefined;
+          }
+        });
       }
     }
   });

--- a/eq-author-api/migrations/updateMutuallyExclusive.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.js
@@ -1,0 +1,25 @@
+const { getAnswers } = require("../schema/resolvers/utils");
+const { MUTUALLY_EXCLUSIVE } = require("../constants/answerTypes");
+
+module.exports = (questionnaire) => {
+  const ctx = {
+    questionnaire,
+  };
+  const answers = getAnswers(ctx);
+
+  answers.map((answer) => {
+    if (answer.type === MUTUALLY_EXCLUSIVE) {
+      if (
+        answer.options[0].qcode !== undefined ||
+        answer.options[0].qcode !== null
+      ) {
+        if (answer.qcode === undefined || answer.qcode === null) {
+          answer.qcode = answer.options[0].qcode.value;
+        }
+        delete answer.options[0].qcode;
+      }
+    }
+  });
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/updateMutuallyExclusive.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.js
@@ -14,7 +14,7 @@ module.exports = (questionnaire) => {
             if (!answer.qCode) {
               answer.qCode = option.qCode;
             }
-            option.qCode = undefined;
+            option.qCode = null;
           }
         });
       }

--- a/eq-author-api/migrations/updateMutuallyExclusive.test.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.test.js
@@ -46,7 +46,7 @@ describe("Migration: fix qcode", () => {
       questionnaire.sections[0].folders[0].pages[0].answers;
 
     expect(questionnaireAnswers[0].qCode).toBe("MEQCodeFromOpt1");
-    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(null);
   });
 
   it("should not copy first options qcode to answer qcode if answer qcode already present", () => {
@@ -60,7 +60,7 @@ describe("Migration: fix qcode", () => {
     const questionnaireAnswers =
       questionnaire.sections[0].folders[0].pages[0].answers;
     expect(questionnaireAnswers[0].qCode).toBe("QCodePresent");
-    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(null);
   });
 
   it("should not update if already set from earlier option", () => {
@@ -78,9 +78,9 @@ describe("Migration: fix qcode", () => {
     const questionnaireAnswers =
       questionnaire.sections[0].folders[0].pages[0].answers;
     expect(questionnaireAnswers[0].qCode).toBe("MEQCodeFromOpt1");
-    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
-    expect(questionnaireAnswers[0].options[1].qCode).toBe(undefined);
-    expect(questionnaireAnswers[0].options[2].qCode).toBe(undefined);
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(null);
+    expect(questionnaireAnswers[0].options[1].qCode).toBe(null);
+    expect(questionnaireAnswers[0].options[2].qCode).toBe(null);
   });
 
   it("should preserve non-mutually exclusive", () => {

--- a/eq-author-api/migrations/updateMutuallyExclusive.test.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.test.js
@@ -18,10 +18,12 @@ describe("Migration: fix qcode", () => {
                     {
                       id: "answer-1",
                       type: "MutuallyExclusive",
+                      qCode: "",
                       label: "How many pets do you have?",
                       options: [
                         {
                           id: "exclusive-1",
+                          qCode: "MEQCodeFromOpt1",
                           label: "No pets",
                           description: "Do not have any pets",
                           mutuallyExclusive: true,
@@ -43,25 +45,41 @@ describe("Migration: fix qcode", () => {
     const questionnaireAnswers =
       questionnaire.sections[0].folders[0].pages[0].answers;
 
-    questionnaire.sections[0].folders[0].pages[0].answers[0].options[0] = {
-      qCode: "MEQCodeFromOpt1",
-    };
     expect(questionnaireAnswers[0].qCode).toBe("MEQCodeFromOpt1");
-    expect(questionnaireAnswers[0].options[0].qCode).toBe("");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
   });
 
   it("should not copy first options qcode to answer qcode if answer qcode already present", () => {
     questionnaire.sections[0].folders[0].pages[0].answers[0] = {
       qCode: "QCodePresent",
-    };
-    questionnaire.sections[0].folders[0].pages[0].answers[0].options[0] = {
-      qCode: "MEQCodeFromOpt1",
+      type: "MutuallyExclusive",
+      options: [{ qCode: "MEQCodeFromOpt1" }],
     };
 
     updateMutuallyExclusive(questionnaire);
     const questionnaireAnswers =
       questionnaire.sections[0].folders[0].pages[0].answers;
     expect(questionnaireAnswers[0].qCode).toBe("QCodePresent");
-    expect(questionnaireAnswers[0].options[0].qCode).toBe("");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
+  });
+
+  it("should not update if already set from earlier option", () => {
+    questionnaire.sections[0].folders[0].pages[0].answers[0] = {
+      qCode: "",
+      type: "MutuallyExclusive",
+      options: [
+        { qCode: "MEQCodeFromOpt1" },
+        { qCode: "MEQCodeFromOpt2" },
+        { qCode: "MEQCodeFromOpt3" },
+      ],
+    };
+
+    updateMutuallyExclusive(questionnaire);
+    const questionnaireAnswers =
+      questionnaire.sections[0].folders[0].pages[0].answers;
+    expect(questionnaireAnswers[0].qCode).toBe("MEQCodeFromOpt1");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe(undefined);
+    expect(questionnaireAnswers[0].options[1].qCode).toBe(undefined);
+    expect(questionnaireAnswers[0].options[2].qCode).toBe(undefined);
   });
 });

--- a/eq-author-api/migrations/updateMutuallyExclusive.test.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.test.js
@@ -82,4 +82,24 @@ describe("Migration: fix qcode", () => {
     expect(questionnaireAnswers[0].options[1].qCode).toBe(undefined);
     expect(questionnaireAnswers[0].options[2].qCode).toBe(undefined);
   });
+
+  it("should preserve non-mutually exclusive", () => {
+    questionnaire.sections[0].folders[0].pages[0].answers[0] = {
+      qCode: "",
+      type: "Number",
+      options: [
+        { qCode: "MEQCodeFromOpt1" },
+        { qCode: "MEQCodeFromOpt2" },
+        { qCode: "MEQCodeFromOpt3" },
+      ],
+    };
+
+    updateMutuallyExclusive(questionnaire);
+    const questionnaireAnswers =
+      questionnaire.sections[0].folders[0].pages[0].answers;
+    expect(questionnaireAnswers[0].qCode).toBe("");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe("MEQCodeFromOpt1");
+    expect(questionnaireAnswers[0].options[1].qCode).toBe("MEQCodeFromOpt2");
+    expect(questionnaireAnswers[0].options[2].qCode).toBe("MEQCodeFromOpt3");
+  });
 });

--- a/eq-author-api/migrations/updateMutuallyExclusive.test.js
+++ b/eq-author-api/migrations/updateMutuallyExclusive.test.js
@@ -1,0 +1,67 @@
+const updateMutuallyExclusive = require("./updateMutuallyExclusive");
+
+describe("Migration: fix qcode", () => {
+  let questionnaire;
+  beforeEach(() => {
+    questionnaire = {
+      id: "questionnaire-1",
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              pages: [
+                {
+                  id: "page-1",
+                  answers: [
+                    {
+                      id: "answer-1",
+                      type: "MutuallyExclusive",
+                      label: "How many pets do you have?",
+                      options: [
+                        {
+                          id: "exclusive-1",
+                          label: "No pets",
+                          description: "Do not have any pets",
+                          mutuallyExclusive: true,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  it("should copy first options qcode to answer qcode and delete option qcode", () => {
+    updateMutuallyExclusive(questionnaire);
+    const questionnaireAnswers =
+      questionnaire.sections[0].folders[0].pages[0].answers;
+
+    questionnaire.sections[0].folders[0].pages[0].answers[0].options[0] = {
+      qCode: "MEQCodeFromOpt1",
+    };
+    expect(questionnaireAnswers[0].qCode).toBe("MEQCodeFromOpt1");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe("");
+  });
+
+  it("should not copy first options qcode to answer qcode if answer qcode already present", () => {
+    questionnaire.sections[0].folders[0].pages[0].answers[0] = {
+      qCode: "QCodePresent",
+    };
+    questionnaire.sections[0].folders[0].pages[0].answers[0].options[0] = {
+      qCode: "MEQCodeFromOpt1",
+    };
+
+    updateMutuallyExclusive(questionnaire);
+    const questionnaireAnswers =
+      questionnaire.sections[0].folders[0].pages[0].answers;
+    expect(questionnaireAnswers[0].qCode).toBe("QCodePresent");
+    expect(questionnaireAnswers[0].options[0].qCode).toBe("");
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

Migration update following change to mutually exclusive qCode setting.
Adds migration update to ensure that existing qCode values for Mutually Exclusive options are used to set the Mutually Exclusive qCode value if one doesn't exist already. Options values are then removed to prevent error in Runner.

### How to review

Check that for an existing questionnaire with mutually exclusive options and no qCode value for the mutually exclusive answer the migration sets the ME qCode value to the first available value in MEO, and that all MEO qCode values are removed

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
