### PR TITLE
EAR-1868 - Deleting calculated summary piped variable in title

### DIFF
--- a/eq-author-api/src/validation/customKeywords/index.js
+++ b/eq-author-api/src/validation/customKeywords/index.js
@@ -10,6 +10,7 @@ module.exports = (ajv) => {
   require("./validateRoutingDestination")(ajv);
   require("./validateRoutingLogicalAND")(ajv);
   require("./validatePipingAnswerInTitle")(ajv);
+  require("./validatePipingVariableInTitle")(ajv);
   require("./validatePipingMetadataInTitle")(ajv);
   require("./idExists")(ajv);
   require("./idPreceedsCurrentEntity")(ajv);

--- a/eq-author-api/src/validation/customKeywords/validatePipingVariableInTitle.js
+++ b/eq-author-api/src/validation/customKeywords/validatePipingVariableInTitle.js
@@ -61,7 +61,7 @@ module.exports = (ajv) =>
       };
 
       for (const pipedId of pipedIdList) {
-        if (!idExists({ questionnaire }, pipedId)) {
+        if (pipedId !== "total" && !idExists({ questionnaire }, pipedId)) {
           return hasError(PIPING_TITLE_DELETED);
         }
 

--- a/eq-author-api/src/validation/customKeywords/validatePipingVariableInTitle.js
+++ b/eq-author-api/src/validation/customKeywords/validatePipingVariableInTitle.js
@@ -1,0 +1,78 @@
+const {
+  PIPING_TITLE_DELETED,
+  PIPING_TITLE_MOVED,
+} = require("../../../constants/validationErrorCodes");
+const createValidationError = require("../createValidationError");
+
+const {
+  getAbsolutePositionById,
+  idExists,
+} = require("../../../schema/resolvers/utils");
+
+const pipedVariableIdRegex = /data-piped="variable" data-id="(.+?)"/gm;
+
+const trimDateRangeId = (id) => id.replace(/(from|to)$/, "");
+
+module.exports = (ajv) =>
+  ajv.addKeyword({
+    $data: true,
+    keyword: "validatePipingVariableInTitle",
+    validate: function isValid(
+      _schema,
+      title,
+      _parentSchema,
+      {
+        parentData: { id: pageId },
+        parentDataProperty: fieldName,
+        instancePath,
+        rootData: questionnaire,
+      }
+    ) {
+      isValid.errors = [];
+      const pipedIdList = [];
+
+      let matches;
+
+      do {
+        matches = pipedVariableIdRegex.exec(title);
+
+        if (matches && matches.length > 1) {
+          const [, variableId] = matches;
+          pipedIdList.push(trimDateRangeId(variableId));
+        }
+      } while (matches);
+
+      if (!pipedIdList.length) {
+        return true;
+      }
+
+      const hasError = (errorMessage) => {
+        isValid.errors = [
+          createValidationError(
+            instancePath,
+            fieldName,
+            errorMessage,
+            questionnaire,
+            "deleted variable in title"
+          ),
+        ];
+
+        return false;
+      };
+
+      for (const pipedId of pipedIdList) {
+        if (!idExists({ questionnaire }, pipedId)) {
+          return hasError(PIPING_TITLE_DELETED);
+        }
+
+        if (
+          getAbsolutePositionById({ questionnaire }, pipedId) >
+          getAbsolutePositionById({ questionnaire }, pageId)
+        ) {
+          return hasError(PIPING_TITLE_MOVED);
+        }
+      }
+
+      return true;
+    },
+  });

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -2081,6 +2081,17 @@ describe("schema validation", () => {
       expect(errors[0].errorCode).toBe(PIPING_TITLE_DELETED);
     });
 
+    it("should validate a deleted piping variable in title", () => {
+      const piping = validation(questionnaire);
+      expect(piping).toHaveLength(0);
+
+      questionnaire.sections[0].folders[0].pages[0].title = `<p><span data-piped="variable" data-id="answer_99" data-type="Number">[number]</span></p>`;
+
+      const errors = validation(questionnaire);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].errorCode).toBe(PIPING_TITLE_DELETED);
+    });
+
     it("should not return errors for valid piping answers in title", () => {
       const piping = validation(questionnaire);
       expect(piping).toHaveLength(0);

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -2092,6 +2092,16 @@ describe("schema validation", () => {
       expect(errors[0].errorCode).toBe(PIPING_TITLE_DELETED);
     });
 
+    it("should not return errors for calculated summary variable in its own title", () => {
+      const piping = validation(questionnaire);
+      expect(piping).toHaveLength(0);
+
+      questionnaire.sections[0].folders[0].pages[0].title = `<p><span data-piped="variable" data-id="total" data-type="Number">[number]</span></p>`;
+
+      const errors = validation(questionnaire);
+      expect(errors).toHaveLength(0);
+    });
+
     it("should not return errors for valid piping answers in title", () => {
       const piping = validation(questionnaire);
       expect(piping).toHaveLength(0);

--- a/eq-author-api/src/validation/schemas/page.json
+++ b/eq-author-api/src/validation/schemas/page.json
@@ -14,6 +14,9 @@
           "validatePipingAnswerInTitle": true
         },
         {
+          "validatePipingVariableInTitle": true
+        },
+        {
           "validatePipingMetadataInTitle": true
         }
       ]


### PR DESCRIPTION
Signed-off-by: sudeep <sudeep.kunhikannan@ons.gov.uk>

### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-1868

### How to review

- Create a questionnaire, add some questions with 'Number' answers.
- Add a calculated summary page, select the previous 'Number' answers for calculation.
- Add another question, in the title, pipe the calculated summary value using the 'variable' option.
- Delete the calculated summary page.
- A validation error must be displayed in the question title - 'The answer being piped has been deleted'.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
