### PR TITLE
Ear 1947 set data version

### DIFF
--- a/eq-author-api/migrations/addDataVersion.js
+++ b/eq-author-api/migrations/addDataVersion.js
@@ -1,0 +1,9 @@
+module.exports = (questionnaire) => {
+  if (questionnaire.collectionLists.lists.length > 0) {
+    questionnaire.dataVersion = "3";
+  } else {
+    questionnaire.dataVersion = "1";
+  }
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addDataVersion.test.js
+++ b/eq-author-api/migrations/addDataVersion.test.js
@@ -1,0 +1,19 @@
+const addDataVersion = require("./addDataVersion");
+
+describe("addDataVersion", () => {
+  it("should set dataVersion value to 3 when questionnaire has lists", () => {
+    const questionnaire = {
+      collectionLists: {
+        lists: [{ id: "list-1" }],
+      },
+    };
+
+    expect(addDataVersion(questionnaire).dataVersion).toBe("3");
+  });
+
+  it("should set dataVersion value to 1 when questionnaire lists are empty", () => {
+    const questionnaire = { collectionLists: { lists: [] } };
+
+    expect(addDataVersion(questionnaire).dataVersion).toBe("1");
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -37,6 +37,7 @@ const migrations = [
   require("./convertMutuallyExclusiveOptions"),
   require("./updateCalculatedSummary"),
   require("./updateMutuallyExclusive"),
+  require("./addDataVersion"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -146,7 +146,7 @@ const createNewQuestionnaire = (input) => {
     qcodes: true,
     navigation: false,
     hub: false,
-    dataVersionThree: false,
+    dataVersion: "1",
     createdAt: new Date(),
     metadata: [],
     sections: [createSection()],
@@ -1046,8 +1046,8 @@ const Resolvers = {
         `List created with - ${JSON.stringify(list)}`
       );
       ctx.questionnaire.collectionLists.lists.push(list);
-      ctx.questionnaire.dataVersionThree =
-        ctx.questionnaire.collectionLists.lists.length > 0;
+      ctx.questionnaire.dataVersion =
+        ctx.questionnaire.collectionLists.lists.length > 0 ? "3" : "1";
       return ctx.questionnaire.collectionLists;
     }),
     updateList: createMutation(async (root, { input }, ctx) => {
@@ -1069,8 +1069,8 @@ const Resolvers = {
         { qid: ctx.questionnaire.id },
         `List removed with ID - ${input.id}`
       );
-      ctx.questionnaire.dataVersionThree =
-        ctx.questionnaire.collectionLists.lists.length > 0;
+      ctx.questionnaire.dataVersion =
+        ctx.questionnaire.collectionLists.lists.length > 0 ? "3" : "1";
 
       return ctx.questionnaire.collectionLists;
     }),

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1603,6 +1603,10 @@ const Resolvers = {
     comments: ({ id }, args, ctx) => ctx.comments[id],
   },
 
+  CollectionLists: {
+    questionnaire: (collectionLists, args, ctx) => ctx.questionnaire,
+  },
+
   Folder: {
     section: ({ id }, args, ctx) => getSectionByFolderId(ctx, id),
     position: ({ id }, args, ctx) => {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -146,6 +146,7 @@ const createNewQuestionnaire = (input) => {
     qcodes: true,
     navigation: false,
     hub: false,
+    dataVersionThree: false,
     createdAt: new Date(),
     metadata: [],
     sections: [createSection()],
@@ -1045,6 +1046,8 @@ const Resolvers = {
         `List created with - ${JSON.stringify(list)}`
       );
       ctx.questionnaire.collectionLists.lists.push(list);
+      ctx.questionnaire.dataVersionThree =
+        ctx.questionnaire.collectionLists.lists.length > 0;
       return ctx.questionnaire.collectionLists;
     }),
     updateList: createMutation(async (root, { input }, ctx) => {
@@ -1066,6 +1069,8 @@ const Resolvers = {
         { qid: ctx.questionnaire.id },
         `List removed with ID - ${input.id}`
       );
+      ctx.questionnaire.dataVersionThree =
+        ctx.questionnaire.collectionLists.lists.length > 0;
 
       return ctx.questionnaire.collectionLists;
     }),

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -57,6 +57,7 @@ type Questionnaire {
   qcodes: Boolean
   navigation: Boolean
   hub: Boolean
+  dataVersionThree: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User!

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -99,6 +99,7 @@ enum HistoryEventTypes {
 type CollectionLists {
   id: ID!
   lists: [List]
+  questionnaire: Questionnaire
 }
 
 type Theme {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -57,7 +57,7 @@ type Questionnaire {
   qcodes: Boolean
   navigation: Boolean
   hub: Boolean
-  dataVersionThree: Boolean
+  dataVersion: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User!

--- a/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
+++ b/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
@@ -15,7 +15,7 @@ query GetQuestionnaire($input: QueryInput!) {
     totalErrorCount
     ...NavigationSidebar
     hub
-    dataVersionThree
+    dataVersion
     collectionLists {
       id
       lists {

--- a/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
+++ b/eq-author/src/App/QuestionnaireDesignPage/getQuestionnaireQuery.graphql
@@ -15,6 +15,7 @@ query GetQuestionnaire($input: QueryInput!) {
     totalErrorCount
     ...NavigationSidebar
     hub
+    dataVersionThree
     collectionLists {
       id
       lists {

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -18,6 +18,7 @@ import {
   TableHeadColumn,
 } from "components/datatable/Elements";
 import { TableInput } from "components/datatable/Controls";
+import { useQuestionnaire } from "components/QuestionnaireContext";
 
 import { colors } from "constants/theme";
 
@@ -116,6 +117,9 @@ const Row = memo((props) => {
     secondary,
   } = props;
 
+  const { questionnaire } = useQuestionnaire();
+  const { dataVersionThree } = questionnaire;
+
   const [qCode, setQcode] = useState(initialQcode);
   const [updateOption] = useMutation(UPDATE_OPTION_QCODE);
   const [updateAnswer] = useMutation(UPDATE_ANSWER_QCODE);
@@ -155,7 +159,25 @@ const Row = memo((props) => {
       )}
       <SpacedTableColumn>{TYPE_TO_DESCRIPTION[type]}</SpacedTableColumn>
       <SpacedTableColumn>{label}</SpacedTableColumn>
-      {[CHECKBOX, RADIO_OPTION, SELECT_OPTION].includes(type) ? (
+      {dataVersionThree ? (
+        [CHECKBOX_OPTION, RADIO_OPTION, SELECT_OPTION].includes(type) ? (
+          <EmptyTableColumn />
+        ) : (
+          <SpacedTableColumn>
+            <ErrorWrappedInput
+              name={`${id}-qcode-entry`}
+              data-test={`${id}${secondary ? "-secondary" : ""}-test-input`}
+              value={qCode}
+              onChange={(e) => setQcode(e.value)}
+              onBlur={() => handleBlur(qCode)}
+              hasError={Boolean(errorMessage)}
+            />
+            {errorMessage && (
+              <QcodeValidationError>{errorMessage}</QcodeValidationError>
+            )}
+          </SpacedTableColumn>
+        )
+      ) : [CHECKBOX, RADIO_OPTION, SELECT_OPTION].includes(type) ? (
         <EmptyTableColumn />
       ) : (
         <SpacedTableColumn>

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -118,7 +118,7 @@ const Row = memo((props) => {
   } = props;
 
   const { questionnaire } = useQuestionnaire();
-  const { dataVersionThree } = questionnaire;
+  const { dataVersion } = questionnaire;
 
   const [qCode, setQcode] = useState(initialQcode);
   const [updateOption] = useMutation(UPDATE_OPTION_QCODE);
@@ -159,7 +159,7 @@ const Row = memo((props) => {
       )}
       <SpacedTableColumn>{TYPE_TO_DESCRIPTION[type]}</SpacedTableColumn>
       <SpacedTableColumn>{label}</SpacedTableColumn>
-      {dataVersionThree ? (
+      {dataVersion === "3" ? (
         [CHECKBOX_OPTION, RADIO_OPTION, SELECT_OPTION].includes(type) ? (
           <EmptyTableColumn />
         ) : (

--- a/eq-author/src/App/qcodes/QCodesTable/index.test.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, fireEvent } from "tests/utils/rtl";
 import { useMutation } from "@apollo/react-hooks";
 import { QCodeContextProvider } from "components/QCodeContext";
+import QuestionnaireContext from "components/QuestionnaireContext";
 import { QCodeTable } from "./index";
 import { buildQuestionnaire } from "tests/utils/createMockQuestionnaire";
 
@@ -24,7 +25,9 @@ useMutation.mockImplementation(jest.fn(() => [jest.fn()]));
 const renderWithContext = ({ questionnaire } = {}) =>
   render(
     <QCodeContextProvider questionnaire={questionnaire}>
-      <QCodeTable />
+      <QuestionnaireContext.Provider value={{ questionnaire }}>
+        <QCodeTable />
+      </QuestionnaireContext.Provider>
     </QCodeContextProvider>
   );
 

--- a/eq-author/src/App/qcodes/QCodesTable/index.test.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.test.js
@@ -683,6 +683,15 @@ describe("Qcode Table", () => {
         const { getAllByText } = renderWithContext({ questionnaire });
         expect(getAllByText("Qcode required")).toBeTruthy();
       });
+
+      it("should render a validation error when duplicate qCodes are present in data version 3", () => {
+        const questionnaire = buildQuestionnaire({ answerCount: 2 });
+        questionnaire.sections[0].folders[0].pages[0].answers[0].qCode = "1";
+        questionnaire.sections[0].folders[0].pages[0].answers[1].qCode = "1";
+        questionnaire.dataVersion = "3";
+        const { getAllByText } = renderWithContext({ questionnaire });
+        expect(getAllByText(QCODE_IS_NOT_UNIQUE)).toBeTruthy();
+      });
     });
   });
 });

--- a/eq-author/src/App/qcodes/QCodesTable/index.test.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.test.js
@@ -104,7 +104,7 @@ const textSetup = () => {
   return renderWithContext({ questionnaire });
 };
 
-const optionsSetup = () => {
+const optionsSetup = (dataVersion) => {
   const questionnaire = buildQuestionnaire({ answerCount: 2 });
   Object.assign(questionnaire.sections[0].folders[0].pages[0], {
     alias: "multiple-choice-answer-types-alias",
@@ -129,8 +129,10 @@ const optionsSetup = () => {
   // Checkbox answer with two options & mutually exclusive option
   Object.assign(
     questionnaire.sections[0].folders[0].pages[0].answers[1],
+    (questionnaire.dataVersion = dataVersion),
     generateAnswer({
       type: "Checkbox",
+      id: "checkbox-answer-id",
       options: [
         {
           id: "checkbox-option-1-id",
@@ -575,6 +577,7 @@ describe("Qcode Table", () => {
             expect(utils.getAllByText(/Checkbox option/)).toHaveLength(2);
             expect(utils.getByText(/Mutually exclusive/)).toBeVisible();
           });
+
           it("should display answer label", () => {
             expect(utils.getByText(/checkbox-option-1-label/)).toBeVisible();
             expect(utils.getByText(/checkbox-option-2-label/)).toBeVisible();
@@ -582,6 +585,7 @@ describe("Qcode Table", () => {
               utils.getByText(/Mutually-exclusive-option-label/)
             ).toBeVisible();
           });
+
           it("should display answer qCode", () => {
             expect(
               utils.getByTestId("checkbox-option-1-id-test-input").value
@@ -593,6 +597,7 @@ describe("Qcode Table", () => {
               utils.getByTestId("checkbox-option-3-id-test-input").value
             ).toEqual("mutually-exclusive-option");
           });
+
           it("should save qCode for option", () => {
             fireEvent.change(
               utils.getByTestId("checkbox-option-1-id-test-input"),
@@ -609,6 +614,7 @@ describe("Qcode Table", () => {
               },
             });
           });
+
           it("should save qCode for mutually exclusive option", () => {
             fireEvent.change(
               utils.getByTestId("checkbox-option-3-id-test-input"),
@@ -626,6 +632,56 @@ describe("Qcode Table", () => {
             });
           });
         });
+      });
+    });
+
+    describe("Data version 3", () => {
+      let utils, mock;
+
+      beforeEach(() => {
+        mock = jest.fn();
+        useMutation.mockImplementation(jest.fn(() => [mock]));
+        utils = optionsSetup("3");
+      });
+
+      it("should display answer qCodes without option qCodes for checkbox answers in data version 3", () => {
+        expect(
+          utils.queryByTestId("checkbox-option-1-id-test-input")
+        ).not.toBeInTheDocument();
+
+        expect(
+          utils.queryByTestId("checkbox-option-2-id-test-input")
+        ).not.toBeInTheDocument();
+
+        expect(
+          utils.getByTestId("checkbox-answer-id-test-input")
+        ).toBeInTheDocument();
+
+        expect(
+          utils.getByTestId("checkbox-option-3-id-test-input").value
+        ).toEqual("mutually-exclusive-option");
+      });
+
+      it("should save qCode for checkbox answer", () => {
+        fireEvent.change(utils.getByTestId("checkbox-answer-id-test-input"), {
+          target: { value: "123" },
+        });
+
+        fireEvent.blur(utils.getByTestId("checkbox-answer-id-test-input"));
+
+        expect(mock).toHaveBeenCalledWith({
+          variables: {
+            input: { id: "checkbox-answer-id", qCode: "123" },
+          },
+        });
+      });
+
+      it("should render a validation error when a qCode is missing in data version 3", () => {
+        const questionnaire = buildQuestionnaire({ answerCount: 1 });
+        questionnaire.sections[0].folders[0].pages[0].answers[0].qCode = "";
+        questionnaire.dataVersion = "3";
+        const { getAllByText } = renderWithContext({ questionnaire });
+        expect(getAllByText("Qcode required")).toBeTruthy();
       });
     });
   });

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import { getPages } from "utils/questionnaireUtils";
 import {
+  RADIO_OPTION,
+  CHECKBOX,
+  CHECKBOX_OPTION,
   MUTUALLY_EXCLUSIVE,
   ANSWER_OPTION_TYPES,
 } from "constants/answer-types";
@@ -63,14 +66,24 @@ export const getFlattenedAnswerRows = (questionnaire) => {
 
 // getDuplicatedQCodes :: [AnswerRow] -> [QCode]
 // Return an array of qCodes which are duplicated in the given list of answer rows
-export const getDuplicatedQCodes = (flattenedAnswers) => {
+export const getDuplicatedQCodes = (flattenedAnswers, { dataVersion }) => {
   const qCodeUsageMap = flattenedAnswers?.reduce(
-    (acc, { qCode, additionalAnswer }) => {
+    (acc, { qCode, type, additionalAnswer }) => {
       const { qCode: additionalAnswerQCode } = additionalAnswer || {};
 
       if (qCode) {
-        const currentValue = acc.get(qCode);
-        acc.set(qCode, currentValue ? currentValue + 1 : 1);
+        if (dataVersion !== "3") {
+          if (type !== CHECKBOX) {
+            const currentValue = acc.get(qCode);
+            acc.set(qCode, currentValue ? currentValue + 1 : 1);
+          }
+        }
+        if (dataVersion === "3") {
+          if (type !== CHECKBOX_OPTION) {
+            const currentValue = acc.get(qCode);
+            acc.set(qCode, currentValue ? currentValue + 1 : 1);
+          }
+        }
       }
 
       if (additionalAnswerQCode) {
@@ -89,6 +102,24 @@ export const getDuplicatedQCodes = (flattenedAnswers) => {
   );
 };
 
+const getEmptyQCodes = (answerRows, dataVersion) => {
+  // If dataVersion is 3, checkbox options and radio options do not have QCodes, and therefore these can be empty
+  // This removes the error badge from the main navigation QCodes tab when data version is 3 and a checkbox option is empty from when it previously used a different data version
+  if (dataVersion === "3") {
+    return answerRows?.find(
+      ({ qCode, type }) =>
+        !qCode && ![CHECKBOX_OPTION, RADIO_OPTION].includes(type)
+    );
+  }
+  // If dataVersion is not 3, checkbox answers and radio options do not have QCodes, and therefore these can be empty
+  // This removes the error badge from the main navigation QCodes tab when data version is not 3 and a checkbox answer is empty from when it previously used data version 3
+  else {
+    return answerRows?.find(
+      ({ qCode, type }) => !qCode && ![CHECKBOX, RADIO_OPTION].includes(type)
+    );
+  }
+};
+
 export const QCodeContextProvider = ({ questionnaire = {}, children }) => {
   const answerRows = useMemo(
     () => getFlattenedAnswerRows(questionnaire) ?? [],
@@ -96,15 +127,13 @@ export const QCodeContextProvider = ({ questionnaire = {}, children }) => {
   );
 
   const duplicatedQCodes = useMemo(
-    () => getDuplicatedQCodes(answerRows) ?? [],
-    [answerRows]
+    () => getDuplicatedQCodes(answerRows, questionnaire) ?? [],
+    [answerRows, questionnaire]
   );
 
   const hasQCodeError =
     duplicatedQCodes?.length ||
-    answerRows?.find(
-      ({ qCode, type }) => !qCode && !["Checkbox", "RadioOption"].includes(type)
-    );
+    getEmptyQCodes(answerRows, questionnaire.dataVersion);
 
   const value = useMemo(
     () => ({

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -67,22 +67,21 @@ export const getFlattenedAnswerRows = (questionnaire) => {
 // getDuplicatedQCodes :: [AnswerRow] -> [QCode]
 // Return an array of qCodes which are duplicated in the given list of answer rows
 export const getDuplicatedQCodes = (flattenedAnswers, { dataVersion }) => {
+  // acc - accumulator
   const qCodeUsageMap = flattenedAnswers?.reduce(
     (acc, { qCode, type, additionalAnswer }) => {
       const { qCode: additionalAnswerQCode } = additionalAnswer || {};
 
       if (qCode) {
-        if (dataVersion !== "3") {
-          if (type !== CHECKBOX) {
-            const currentValue = acc.get(qCode);
-            acc.set(qCode, currentValue ? currentValue + 1 : 1);
-          }
+        // If dataVersion is 3, do not check if a QCode has the same value as a checkbox option's QCode
+        if (dataVersion === "3" && type !== CHECKBOX_OPTION) {
+          const currentValue = acc.get(qCode);
+          acc.set(qCode, currentValue ? currentValue + 1 : 1);
         }
-        if (dataVersion === "3") {
-          if (type !== CHECKBOX_OPTION) {
-            const currentValue = acc.get(qCode);
-            acc.set(qCode, currentValue ? currentValue + 1 : 1);
-          }
+        // If dataVersion is not 3, do not check if a QCode has the same value as a checkbox answer's QCode
+        else if (dataVersion !== "3" && type !== CHECKBOX) {
+          const currentValue = acc.get(qCode);
+          acc.set(qCode, currentValue ? currentValue + 1 : 1);
         }
       }
 

--- a/eq-author/src/graphql/lists/deleteCollectionListMutation.graphql
+++ b/eq-author/src/graphql/lists/deleteCollectionListMutation.graphql
@@ -6,5 +6,9 @@ mutation DeleteList($input: DeleteListInput) {
     lists {
       ...List
     }
+    questionnaire {
+      id
+      dataVersion
+    }
   }
 }


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-1947

**Publisher:** https://github.com/ONSdigital/eq-publisher-v3/pull/143

Add dataVersion value to questionnaire data

When a questionnaire has collection lists, dataVersion should be 1
When a questionnaire does not have any collection lists, dataVersion should be 3

When a questionnaire's data version is 1, QCodes for checkbox answers should be assigned to each of the checkbox options, and not to the checkbox answer (there may be multiple QCodes for a checkbox answer)
When a questionnaire's data version is 3, QCodes for checkbox answers should only be assigned to the checkbox answer, and not to any of the checkbox options (there should only be one QCode for a checkbox answer)

### How to review

**Check:**
- [ ] When a questionnaire has no collection lists, the questionnaire's dataVersion is "1" - check this in the questionnaire's JSON schema
- [ ] When a questionnaire has one or more collection lists, the questionnaire's dataVersion is "3" - check this in the questionnaire's JSON schema
- [ ] Pre-existing questionnaires with no collection lists are set to dataVersion "1" by default
- [ ] Pre-existing questionnaires with collection lists are set to dataVersion "3" by default
- [ ] When data version is 1, QCodes for checkbox answers are assigned to each of the checkbox options, and not to the checkbox answer - this will match Author's pre-existing behaviour
- [ ] When data version is 3, QCodes for checkbox answers are assigned to the checkbox answer, and not to any of the checkbox's options
- [ ] Adding a collection list to a questionnaire that did not have any collection lists before sets the questionnaire's data version to 3, and checkbox answer QCodes are updated to reflect this
- [ ] Deleting the last collection list in a questionnaire sets the questionnaire's data version to 1, and checkbox answer QCodes are updated to reflect this
- [ ] If data version changes, validation errors are not displayed on the QCodes page on columns which are no longer enabled for empty QCodes - e.g. if data version changes from 3 to 1, and a checkbox answer's QCode was empty, the checkbox answer's column is disabled, the column does not include a validation error, and a validation badge is not displayed on the QCodes navigation panel item
- [ ] If data version changes, validation errors are not displayed if a previous checkbox answer QCode matches a current checkbox option QCode (or if a current checkbox answer QCode matches a previous checkbox option QCode) - e.g. if data version changes from 3 to 1, and a checkbox answer's QCode was 1, the checkbox answer's column is disabled, and entering a QCode of 1 for one of the enabled checkbox option QCodes does not display a validation error for unique QCodes and does not display a validation error badge on the QCodes navigation panel item
- [ ] QCodes are not lost when changing between data versions - e.g. if data version is 3 and a checkbox answer has QCode 1, then the questionnaire changes to data version 1, and then back to data version 3, the checkbox answer's QCode value of 1 is still saved and displayed in the QCodes page
- [ ] Other answer types in Author and their QCodes have not changed

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
