### PR TITLE
added qcode for option answer

### DIFF
--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -217,11 +217,16 @@ export const QCodeTable = () => {
     (!qCode && QCODE_REQUIRED) ||
     (duplicatedQCodes.includes(qCode) && QCODE_IS_NOT_UNIQUE);
 
+  const { questionnaire } = useQuestionnaire();
+  const dataVersion = questionnaire?.dataVersion;
+
   return (
     <Table data-test="qcodes-table">
       <TableHead>
         <TableRow>
-          <TableHeadColumn width="20%">Short code</TableHeadColumn>
+          <TableHeadColumn width="20%">
+            Short code {dataVersion}
+          </TableHeadColumn>
           <TableHeadColumn width="20%">Question</TableHeadColumn>
           <TableHeadColumn width="20%">Type</TableHeadColumn>
           <TableHeadColumn width="20%">Answer label</TableHeadColumn>
@@ -230,7 +235,10 @@ export const QCodeTable = () => {
       </TableHead>
       <StyledTableBody>
         {answerRows?.map((item, index) => {
-          if (item.additionalAnswer && item.type !== "CheckboxOption") {
+          if (
+            item.additionalAnswer &&
+            (dataVersion === "3" || item.type !== "CheckboxOption")
+          ) {
             return (
               <>
                 <Row

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -106,6 +106,7 @@ const mutationVariables = (inputValues) => ({
 
 const Row = memo((props) => {
   const {
+    dataVersion,
     id,
     questionTitle,
     questionShortCode,
@@ -116,9 +117,6 @@ const Row = memo((props) => {
     option,
     secondary,
   } = props;
-
-  const { questionnaire } = useQuestionnaire();
-  const { dataVersion } = questionnaire;
 
   const [qCode, setQcode] = useState(initialQcode);
   const [updateOption] = useMutation(UPDATE_OPTION_QCODE);
@@ -199,6 +197,7 @@ const Row = memo((props) => {
 });
 
 Row.propTypes = {
+  dataVersion: PropTypes.string,
   id: PropTypes.string,
   questionTitle: PropTypes.string,
   questionShortCode: PropTypes.string,
@@ -212,21 +211,16 @@ Row.propTypes = {
 };
 
 export const QCodeTable = () => {
-  const { answerRows, duplicatedQCodes } = useQCodeContext();
+  const { answerRows, duplicatedQCodes, dataVersion } = useQCodeContext();
   const getErrorMessage = (qCode) =>
     (!qCode && QCODE_REQUIRED) ||
     (duplicatedQCodes.includes(qCode) && QCODE_IS_NOT_UNIQUE);
-
-  const { questionnaire } = useQuestionnaire();
-  const dataVersion = questionnaire?.dataVersion;
 
   return (
     <Table data-test="qcodes-table">
       <TableHead>
         <TableRow>
-          <TableHeadColumn width="20%">
-            Short code {dataVersion}
-          </TableHeadColumn>
+          <TableHeadColumn width="20%">Short code</TableHeadColumn>
           <TableHeadColumn width="20%">Question</TableHeadColumn>
           <TableHeadColumn width="20%">Type</TableHeadColumn>
           <TableHeadColumn width="20%">Answer label</TableHeadColumn>
@@ -243,11 +237,13 @@ export const QCodeTable = () => {
               <>
                 <Row
                   key={`${item.id}-${index}`}
+                  dataVersion={dataVersion}
                   {...item}
                   errorMessage={getErrorMessage(item.qCode)}
                 />
                 <Row
                   key={`${item.additionalAnswer.id}-${index}`}
+                  dataVersion={dataVersion}
                   {...item.additionalAnswer}
                   errorMessage={getErrorMessage(item.additionalAnswer.qCode)}
                 />
@@ -257,6 +253,7 @@ export const QCodeTable = () => {
             return (
               <Row
                 key={`${item.id}-${index}`}
+                dataVersion={dataVersion}
                 {...item}
                 errorMessage={getErrorMessage(item.qCode)}
               />

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -18,7 +18,6 @@ import {
   TableHeadColumn,
 } from "components/datatable/Elements";
 import { TableInput } from "components/datatable/Controls";
-import { useQuestionnaire } from "components/QuestionnaireContext";
 
 import { colors } from "constants/theme";
 

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -82,7 +82,6 @@ export const getDuplicatedQCodes = (flattenedAnswers, { dataVersion }) => {
           const currentValue = acc.get(additionalAnswerQCode);
           acc.set(additionalAnswerQCode, currentValue ? currentValue + 1 : 1);
         }
-        return acc;
       }
 
       if (dataVersion !== "3") {
@@ -95,8 +94,8 @@ export const getDuplicatedQCodes = (flattenedAnswers, { dataVersion }) => {
           const currentValue = acc.get(additionalAnswerQCode);
           acc.set(additionalAnswerQCode, currentValue ? currentValue + 1 : 1);
         }
-        return acc;
       }
+      return acc;
     },
     new Map()
   );

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -72,25 +72,31 @@ export const getDuplicatedQCodes = (flattenedAnswers, { dataVersion }) => {
     (acc, { qCode, type, additionalAnswer }) => {
       const { qCode: additionalAnswerQCode } = additionalAnswer || {};
 
-      if (qCode) {
-        // If dataVersion is 3, do not check if a QCode has the same value as a checkbox option's QCode
-        if (dataVersion === "3" && type !== CHECKBOX_OPTION) {
+      if (dataVersion === "3") {
+        if (qCode && type !== CHECKBOX_OPTION) {
           const currentValue = acc.get(qCode);
           acc.set(qCode, currentValue ? currentValue + 1 : 1);
         }
-        // If dataVersion is not 3, do not check if a QCode has the same value as a checkbox answer's QCode
-        else if (dataVersion !== "3" && type !== CHECKBOX) {
+
+        if (additionalAnswerQCode) {
+          const currentValue = acc.get(additionalAnswerQCode);
+          acc.set(additionalAnswerQCode, currentValue ? currentValue + 1 : 1);
+        }
+        return acc;
+      }
+
+      if (dataVersion !== "3") {
+        if (qCode && type !== CHECKBOX) {
           const currentValue = acc.get(qCode);
           acc.set(qCode, currentValue ? currentValue + 1 : 1);
         }
-      }
 
-      if (additionalAnswerQCode) {
-        const currentValue = acc.get(additionalAnswerQCode);
-        acc.set(additionalAnswerQCode, currentValue ? currentValue + 1 : 1);
+        if (additionalAnswerQCode && type !== CHECKBOX_OPTION) {
+          const currentValue = acc.get(additionalAnswerQCode);
+          acc.set(additionalAnswerQCode, currentValue ? currentValue + 1 : 1);
+        }
+        return acc;
       }
-
-      return acc;
     },
     new Map()
   );

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -134,13 +134,16 @@ export const QCodeContextProvider = ({ questionnaire = {}, children }) => {
     duplicatedQCodes?.length ||
     getEmptyQCodes(answerRows, questionnaire.dataVersion);
 
+  const dataVersion = questionnaire?.dataVersion;
+
   const value = useMemo(
     () => ({
       answerRows,
       duplicatedQCodes,
+      dataVersion,
       hasQCodeError,
     }),
-    [answerRows, duplicatedQCodes, hasQCodeError]
+    [answerRows, duplicatedQCodes, dataVersion, hasQCodeError]
   );
 
   return (


### PR DESCRIPTION
Added support to allow q-codes to be entered for other answer in checkboxes.

To test

- Add a list
- Add a checkbox answer
- add an 'Other option'
- check you can record a q-code for it on the q-code page.