### PR TITLE
fix for importing from old questionnaires

### DIFF
--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -550,6 +550,7 @@ enum AnswerType {
 }
 
 enum ThemeShortName {
+  default
   business
   social
   health


### PR DESCRIPTION
Added default to type defs to allow un migrated questionnaires to be imported from.
