### PR TITLE
Fix section introduction piping error message

### DIFF
--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -23,7 +23,10 @@ import getIdForObject from "utils/getIdForObject";
 
 import MoveSectionModal from "./MoveSectionModal";
 import MoveSectionQuery from "./MoveSectionModal/MoveSectionQuery";
-import { sectionErrors } from "constants/validationMessages";
+import {
+  sectionErrors,
+  richTextEditorErrors,
+} from "constants/validationMessages";
 import {
   DELETE_SECTION_TITLE,
   DELETE_PAGE_WARNING,
@@ -203,6 +206,7 @@ export class SectionEditor extends React.Component {
                   field: "introductionTitle",
                   label: "Introduction Title",
                   requiredMsg: sectionErrors.SECTION_INTRO_TITLE_NOT_ENTERED,
+                  message: richTextEditorErrors.PIPING_TITLE_DELETED.message,
                 })
               }
             />
@@ -229,6 +233,7 @@ export class SectionEditor extends React.Component {
                   field: "introductionContent",
                   label: "Introduction Content",
                   requiredMsg: sectionErrors.SECTION_INTRO_CONTENT_NOT_ENTERED,
+                  message: richTextEditorErrors.PIPING_TITLE_DELETED.message,
                 })
               }
             />

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -4,6 +4,7 @@ export default {
   ERR_UNIQUE_REQUIRED: ({ label }) => `${label} must be unique`,
   ERR_REQUIRED_WHEN_SETTING: ({ message }) => message,
   ERR_NO_ANSWERS: ({ message }) => message,
+  PIPING_TITLE_DELETED: ({ message }) => message,
 };
 
 export const LIST_COLLECTOR_ERRORS = [


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes error causing the error message "PIPING_TITLE_DELETED" to be displayed when answer piped into section introduction title or content is deleted

### How to review

- Pipe an answer and a list collector answer into a section introduction
- Delete the answer
- Check error message "The answer being piped has been deleted" is displayed
- When repeating section is not enabled and the section introduction pipes a list collector value, check the error message "The answer being piped has been deleted" is displayed

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
