### PR TITLE
EAR-1972 Change default theme

### DIFF
--- a/eq-author-api/constants/themes.js
+++ b/eq-author-api/constants/themes.js
@@ -1,5 +1,5 @@
 const THEME_SHORT_NAMES = [
-  "default",
+  "business",
   "northernireland",
   "covid",
   "epe",

--- a/eq-author-api/db/datastore/datastore-firestore.test.js
+++ b/eq-author-api/db/datastore/datastore-firestore.test.js
@@ -90,7 +90,7 @@ describe("Firestore Datastore", () => {
 
     questionnaireWithoutSections = {
       ...baseQuestionnaire,
-      theme: "default",
+      theme: "business",
       legalBasis: "Voluntary",
       navigation: false,
       metadata: [],

--- a/eq-author-api/db/datastore/mock-questionnaire.js
+++ b/eq-author-api/db/datastore/mock-questionnaire.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require("uuid");
 const mockQuestionnaire = () => {
   const questionnaire = {
     title: "Working from home",
-    theme: "default",
+    theme: "business",
     legalBasis: "Voluntary",
     navigation: false,
     metadata: [],

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -39,6 +39,7 @@ const migrations = [
   require("./updateMutuallyExclusive"),
   require("./addDataVersion"),
   require("./updateUKIStoBEISTheme"),
+  require("./updateDefaultToBusinessTheme"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateDefaultToBusinessTheme.js
+++ b/eq-author-api/migrations/updateDefaultToBusinessTheme.js
@@ -1,0 +1,17 @@
+module.exports = (questionnaire) => {
+  questionnaire.themeSettings.themes.forEach((theme) => {
+    if (theme.shortName === "default") {
+      theme.shortName = "business";
+      theme.id = "business";
+    }
+  });
+
+  if (questionnaire.themeSettings.previewTheme === "default") {
+    questionnaire.themeSettings.previewTheme = "business";
+  }
+
+  if (questionnaire.theme === "default") {
+    questionnaire.theme = "business";
+  }
+  return questionnaire;
+};

--- a/eq-author-api/migrations/updateDefaultToBusinessTheme.test.js
+++ b/eq-author-api/migrations/updateDefaultToBusinessTheme.test.js
@@ -1,0 +1,27 @@
+const updateUKIStoBEISTheme = require("./updateDefaultToBusinessTheme");
+
+describe("updateDefaultThemes", () => {
+  it("should update default theme", () => {
+    const questionnaire = {
+      themeSettings: {
+        id: "1",
+        previewTheme: "default",
+        themes: [
+          {
+            enabled: true,
+            shortName: "default",
+            legalBasisCode: "VOLUNTARY",
+            eqId: "123",
+            formType: "1234",
+            id: "default",
+          },
+        ],
+      },
+    };
+
+    const updatedTheme = updateUKIStoBEISTheme(questionnaire);
+    expect(updatedTheme.themeSettings.themes[0].shortName).toBe("business");
+    expect(updatedTheme.themeSettings.themes[0].id).toBe("business");
+    expect(updatedTheme.themeSettings.previewTheme).toBe("business");
+  });
+});

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -139,11 +139,11 @@ const deleteLastPageRouting = require("../../src/businessLogic/deleteLastPageRou
 
 const createNewQuestionnaire = (input) => {
   const defaultTheme = createTheme({
-    shortName: "default",
+    shortName: "business",
   });
   const defaultQuestionnaire = {
     id: uuidv4(),
-    theme: "default",
+    theme: "business",
     qcodes: true,
     navigation: false,
     hub: false,
@@ -1107,7 +1107,7 @@ const Resolvers = {
     triggerPublish: createMutation(async (root, { input }, ctx) => {
       const themeLookup = {
         "Northern Ireland": "northernireland",
-        ONS: "default",
+        Business: "business",
         Social: "social",
         Health: "health",
         "UKIS Northern Ireland": "ukis_ni",

--- a/eq-author-api/schema/tests/folder.test.js
+++ b/eq-author-api/schema/tests/folder.test.js
@@ -27,7 +27,7 @@ describe("Folders", () => {
       title: "Ratchet and Clank",
       description: "A survey about an amazing game",
       surveyId: "015",
-      theme: "default",
+      theme: "business",
       navigation: false,
       summary: false,
       type: "Business",

--- a/eq-author-api/schema/tests/lists.test.js
+++ b/eq-author-api/schema/tests/lists.test.js
@@ -21,7 +21,7 @@ describe("Lists", () => {
       title: "Ratchet and Clank",
       description: "A survey about an amazing game",
       surveyId: "015",
-      theme: "default",
+      theme: "business",
       navigation: false,
       summary: false,
       type: "Business",

--- a/eq-author-api/schema/tests/questionnaire.test.js
+++ b/eq-author-api/schema/tests/questionnaire.test.js
@@ -70,7 +70,7 @@ describe("questionnaire", () => {
         title: "Questionnaire",
         description: "Description",
         surveyId: "1",
-        theme: "default",
+        theme: "business",
         navigation: false,
         summary: false,
         type: SOCIAL,
@@ -119,11 +119,11 @@ describe("questionnaire", () => {
       });
       expect(questionnaire).toMatchObject({
         themeSettings: {
-          previewTheme: "default",
+          previewTheme: "business",
           themes: expect.arrayContaining([
             expect.objectContaining({
               id: expect.any(String),
-              shortName: "default",
+              shortName: "business",
               legalBasisCode: "NOTICE_1",
               eqId: "",
               formType: "",
@@ -140,11 +140,11 @@ describe("questionnaire", () => {
       });
       expect(questionnaire).toMatchObject({
         themeSettings: {
-          previewTheme: "default",
+          previewTheme: "business",
           themes: expect.arrayContaining([
             expect.objectContaining({
               id: expect.any(String),
-              shortName: "default",
+              shortName: "business",
               legalBasisCode: "NOTICE_1",
               eqId: "",
               formType: "",
@@ -170,7 +170,7 @@ describe("questionnaire", () => {
         title: "Questionnaire",
         description: "Description",
         surveyId: "1",
-        theme: "default",
+        theme: "business",
         navigation: false,
         summary: false,
         metadata: [{}],
@@ -349,7 +349,7 @@ describe("questionnaire", () => {
         await enableTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "default",
+            shortName: "business",
           },
           ctx
         );
@@ -363,7 +363,7 @@ describe("questionnaire", () => {
         await disableTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "default",
+            shortName: "business",
           },
           ctx
         );
@@ -377,7 +377,7 @@ describe("questionnaire", () => {
         const { themeSettings: initialThemes } = await queryQuestionnaire(ctx);
 
         expect(initialThemes.themes[0].enabled).toBe(true);
-        expect(initialThemes.previewTheme).toBe("default");
+        expect(initialThemes.previewTheme).toBe("business");
 
         await enableTheme(
           {
@@ -396,12 +396,12 @@ describe("questionnaire", () => {
           ).enabled
         ).toBe(true);
 
-        expect(themeSettingsWithTwoThemes.previewTheme).toBe("default");
+        expect(themeSettingsWithTwoThemes.previewTheme).toBe("business");
 
         await disableTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "default",
+            shortName: "business",
           },
           ctx
         );
@@ -435,7 +435,7 @@ describe("questionnaire", () => {
         await updateTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "default",
+            shortName: "business",
             eqId: newEqId,
           },
           ctx
@@ -453,7 +453,7 @@ describe("questionnaire", () => {
         await updateTheme(
           {
             questionnaireId: questionnaire.id,
-            shortName: "default",
+            shortName: "business",
             eqId: newEqId,
             formType: newFormType,
           },
@@ -490,7 +490,7 @@ describe("questionnaire", () => {
             variants: [
               {
                 language: "en",
-                theme: "default",
+                theme: "business",
               },
             ],
           },
@@ -504,7 +504,7 @@ describe("questionnaire", () => {
           {
             questionnaireId: ctx.questionnaire.id,
             surveyId,
-            variants: [{ theme: "ONS", formType: "456" }],
+            variants: [{ theme: "Business", formType: "456" }],
           },
           ctx
         );
@@ -547,7 +547,7 @@ describe("questionnaire", () => {
                 {
                   surveyId,
                   formType: "321",
-                  variants: [{ language: "en", theme: "default" }],
+                  variants: [{ language: "en", theme: "business" }],
                 },
               ],
             }),
@@ -657,7 +657,7 @@ describe("questionnaire", () => {
         title: "Questionnaire",
         description: "Description",
         surveyId: "1",
-        theme: "default",
+        theme: "business",
         navigation: false,
         summary: false,
         type: SOCIAL,
@@ -879,7 +879,7 @@ describe("questionnaire", () => {
         title: "Which Game of Thrones house are you?",
         description: "Description",
         surveyId: "1",
-        theme: "default",
+        theme: "business",
         navigation: false,
         summary: false,
         type: SOCIAL,

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -550,7 +550,7 @@ enum AnswerType {
 }
 
 enum ThemeShortName {
-  default
+  business
   social
   health
   census

--- a/eq-author-api/src/businessLogic/createTheme.js
+++ b/eq-author-api/src/businessLogic/createTheme.js
@@ -1,6 +1,6 @@
 const createTheme = (attrs = {}) => ({
   enabled: true,
-  shortName: "default",
+  shortName: "business",
   legalBasisCode: "NOTICE_1",
   eqId: "",
   formType: "",

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -180,7 +180,7 @@ describe("schema validation", () => {
     it("should return an error if all themes are disabled", () => {
       questionnaire.themeSettings = {
         id: "ts-1",
-        previewTheme: "default",
+        previewTheme: "business",
         themes: [
           {
             id: "theme-1",
@@ -193,7 +193,7 @@ describe("schema validation", () => {
           {
             id: "theme-2",
             enabled: false,
-            shortName: "default",
+            shortName: "business",
             legalBasisCode: "NOTICE_1",
             eqId: "ivan",
             formType: "888",

--- a/eq-author-api/tests/utils/contextBuilder/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/index.js
@@ -63,7 +63,7 @@ const buildContext = async (questionnaireConfig, userConfig = {}) => {
   await createQuestionnaire(ctx, {
     title: "Questionnaire",
     surveyId: "1",
-    theme: "default",
+    theme: "business",
     navigation: false,
     type: SOCIAL,
     ...questionnaireProps,

--- a/eq-author-api/utils/questionnaireEvents.test.js
+++ b/eq-author-api/utils/questionnaireEvents.test.js
@@ -10,7 +10,7 @@ describe("SurveyDetails", () => {
       variants: [
         {
           language: "en",
-          theme: "default",
+          theme: "business",
           authorId: "77df029c-a3ab-4451-8ef5-6a265f0f1b6d",
         },
       ],

--- a/eq-author/src/App/QuestionnaireSettingsModal/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/QuestionnaireSettingsModal/__snapshots__/index.test.js.snap
@@ -28,7 +28,7 @@ exports[`QuestionnaireSettingsModal should render 1`] = `
         "description": "",
         "navigation": false,
         "surveyId": "",
-        "theme": "default",
+        "theme": "business",
         "title": "",
       }
     }

--- a/eq-author/src/App/QuestionnaireSettingsModal/index.js
+++ b/eq-author/src/App/QuestionnaireSettingsModal/index.js
@@ -15,7 +15,7 @@ const defaultQuestionnaire = {
   title: "",
   description: "",
   surveyId: "",
-  theme: "default",
+  theme: "business",
   navigation: false,
 };
 

--- a/eq-author/src/App/settings/LegalBasisSelect/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/settings/LegalBasisSelect/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`LegalBasisField should render 1`] = `
   </p>
   <LegalOption
     key="NOTICE_1"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={true}
     value="NOTICE_1"
@@ -21,7 +21,7 @@ exports[`LegalBasisField should render 1`] = `
   </LegalOption>
   <LegalOption
     key="NOTICE_2"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={false}
     value="NOTICE_2"
@@ -32,7 +32,7 @@ exports[`LegalBasisField should render 1`] = `
   </LegalOption>
   <LegalOption
     key="NOTICE_3"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={false}
     value="NOTICE_3"
@@ -43,7 +43,7 @@ exports[`LegalBasisField should render 1`] = `
   </LegalOption>
   <LegalOption
     key="NOTICE_NI"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={false}
     value="NOTICE_NI"
@@ -54,7 +54,7 @@ exports[`LegalBasisField should render 1`] = `
   </LegalOption>
   <LegalOption
     key="NOTICE_FUELS"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={false}
     value="NOTICE_FUELS"
@@ -65,7 +65,7 @@ exports[`LegalBasisField should render 1`] = `
   </LegalOption>
   <LegalOption
     key="VOLUNTARY"
-    name="default"
+    name="business"
     onChange={[Function]}
     selected={false}
     value="VOLUNTARY"

--- a/eq-author/src/App/settings/LegalBasisSelect/index.test.js
+++ b/eq-author/src/App/settings/LegalBasisSelect/index.test.js
@@ -16,7 +16,7 @@ describe("LegalBasisField", () => {
   beforeEach(() => {
     props = {
       legalBasis: "NOTICE_1",
-      shortName: "default",
+      shortName: "business",
       questionnaireId: "my-fave-questionnaire",
     };
   });

--- a/eq-author/src/App/settings/SettingsPage.test.js
+++ b/eq-author/src/App/settings/SettingsPage.test.js
@@ -37,7 +37,7 @@ describe("Settings page", () => {
       collapsibleSummary: false,
       description: "A questionnaire about a lovable, purple dragon",
       surveyId: "123",
-      theme: "default",
+      theme: "business",
       displayName: "Roar",
       introduction: {
         id: "spyro-1",

--- a/eq-author/src/App/settings/ThemesPage.test.js
+++ b/eq-author/src/App/settings/ThemesPage.test.js
@@ -36,9 +36,9 @@ describe("Themes page", () => {
       collapsibleSummary: false,
       description: "Questionnaire",
       surveyId: "123",
-      theme: "default",
+      theme: "business",
       themeSettings: {
-        previewTheme: "default",
+        previewTheme: "business",
         validationErrorInfo: {
           id: "valid-1",
           errors: [],
@@ -46,9 +46,9 @@ describe("Themes page", () => {
         },
         themes: [
           {
-            title: "GB theme",
+            title: "Business theme",
             legalBasisCode: "NOTICE_1",
-            shortName: "default",
+            shortName: "business",
             enabled: true,
             validationErrorInfo: {
               errors: [
@@ -171,7 +171,7 @@ describe("Themes page", () => {
     useMutation.mockImplementation(() => [toggleTheme]);
     renderThemesPage(mockQuestionnaire);
 
-    expect(screen.getByText(`GB theme`)).toBeVisible();
+    expect(screen.getByText(`Business theme`)).toBeVisible();
     expect(screen.getByText(`NI theme`)).toBeVisible();
     expect(
       screen.getByText(
@@ -219,7 +219,7 @@ describe("Themes page", () => {
     useMutation.mockImplementation(() => [handleEQIdBlur]);
     renderThemesPage(mockQuestionnaire);
 
-    const eqIdInput = screen.getByTestId("default-eq-id-input");
+    const eqIdInput = screen.getByTestId("business-eq-id-input");
 
     fireEvent.change(eqIdInput, {
       target: { value: "123" },
@@ -232,7 +232,7 @@ describe("Themes page", () => {
           input: {
             questionnaireId: expect.any(String),
             eqId: "123",
-            shortName: "default",
+            shortName: "business",
           },
         },
       })
@@ -244,7 +244,7 @@ describe("Themes page", () => {
     useMutation.mockImplementation(() => [handleEQIdBlur]);
     renderThemesPage(mockQuestionnaire);
 
-    const eqIdInput = screen.getByTestId("default-eq-id-input");
+    const eqIdInput = screen.getByTestId("business-eq-id-input");
 
     fireEvent.change(eqIdInput, {
       target: { value: " " },
@@ -257,7 +257,7 @@ describe("Themes page", () => {
           input: {
             questionnaireId: expect.any(String),
             eqId: " ",
-            shortName: "default",
+            shortName: "business",
           },
         },
       })
@@ -275,7 +275,7 @@ describe("Themes page", () => {
     useMutation.mockImplementation(() => [handleFormTypeBlur]);
     renderThemesPage(mockQuestionnaire);
 
-    const formTypeInput = screen.getByTestId("default-form-type-input");
+    const formTypeInput = screen.getByTestId("business-form-type-input");
 
     fireEvent.change(formTypeInput, {
       target: { value: "123" },
@@ -288,7 +288,7 @@ describe("Themes page", () => {
           input: {
             questionnaireId: expect.any(String),
             formType: "123",
-            shortName: "default",
+            shortName: "business",
           },
         },
       })

--- a/eq-author/src/constants/themeSettings.js
+++ b/eq-author/src/constants/themeSettings.js
@@ -1,5 +1,5 @@
 export const THEME_TITLES = {
-  default: "GB theme",
+  business: "Business theme",
   northernireland: "NI theme",
   orr: "Office of Rail and Road theme",
   beis: "Department for Business, Energy and Industrial Strategy theme",


### PR DESCRIPTION
### What is the context of this PR?

Removes the existing 'GB'/default theme, and replaces it with the 'business' theme in the UI
Also changes all instances of the 'default' theme value in 'theme', 'previewTheme' and 'shortName' throughout the code
Uses a migration to update existing values from 'default' to 'business'

Note changes do not fix the known issue with the value of the top level 'theme' not updating, it only changes the value from 'default' to prevent an error with ENUM matching

### How to review

Pre-test
1. Open the UI on the master branch
2. Create a questionnaire set to the 'GB'/default theme
3. Create a questionnaire set to the 'Social' theme

Test change
1. Open the UI on the PR branch
2. Create a new questionnaire
4. Confirm in 'Settings' > 'Themes' that the 'Business' theme is selected by default.
5. Check the export to ensure that the 'business' theme is set to 'true', and the 'previewTheme' value is set to 'business'
6. Change the theme value via the UI, ensuring to deselect the 'business' theme.
7. Ensure the export reflects the change correctly.

Test migration 
1. Still on the PR branch
2. Open the questionnaire that was created with the 'GB'/default theme
3. Check it is now set to the 'Business' theme in the UI and the export 
4. Open the questionnaire that was created with the 'Social' theme
5. Check it is still set to the 'Social' theme in the UI and the export
