### PR TITLE
EAR 1815 Answer required and mutually exclusive

### DIFF
--- a/eq-author/src/App/page/Design/answers/DateSingle/index.js
+++ b/eq-author/src/App/page/Design/answers/DateSingle/index.js
@@ -28,7 +28,11 @@ export const DateSingle = ({ answer, onChange, onUpdate, ...otherProps }) => {
         showDummyDate={false}
         {...otherProps}
       />
-      <AnswerProperties answer={answer} updateAnswer={updateAnswer} />
+      <AnswerProperties
+        answer={answer}
+        updateAnswer={updateAnswer}
+        page={otherProps.page}
+      />
       <AdvancedProperties answer={answer} updateAnswer={updateAnswer}>
         <AnswerValidation answer={answer} />
       </AdvancedProperties>

--- a/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/MultipleChoiceAnswer/index.js
@@ -167,7 +167,11 @@ export const UnwrappedMultipleChoiceAnswer = ({
           />
         </Field>
       )}
-      <AnswerProperties answer={answer} updateAnswer={updateAnswer} />
+      <AnswerProperties
+        answer={answer}
+        updateAnswer={updateAnswer}
+        page={otherProps.page}
+      />
       {type === SELECT && (
         <Collapsible title="Why is there a minimum requirement of 25 labels?">
           <CollapsibleContent>

--- a/eq-author/src/components/AnswerContent/AnswerProperties/CheckboxProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/CheckboxProperties.js
@@ -2,13 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import Required from "components/AnswerContent/Required";
 
-const CheckboxProperties = ({ answer, updateAnswer }) => {
-  return <Required answer={answer} updateAnswer={updateAnswer} />;
+const CheckboxProperties = ({
+  answer,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => {
+  return (
+    <Required
+      answer={answer}
+      updateAnswer={updateAnswer}
+      hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+    />
+  );
 };
 
 CheckboxProperties.propTypes = {
   answer: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default CheckboxProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/DateProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/DateProperties.js
@@ -11,7 +11,11 @@ const StyledSelect = styled(Select)`
 
 const monthText = "mm";
 
-const DateProperties = ({ answer, updateAnswer }) => {
+const DateProperties = ({
+  answer,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => {
   const onUpdateFormat = ({ value }) => {
     updateAnswer({
       variables: {
@@ -46,7 +50,11 @@ const DateProperties = ({ answer, updateAnswer }) => {
           </option>
         </StyledSelect>
       </MultiLineField>
-      <Required answer={answer} updateAnswer={updateAnswer} />
+      <Required
+        answer={answer}
+        updateAnswer={updateAnswer}
+        hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+      />
     </>
   );
 };
@@ -54,6 +62,7 @@ const DateProperties = ({ answer, updateAnswer }) => {
 DateProperties.propTypes = {
   answer: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func.isRequired,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default DateProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/DurationProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/DurationProperties.js
@@ -16,6 +16,7 @@ const DurationProperties = ({
   page,
   updateAnswer,
   updateAnswerOfType,
+  hasMutuallyExclusiveAnswer,
 }) => {
   const sortedUnits = groupBy(durationTypes.durationConversion, "type");
   const onUpdateUnit = (value) => {
@@ -50,7 +51,11 @@ const DurationProperties = ({
           })}
         </StyledSelect>
       </MultiLineField>
-      <Required answer={answer} updateAnswer={updateAnswer} />
+      <Required
+        answer={answer}
+        updateAnswer={updateAnswer}
+        hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+      />
     </>
   );
 };
@@ -60,6 +65,7 @@ DurationProperties.propTypes = {
   page: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
   updateAnswerOfType: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default DurationProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/NumberProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/NumberProperties.js
@@ -9,6 +9,7 @@ const NumberProperties = ({
   page,
   updateAnswer,
   updateAnswerOfType,
+  hasMutuallyExclusiveAnswer,
 }) => {
   return (
     <>
@@ -22,7 +23,11 @@ const NumberProperties = ({
           value={answer.properties.decimals}
         />
       </MultiLineField>
-      <Required answer={answer} updateAnswer={updateAnswer} />
+      <Required
+        answer={answer}
+        updateAnswer={updateAnswer}
+        hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+      />
     </>
   );
 };
@@ -32,6 +37,7 @@ NumberProperties.propTypes = {
   page: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
   updateAnswerOfType: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default NumberProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/SelectProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/SelectProperties.js
@@ -2,13 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import Required from "components/AnswerContent/Required";
 
-const SelectProperties = ({ answer, updateAnswer }) => {
-  return <Required answer={answer} updateAnswer={updateAnswer} />;
+const SelectProperties = ({
+  answer,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => {
+  return (
+    <Required
+      answer={answer}
+      updateAnswer={updateAnswer}
+      hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+    />
+  );
 };
 
 SelectProperties.propTypes = {
   answer: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default SelectProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.js
@@ -20,7 +20,11 @@ const SmallNumber = styled(Number)`
   }
 `;
 
-const TextAreaProperties = ({ answer, updateAnswer }) => {
+const TextAreaProperties = ({
+  answer,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => {
   const errors = filter(answer.validationErrorInfo.errors, {
     field: "maxLength",
   });
@@ -63,7 +67,11 @@ const TextAreaProperties = ({ answer, updateAnswer }) => {
           {textAreaErrors[errors[0].errorCode].message}
         </ValidationError>
       )}
-      <Required answer={answer} updateAnswer={updateAnswer} />
+      <Required
+        answer={answer}
+        updateAnswer={updateAnswer}
+        hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+      />
     </>
   );
 };
@@ -72,6 +80,7 @@ TextAreaProperties.propTypes = {
   answer: PropTypes.object, //eslint-disable-line
   page: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default TextAreaProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.test.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.test.js
@@ -4,7 +4,8 @@ import TextAreaProperties from "./TextAreaProperties";
 import { colors } from "constants/theme";
 import { act } from "react-dom/test-utils";
 
-const renderTextProperties = (props) => render(<TextAreaProperties {...props} />);
+const renderTextProperties = (props) =>
+  render(<TextAreaProperties {...props} />);
 
 describe("Text Property", () => {
   let props;
@@ -40,7 +41,7 @@ describe("Text Property", () => {
 
     act(() => {
       fireEvent.change(inputBox, {
-        target: { value: "" },
+        target: { value: null },
       });
     });
 
@@ -50,6 +51,24 @@ describe("Text Property", () => {
       await flushPromises();
     });
     expect(inputBox.value).toBe("2000");
+  });
+
+  it("should not change input box value if within max length range", async () => {
+    const { getByTestId } = renderTextProperties(props);
+    const inputBox = getByTestId("maxCharacterInput");
+
+    act(() => {
+      fireEvent.change(inputBox, {
+        target: { value: 50 },
+      });
+    });
+
+    expect(inputBox.value).toBe("50");
+    await act(async () => {
+      fireEvent.blur(inputBox);
+      await flushPromises();
+    });
+    expect(inputBox.value).toBe("50");
   });
 
   it("when max character is out of range, box border should be errorPrimary", async () => {

--- a/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.test.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/TextAreaProperties.test.js
@@ -53,7 +53,7 @@ describe("Text Property", () => {
     expect(inputBox.value).toBe("2000");
   });
 
-  it("should not change input box value if within max length range", async () => {
+  it("should change input box value if within max length range", async () => {
     const { getByTestId } = renderTextProperties(props);
     const inputBox = getByTestId("maxCharacterInput");
 

--- a/eq-author/src/components/AnswerContent/AnswerProperties/TextFieldProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/TextFieldProperties.js
@@ -2,11 +2,22 @@ import React from "react";
 import PropTypes from "prop-types";
 import Required from "components/AnswerContent/Required";
 
-const TextFieldProperties = ({ answer, updateAnswer }) => (<Required answer={answer} updateAnswer={updateAnswer} />);
+const TextFieldProperties = ({
+  answer,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => (
+  <Required
+    answer={answer}
+    updateAnswer={updateAnswer}
+    hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+  />
+);
 
 TextFieldProperties.propTypes = {
   updateAnswer: PropTypes.func,
   answer: PropTypes.object, //eslint-disable-line
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default TextFieldProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.js
@@ -50,7 +50,13 @@ const filterUnitOptions = (options, query) => {
   return [common];
 };
 
-const UnitProperties = ({ answer, page, updateAnswer, updateAnswerOfType }) => {
+const UnitProperties = ({
+  answer,
+  page,
+  updateAnswer,
+  updateAnswerOfType,
+  hasMutuallyExclusiveAnswer,
+}) => {
   const errors = filter(answer.validationErrorInfo.errors, { field: "unit" });
   const onUpdateUnit = (value) => {
     updateAnswerOfType({
@@ -102,7 +108,11 @@ const UnitProperties = ({ answer, page, updateAnswer, updateAnswerOfType }) => {
           value={answer.properties.decimals}
         />
       </MultiLineField>
-      <Required answer={answer} updateAnswer={updateAnswer} />
+      <Required
+        answer={answer}
+        updateAnswer={updateAnswer}
+        hasMutuallyExclusiveAnswer={hasMutuallyExclusiveAnswer}
+      />
     </>
   );
 };
@@ -112,6 +122,7 @@ UnitProperties.propTypes = {
   page: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func,
   updateAnswerOfType: PropTypes.func,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default UnitProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.test.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.test.js
@@ -57,4 +57,42 @@ describe("Required Property", () => {
     userEvent.type(getByTestId(inputId), `{enter}`);
     expect(props.updateAnswerOfType).toHaveBeenCalledTimes(1);
   });
+
+  it("should set default value for unit", () => {
+    props.answer.properties.unit = "";
+    const { getByTestId } = renderUnitProperties(props);
+    getByTestId(inputId).focus();
+    fireEvent.change(getByTestId(inputId), { target: { value: "" } });
+    fireEvent.keyDown(getByTestId(inputId), {
+      key: ArrowDown,
+      code: ArrowDown,
+    });
+    userEvent.type(getByTestId(inputId), `{enter}`);
+    expect(props.updateAnswerOfType).toHaveBeenCalledTimes(1);
+  });
+
+  it("should check for errors", () => {
+    props.answer.properties.unit = "";
+    props.answer.validationErrorInfo = {
+      totalCount: 1,
+      errors: [
+        {
+          id: "1",
+          field: "unit",
+          errorCode: "ERR_VALID_REQUIRED",
+        },
+      ],
+      id: "1",
+    };
+
+    const { getByTestId } = renderUnitProperties(props);
+    getByTestId(inputId).focus();
+    fireEvent.change(getByTestId(inputId), { target: { value: "" } });
+    fireEvent.keyDown(getByTestId(inputId), {
+      key: ArrowDown,
+      code: ArrowDown,
+    });
+    userEvent.type(getByTestId(inputId), `{enter}`);
+    expect(props.updateAnswerOfType).toHaveBeenCalledTimes(1);
+  });
 });

--- a/eq-author/src/components/AnswerContent/AnswerProperties/index.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/index.js
@@ -23,9 +23,21 @@ import {
   DURATION,
   DATE,
   SELECT,
+  MUTUALLY_EXCLUSIVE,
 } from "constants/answer-types";
 
 const AnswerProperties = (props) => {
+  props = {
+    ...props,
+    hasMutuallyExclusiveAnswer: false,
+  };
+
+  if (props.page) {
+    props.hasMutuallyExclusiveAnswer = props.page.answers.some(
+      ({ type }) => type === MUTUALLY_EXCLUSIVE
+    );
+  }
+
   if ([NUMBER, CURRENCY, PERCENTAGE].includes(props.answer.type)) {
     return <NumberProperties {...props} />;
   }
@@ -61,6 +73,8 @@ const AnswerProperties = (props) => {
 
 AnswerProperties.propTypes = {
   answer: CustomPropTypes.answer.isRequired,
+  page: CustomPropTypes.page,
+  hasMutuallyExclusiveAnswer: CustomPropTypes.hasMutuallyExclusiveAnswer,
 };
 
 export default AnswerProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/index.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/index.js
@@ -74,7 +74,6 @@ const AnswerProperties = (props) => {
 AnswerProperties.propTypes = {
   answer: CustomPropTypes.answer.isRequired,
   page: CustomPropTypes.page,
-  hasMutuallyExclusiveAnswer: CustomPropTypes.hasMutuallyExclusiveAnswer,
 };
 
 export default AnswerProperties;

--- a/eq-author/src/components/AnswerContent/AnswerProperties/index.test.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/index.test.js
@@ -1,0 +1,277 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import AnswerProperties from "./";
+
+describe("Answer Properties", () => {
+  let data,
+    data2,
+    onClose,
+    onSubmit,
+    updateAnswerOfType,
+    updateAnswer,
+    startingSelectedAnswers,
+    title,
+    showTypes,
+    answer,
+    props;
+
+  const validationErrorInfo = {
+    errors: [],
+    id: "eror-1",
+    totalCount: "0",
+    __typename: "ValidationErrorInfo",
+  };
+
+  beforeEach(() => {
+    onClose = jest.fn();
+    onSubmit = jest.fn();
+    updateAnswerOfType = jest.fn();
+    updateAnswer = jest.fn();
+    startingSelectedAnswers = [];
+    title = "Select one or more answer";
+    data = [
+      {
+        id: "section 1",
+        displayName: "Untitled Section",
+        folders: [
+          {
+            pages: [
+              {
+                id: "Page 1",
+                displayName: "Page 1",
+                answers: [
+                  {
+                    id: "Number 1",
+                    displayName: "Number 1",
+                    type: "Number",
+                    properties: {
+                      decimals: 0,
+                    },
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Unit 1",
+                    displayName: "Unit 1",
+                    type: "Unit",
+                    properties: {
+                      unit: "Centimetres",
+                      decimals: 0,
+                    },
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Duration 1",
+                    displayName: "Duration 1",
+                    type: "Duration",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "TextField 1",
+                    displayName: "TextField 1",
+                    type: "TextField",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "TextArea 1",
+                    displayName: "TextArea 1",
+                    type: "TextArea",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Date 1",
+                    displayName: "Date 1",
+                    type: "Date",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "DateRange 1",
+                    displayName: "DateRange 1",
+                    type: "DateRange",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Radio 1",
+                    displayName: "Radio 1",
+                    type: "Radio",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Checkbox 1",
+                    displayName: "Checkbox 1",
+                    type: "Checkbox",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "Select 1",
+                    displayName: "Select 1",
+                    type: "Select",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    data2 = [
+      {
+        id: "section 1",
+        displayName: "Untitled Section",
+        folders: [
+          {
+            pages: [
+              {
+                id: "Page 1",
+                displayName: "Page 1",
+                answers: [
+                  {
+                    id: "Checkbox 1",
+                    displayName: "Checkbox 1",
+                    type: "Checkbox",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                  {
+                    id: "MutuallyExclusive 1",
+                    displayName: "MutuallyExclusive 1",
+                    type: "MutuallyExclusive",
+                    properties: {},
+                    validationErrorInfo: validationErrorInfo,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    props = {
+      data,
+      onClose,
+      onSubmit,
+      startingSelectedAnswers,
+      title,
+      answer,
+      showTypes,
+      updateAnswerOfType,
+      updateAnswer,
+    };
+  });
+
+  const renderAnswerProperties = () =>
+    render(<AnswerProperties {...props} isOpen />);
+
+  it("should check that Number properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[0],
+      value: 0,
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Number 1")).toBeInTheDocument();
+  });
+
+  it("should check that Unit properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[1],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Unit 1")).toBeInTheDocument();
+  });
+
+  it("should check that Duration properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[2],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Duration 1")).toBeInTheDocument();
+  });
+
+  it("should check that TextField properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[3],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("TextField 1")).toBeInTheDocument();
+  });
+
+  it("should check that TextArea properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[4],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("TextArea 1")).toBeInTheDocument();
+  });
+
+  it("should check that Date properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[5],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Date 1")).toBeInTheDocument();
+  });
+
+  it("should check that DateRange properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[6],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("DateRange 1")).toBeInTheDocument();
+  });
+
+  it("should check that Radio properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[7],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Radio 1")).toBeInTheDocument();
+  });
+
+  it("should check that Checkbox properties are called", () => {
+    props = {
+      ...props,
+      answer: data2[0].folders[0].pages[0].answers[0],
+      page: data2[0].folders[0].pages[0],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Checkbox 1")).toBeInTheDocument();
+  });
+
+  it("should check that Select properties are called", () => {
+    props = {
+      ...props,
+      answer: data[0].folders[0].pages[0].answers[9],
+    };
+    const { getByTestId } = renderAnswerProperties();
+
+    expect(getByTestId("Select 1")).toBeInTheDocument();
+  });
+});

--- a/eq-author/src/components/AnswerContent/Required/index.js
+++ b/eq-author/src/components/AnswerContent/Required/index.js
@@ -3,8 +3,14 @@ import PropTypes from "prop-types";
 
 import InlineField from "components/AnswerContent/Format/InlineField";
 import ToggleSwitch from "components/buttons/ToggleSwitch";
+import { InformationPanel } from "components/Panel";
 
-const Required = ({ answer, label, updateAnswer }) => {
+const Required = ({
+  answer,
+  label,
+  updateAnswer,
+  hasMutuallyExclusiveAnswer,
+}) => {
   const onUpdateRequired = ({ value }) => {
     updateAnswer({
       variables: {
@@ -16,17 +22,24 @@ const Required = ({ answer, label, updateAnswer }) => {
     });
   };
   return (
-    <InlineField id={answer.id} label={label}>
-      <ToggleSwitch
-        data-test="answer-properties-required-toggle"
-        name="required"
-        id={answer.id}
-        onChange={onUpdateRequired}
-        checked={answer.properties.required}
-        hideLabels={false}
-        ariaLabel={label}
-      />
-    </InlineField>
+    <>
+      <InlineField id={answer.id} label={label}>
+        <ToggleSwitch
+          data-test="answer-properties-required-toggle"
+          name="required"
+          id={answer.id}
+          onChange={onUpdateRequired}
+          checked={answer.properties.required}
+          hideLabels={false}
+          ariaLabel={label}
+        />
+      </InlineField>
+      {hasMutuallyExclusiveAnswer && (
+        <InformationPanel>
+          Answer required setting also applies to OR answer type.
+        </InformationPanel>
+      )}
+    </>
   );
 };
 
@@ -34,6 +47,7 @@ Required.propTypes = {
   answer: PropTypes.object, //eslint-disable-line
   updateAnswer: PropTypes.func.isRequired,
   label: PropTypes.string,
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 Required.defaultProps = {

--- a/eq-author/src/custom-prop-types/index.js
+++ b/eq-author/src/custom-prop-types/index.js
@@ -119,7 +119,6 @@ const CustomPropTypes = {
     email: PropTypes.string.isRequired,
     picture: PropTypes.string,
   }),
-  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default CustomPropTypes;

--- a/eq-author/src/custom-prop-types/index.js
+++ b/eq-author/src/custom-prop-types/index.js
@@ -119,6 +119,7 @@ const CustomPropTypes = {
     email: PropTypes.string.isRequired,
     picture: PropTypes.string,
   }),
+  hasMutuallyExclusiveAnswer: PropTypes.bool,
 };
 
 export default CustomPropTypes;


### PR DESCRIPTION

### What is the context of this PR?

> When a mutually exclusive answer is added then a banner is placed below the answer required toggle switch of the main answer to indicate that the answer required will also apply to the mutually exclusive answer.
>
> E.g. _"Currently, if you add a new question to Author the entire app crashed. This is because..."_

### How to review

> Add to the list below as appropriate, including screenshots when necessary

- Create a questions with answers of type Number, Unit, Duration, TextField, TextArea, Date, Checkbox and Select.
- For each of the above check that Answer Required has a banner below it when a Mutually Exclusive answer is added and not shown before and after the Mutually Exlusive answer is removed.
- Check that DateRange and Radio cannot have mutually exclusive answer added and that the banner is not shown below the Answer Required toggle switch.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
