### PR TITLE
EAR-1886-Duplicate-folder-button-requires-refresh

### DIFF
--- a/eq-author/src/graphql/duplicateFolder.graphql
+++ b/eq-author/src/graphql/duplicateFolder.graphql
@@ -61,6 +61,30 @@ mutation duplicateFolder($input: DuplicateFolderInput!) {
           ... on CalculatedSummaryPage {
             id
             alias
+            totalTitle
+            type
+            answers {
+              ...Answer
+              ... on BasicAnswer {
+                secondaryQCode
+              }
+              ... on MultipleChoiceAnswer {
+                options {
+                  ...Option
+                }
+                mutuallyExclusiveOption {
+                  id
+                  displayName
+                  label
+                  description
+                  value
+                  qCode
+                }
+              }
+            }
+            summaryAnswers {
+              id
+            }
             comments {
               ...Comment
             }

--- a/eq-author/src/graphql/duplicateSection.graphql
+++ b/eq-author/src/graphql/duplicateSection.graphql
@@ -59,6 +59,31 @@ mutation duplicateSection($input: DuplicateSectionInput!) {
         }
         ... on CalculatedSummaryPage {
           id
+          alias
+          totalTitle
+          type
+          answers {
+            ...Answer
+            ... on BasicAnswer {
+              secondaryQCode
+            }
+            ... on MultipleChoiceAnswer {
+              options {
+                ...Option
+              }
+              mutuallyExclusiveOption {
+                id
+                displayName
+                label
+                description
+                value
+                qCode
+              }
+            }
+          }
+          summaryAnswers {
+            id
+          }
           comments {
             ...Comment
           }


### PR DESCRIPTION

### What is the context of this PR?

This PR is linked to this Jira [ticket](https://jira.ons.gov.uk/browse/EAR-1886)

When duplicating a folder that contains a calculated summary this requires a refresh for the duplicate folder to show on the menu, this is also true when duplicating a section. 

Steps to replicate the bug :
- Checkout the master branch
- Create a folder with a calculated summary
- Duplicate the folder using the duplicate button
- Nothing changes on the menu
- The duplicate will only show on the menu after a refresh
- Duplicate the section using the duplicate button
- Again the changes will only reflect after a browser refresh

## How to review
- Checkout EAR-1886-Duplicate-folder-button-refresh
- Create a folder with a calculated summary
- Duplicate the folder using the duplicate button
- The menu will automatically update
- Duplicate the section using the duplicate button
- Again the menu will update without a browser refresh

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
