### PR TITLE
Fix for List Answer Option Bug

### DIFF
--- a/eq-author-api/src/validation/index.js
+++ b/eq-author-api/src/validation/index.js
@@ -15,7 +15,7 @@ require("ajv-errors")(ajv);
 const validate = ajv.addSchema(schemas.slice(1)).compile(schemas[0]);
 
 const formatErrorMessage = (error, questionnaire) => {
-  if (error.sectionId) {
+  if (error.sectionId || error.listId) {
     delete error.dataPath;
     delete error.schemaPath;
     delete error.keyword;


### PR DESCRIPTION
Fixes issue when adding an option type answer to a list and a duplicate label is added. 

To test 

- Add a list
- Add a radio
- add 2 options with the same label
- It should not lock up and break