### PR TITLE
EAR-1775 Add health and social themes

### DIFF
--- a/eq-author-api/constants/themes.js
+++ b/eq-author-api/constants/themes.js
@@ -8,6 +8,8 @@ const THEME_SHORT_NAMES = [
   "ukis",
   "ukis_ni",
   "orr",
+  "social",
+  "health",
 ];
 
 module.exports = { THEME_SHORT_NAMES };

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1109,6 +1109,7 @@ const Resolvers = {
         "Northern Ireland": "northernireland",
         ONS: "default",
         Social: "social",
+        Health: "health",
         "UKIS Northern Ireland": "ukis_ni",
         "UKIS ONS": "ukis",
       };

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -552,6 +552,7 @@ enum AnswerType {
 enum ThemeShortName {
   default
   social
+  health
   census
   northernireland
   covid

--- a/eq-author/src/App/settings/ThemesPage.test.js
+++ b/eq-author/src/App/settings/ThemesPage.test.js
@@ -79,6 +79,24 @@ describe("Themes page", () => {
             shortName: "ukis_ni",
             validationErrorInfo: { errors: [] },
           },
+          {
+            title: "Office of Rail and Road theme",
+            legalBasisCode: "NOTICE_1",
+            shortName: "orr",
+            validationErrorInfo: { errors: [] },
+          },
+          {
+            title: "Social theme",
+            legalBasisCode: "NOTICE_1",
+            shortName: "social",
+            validationErrorInfo: { errors: [] },
+          },
+          {
+            title: "Health NI theme",
+            legalBasisCode: "NOTICE_1",
+            shortName: "health",
+            validationErrorInfo: { errors: [] },
+          },
         ],
       },
       displayName: "Tests",
@@ -151,7 +169,13 @@ describe("Themes page", () => {
     useMutation.mockImplementation(() => [toggleTheme]);
     renderThemesPage(mockQuestionnaire);
 
+    expect(screen.getByText(`GB theme`)).toBeVisible();
+    expect(screen.getByText(`NI theme`)).toBeVisible();
     expect(screen.getByText(`UKIS theme`)).toBeVisible();
+    expect(screen.getByText(`UKIS NI theme`)).toBeVisible();
+    expect(screen.getByText(`Office of Rail and Road theme`)).toBeVisible();
+    expect(screen.getByText(`Social theme`)).toBeVisible();
+    expect(screen.getByText(`Health theme`)).toBeVisible();
   });
 
   it("Should toggle theme enabled", () => {

--- a/eq-author/src/constants/themeSettings.js
+++ b/eq-author/src/constants/themeSettings.js
@@ -5,4 +5,6 @@ export const THEME_TITLES = {
   ukis: "UKIS theme",
   ukis_ni: "UKIS NI theme", //eslint-disable-line
   orr: "Office of Rail and Road theme",
+  health: "Health theme",
+  social: "Social theme",
 };


### PR DESCRIPTION
### What is the context of this PR?

Adds 2 additional theme options for 'social' and 'health' to questionnaires

### How to review

Check that theme options for 'social' and 'health' exist on the Settings > Themes page
Check that selecting them updates the export, setting primaryTheme and the appropriate theme > shortName