### PR TITLE
EAR-1858 - Highlights navigation item and section

### DIFF
--- a/eq-author/src/components/CollapsibleNavItem/index.js
+++ b/eq-author/src/components/CollapsibleNavItem/index.js
@@ -172,6 +172,7 @@ const CollapsibleNavItem = ({
             containsActiveEntity && !isOpen ? colors.orange : colors.grey
           }
           data-test="CollapsibleNavItem-title"
+          onMouseDown={(e) => e.currentTarget.focus()}
         >
           {Icon && <Icon data-test="CollapsibleNavItem-icon" />}
           <Title>{title}</Title>


### PR DESCRIPTION
Signed-off-by: sudeep <sudeep.kunhikannan@ons.gov.uk>

> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

This is to resolve the bug when the Main navigation button (View, Settings, Sharing, History etc.) and the Section/Folder items are both highlighted.

- Create a new questionnaire with a section, a folder and some questions
- Name the section and folder titles
- Click on any main navigation button - View, Settings, Sharing, History etc.
- Click on the section or folder
- Both the main navigation button and section/folder remain highlighted.

### How to review

- Create a new questionnaire with a section, a folder and some questions
- Name the section and folder titles
- Click on any main navigation button - View, Settings, Sharing, History etc.
- Click on the section or folder
- The main navigation button must not be highlighted, only the Section/Folder item must be highlighted.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
