### PR TITLE
hub settings update

### DIFF
--- a/eq-author-api/schema/resolvers/importing.js
+++ b/eq-author-api/schema/resolvers/importing.js
@@ -144,7 +144,7 @@ module.exports = {
         }
 
         destinationSections.splice(insertionIndex, 0, ...sectionsWithoutLogic);
-
+        ctx.questionnaire.hub = ctx.questionnaire.sections.length > 1;
         return destinationSections;
       }
     ),


### PR DESCRIPTION
[EAR-1857](https://jira.ons.gov.uk/browse/EAR-1857)
This PR sets hub enabled when importing a section.

To test:

- Create a new questionnaire with only one section
- Import a section from another questionnaire
- Check on the export that the enabled property is set to true