### PR TITLE
EAR-1967 Incorrect QCode warning icon

### DIFF
--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -8,6 +8,7 @@ import {
   CHECKBOX_OPTION,
   MUTUALLY_EXCLUSIVE,
   ANSWER_OPTION_TYPES,
+  SELECT_OPTION,
 } from "constants/answer-types";
 
 export const QCodeContext = createContext();
@@ -112,14 +113,15 @@ const getEmptyQCodes = (answerRows, dataVersion) => {
   if (dataVersion === "3") {
     return answerRows?.find(
       ({ qCode, type }) =>
-        !qCode && ![CHECKBOX_OPTION, RADIO_OPTION].includes(type)
+        !qCode && ![CHECKBOX_OPTION, RADIO_OPTION, SELECT_OPTION].includes(type)
     );
   }
   // If dataVersion is not 3, checkbox answers and radio options do not have QCodes, and therefore these can be empty
   // This removes the error badge from the main navigation QCodes tab when data version is not 3 and a checkbox answer is empty from when it previously used data version 3
   else {
     return answerRows?.find(
-      ({ qCode, type }) => !qCode && ![CHECKBOX, RADIO_OPTION].includes(type)
+      ({ qCode, type }) =>
+        !qCode && ![CHECKBOX, RADIO_OPTION, SELECT_OPTION].includes(type)
     );
   }
 };


### PR DESCRIPTION
### What is the context of this PR?

A bug was found where if the new 'select' answer type as used, the error marker on the qCodes nav option was displayed, even though no qCodes were missing.
Change was made to add SELECT_OPTION to the exclusions for 'calculating' if qCodes are missing, the same as already implemented for RADIO_OPTION

### How to review

1. Whilst on the master branch, add a question with a 'select' answer type
2. Check that the left nav qCodes option has the orange 'error' marker when the QCodes pages has no outstanding missing values
3. Switch to this branch
4. Check that the left nav qCodes option no longer has the orange 'error' marker when the QCodes pages has no outstanding missing values
