### PR TITLE
Fix to placeholder in Import Content dialogs

### DIFF
--- a/eq-author/src/components/QuestionPicker/index.js
+++ b/eq-author/src/components/QuestionPicker/index.js
@@ -190,6 +190,7 @@ const QuestionPicker = ({
           <SearchBar
             size="large"
             onChange={({ value }) => setSearchTerm(value)}
+            placeholder="Search questions"
           />
         )}
         {warningPanel && (

--- a/eq-author/src/components/QuestionPicker/index.test.js
+++ b/eq-author/src/components/QuestionPicker/index.test.js
@@ -72,9 +72,10 @@ describe("QuestionPicker", () => {
 
   describe("Testing the search UI", () => {
     it("Types pet into the search bar and returns the question Why do you not have pets?", () => {
-      const { getByText, getByTestId, queryByText } = renderQuestionPicker({});
+      const { getByText, queryByPlaceholderText, queryByText } =
+        renderQuestionPicker({});
 
-      const searchBar = getByTestId("search-bar");
+      const searchBar = queryByPlaceholderText("Search questions");
 
       fireEvent.change(searchBar, {
         target: { value: "pet" },
@@ -85,9 +86,10 @@ describe("QuestionPicker", () => {
     });
 
     it("Types car into the search bar and returns the question Do you have a car && what colour car do you have?", () => {
-      const { getByText, getByTestId, queryByText } = renderQuestionPicker({});
+      const { getByText, queryByPlaceholderText, queryByText } =
+        renderQuestionPicker({});
 
-      const searchBar = getByTestId("search-bar");
+      const searchBar = queryByPlaceholderText("Search questions");
 
       fireEvent.change(searchBar, {
         target: { value: "car" },
@@ -119,8 +121,8 @@ describe("QuestionPicker", () => {
           <QuestionPicker isOpen {...defaultPropsWithSearchFalse} {...args} />
         );
 
-      const { queryByTestId } = renderQuestionPicker({});
-      const searchBar = queryByTestId("search-bar");
+      const { queryByPlaceholderText } = renderQuestionPicker({});
+      const searchBar = queryByPlaceholderText("Search questions");
 
       expect(searchBar).toBeNull();
     });

--- a/eq-author/src/components/SectionPicker/index.js
+++ b/eq-author/src/components/SectionPicker/index.js
@@ -124,6 +124,7 @@ const SectionPicker = ({
           <SearchBar
             size="large"
             onChange={({ value }) => setSearchTerm(value)}
+            placeholder="Search sections"
           />
         )}
       </Header>

--- a/eq-author/src/components/SectionPicker/index.test.js
+++ b/eq-author/src/components/SectionPicker/index.test.js
@@ -76,9 +76,10 @@ describe("SectionPicker", () => {
 
   describe("Testing the search UI", () => {
     it("Types pet into the search bar and returns the Pets section", () => {
-      const { getByText, getByTestId, queryByText } = renderSectionPicker({});
+      const { getByText, queryByPlaceholderText, queryByText } =
+        renderSectionPicker({});
 
-      const searchBar = getByTestId("search-bar");
+      const searchBar = queryByPlaceholderText("Search sections");
 
       fireEvent.change(searchBar, {
         target: { value: "pet" },
@@ -89,9 +90,10 @@ describe("SectionPicker", () => {
     });
 
     it("Types pet into the search bar and returns the sections Pets and Pets 2", () => {
-      const { getByText, getByTestId, queryByText } = renderSectionPicker({});
+      const { getByText, queryByPlaceholderText, queryByText } =
+        renderSectionPicker({});
 
-      const searchBar = getByTestId("search-bar");
+      const searchBar = queryByPlaceholderText("Search sections");
 
       fireEvent.change(searchBar, {
         target: { value: "pet" },
@@ -103,9 +105,10 @@ describe("SectionPicker", () => {
     });
 
     it("Renders no results component if section is not found", () => {
-      const { getByText, getByTestId, queryByText } = renderSectionPicker({});
+      const { getByText, queryByPlaceholderText, queryByText } =
+        renderSectionPicker({});
 
-      const searchBar = getByTestId("search-bar");
+      const searchBar = queryByPlaceholderText("Search sections");
 
       fireEvent.change(searchBar, {
         target: { value: "house" },
@@ -119,8 +122,10 @@ describe("SectionPicker", () => {
     });
 
     it("Does not show the search bar if showSearch is false", () => {
-      const { queryByTestId } = renderSectionPicker({ showSearch: false });
-      const searchBar = queryByTestId("search-bar");
+      const { queryByPlaceholderText } = renderSectionPicker({
+        showSearch: false,
+      });
+      const searchBar = queryByPlaceholderText("Search sections");
 
       expect(searchBar).toBeNull();
     });


### PR DESCRIPTION
### What is the context of this PR?

Updates the search input placeholder text in the modal for Importing Content, for Questions and Sections
Also tweaks the testing to find the input by placeholder text rather than testId

### How to review

1. Ensure you have at least 2 questionnaires to work with
2. Open a questionnaire, and 'Add / Import content' > 'Import content'
3. Select a questionnaire
4. Select 'Questions' and ensure that the placeholder in the search box says 'Select questions'
5. Click cancel
6. Select 'Sections' and ensure that the placeholder in the search box says 'Select sections'

### Links

Jira: https://jira.ons.gov.uk/browse/EAR-1915