### PR TITLE
EAR-1929 Incorrect label on Select answer

### DIFF
--- a/eq-author/src/App/Comments/index.test.js
+++ b/eq-author/src/App/Comments/index.test.js
@@ -47,6 +47,25 @@ const mockUseQuery = {
           },
         ],
       },
+      {
+        id: "comment-3",
+        user: { id: "user-1", displayName: "Dina" },
+        commentText:
+          "If a tree falls and no-one is there to hear it, does it make a sound",
+        createdTime: "2021-04-30T14:49:00.000Z",
+        editedTime: null,
+        readBy: ["user-1"],
+        replies: [
+          {
+            id: "comment-2-reply-1",
+            user: { id: "user-2", displayName: "Amy" },
+            commentText: "Yes and no",
+            createdTime: "2021-04-30T15:01:00.000Z",
+            editedTime: null,
+            readBy: [],
+          },
+        ],
+      },
     ],
   },
 };
@@ -143,5 +162,18 @@ describe("Comments panel", () => {
 
     expect(queryByTestId("Comment__CommentText")).toBeFalsy();
     expect(commentPanel).toBeTruthy();
+  });
+
+  it.only("Shuld have status of hasNotRead", () => {
+    const { getByTestId } = renderPanel();
+
+    const { id, replies } = mockUseQuery.data.comments[2];
+
+    const commentWrapper = getByTestId(`Comment-${id}`);
+
+    const collapsible = queryByTestId(commentWrapper, "collapsible");
+
+    expect(replies.length).toBe(1);
+    expect(replies.readBy).toEqual(undefined);
   });
 });

--- a/eq-author/src/App/Comments/index.test.js
+++ b/eq-author/src/App/Comments/index.test.js
@@ -51,13 +51,13 @@ const mockUseQuery = {
         id: "comment-3",
         user: { id: "user-1", displayName: "Dina" },
         commentText:
-          "If a tree falls and no-one is there to hear it, does it make a sound",
+          "Has anyone noticed anything out of the ordinary back here? ",
         createdTime: "2021-04-30T14:49:00.000Z",
         editedTime: null,
         readBy: ["user-1"],
         replies: [
           {
-            id: "comment-2-reply-1",
+            id: "comment-3-reply-1",
             user: { id: "user-2", displayName: "Amy" },
             commentText: "Yes and no",
             createdTime: "2021-04-30T15:01:00.000Z",
@@ -97,6 +97,17 @@ describe("Comments panel", () => {
     );
 
   afterEach(() => jest.clearAllMocks());
+
+  it("Shuld have status of hasNotRead", () => {
+    const props = { ...mockUseQuery };
+    const { getByTestId } = renderPanel(props);
+
+    const { id, replies } = mockUseQuery.data.comments[2];
+    const commentWrapper = getByTestId(`Comment-${id}`);
+
+    expect(replies.readBy).toEqual(undefined);
+    expect(commentWrapper).toBeTruthy();
+  });
 
   it("Can render", () => {
     const { getByTestId } = renderPanel();
@@ -162,18 +173,5 @@ describe("Comments panel", () => {
 
     expect(queryByTestId("Comment__CommentText")).toBeFalsy();
     expect(commentPanel).toBeTruthy();
-  });
-
-  it.only("Shuld have status of hasNotRead", () => {
-    const { getByTestId } = renderPanel();
-
-    const { id, replies } = mockUseQuery.data.comments[2];
-
-    const commentWrapper = getByTestId(`Comment-${id}`);
-
-    const collapsible = queryByTestId(commentWrapper, "collapsible");
-
-    expect(replies.length).toBe(1);
-    expect(replies.readBy).toEqual(undefined);
   });
 });

--- a/eq-author/src/App/page/Design/answers/withCreateOption.js
+++ b/eq-author/src/App/page/Design/answers/withCreateOption.js
@@ -1,29 +1,12 @@
 import { graphql } from "react-apollo";
 import createOptionMutation from "graphql/createOption.graphql";
-import fragment from "graphql/answerFragment.graphql";
-
-export const createUpdater = (answerId) => (proxy, result) => {
-  const id = `MultipleChoiceAnswer${answerId}`;
-  const answer = proxy.readFragment({ id, fragment });
-
-  answer.options.push(result.data.createOption);
-
-  proxy.writeFragment({
-    id,
-    fragment,
-    data: answer,
-  });
-};
 
 export const mapMutateToProps = ({ mutate }) => ({
   onAddOption(answerId, { hasAdditionalAnswer }) {
     const option = { answerId, hasAdditionalAnswer };
 
-    const update = createUpdater(answerId);
-
     return mutate({
       variables: { input: option },
-      update,
     }).then((res) => res.data.createOption);
   },
 });

--- a/eq-author/src/App/page/Design/answers/withCreateOption.test.js
+++ b/eq-author/src/App/page/Design/answers/withCreateOption.test.js
@@ -1,4 +1,4 @@
-import { mapMutateToProps, createUpdater } from "./withCreateOption";
+import { mapMutateToProps } from "./withCreateOption";
 import fragment from "graphql/answerFragment.graphql";
 
 describe("containers/QuestionnaireDesignPage/withCreateOption", () => {
@@ -21,25 +21,6 @@ describe("containers/QuestionnaireDesignPage/withCreateOption", () => {
     };
 
     mutate = jest.fn(() => Promise.resolve(result));
-  });
-
-  describe("createUpdater", () => {
-    it("should update the cache pass and the result to be the correct page", () => {
-      const id = `MultipleChoiceAnswer${answer.id}`;
-      const writeFragment = jest.fn();
-      const readFragment = jest.fn(() => answer);
-
-      const updater = createUpdater(answer.id);
-      updater({ readFragment, writeFragment }, result);
-
-      expect(readFragment).toHaveBeenCalledWith({ id, fragment });
-      expect(writeFragment).toHaveBeenCalledWith({
-        id,
-        fragment,
-        data: answer,
-      });
-      expect(answer.options).toContain(newOption);
-    });
   });
 
   describe("mapMutateToProps", () => {

--- a/eq-author/src/App/page/Design/answers/withCreateOption.test.js
+++ b/eq-author/src/App/page/Design/answers/withCreateOption.test.js
@@ -1,5 +1,4 @@
 import { mapMutateToProps } from "./withCreateOption";
-import fragment from "graphql/answerFragment.graphql";
 
 describe("containers/QuestionnaireDesignPage/withCreateOption", () => {
   const answer = {


### PR DESCRIPTION

### What is the context of this PR?

> When creating an option for a select answer, the numbered label sometimes displays one number above the number it is supposed to (e.g. creating label 26 displays label 27 instead)
>
> 

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Create basic questionnaire
- Create a Collection List with a Select answer
- Add a few extra options
- Delete the last option
- Add another option and check the new label is contiguous with the previous label number

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
