### PR TITLE
Fix to Repeating Section Toggle Bug

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -56,6 +56,7 @@ const {
 const {
   getExpressions,
   getSections,
+  getPagesFromSection,
   getSectionById,
   getFolderById,
   getSectionByFolderId,
@@ -1620,6 +1621,7 @@ const Resolvers = {
           id === sectionId && !pageId && !folderId
       ),
     comments: ({ id }, args, ctx) => ctx.comments[id],
+    allowRepeatingSection: (section) => Boolean (findIndex(getPagesFromSection(section), {pageType: "ListCollectorPage"})<0),
   },
 
   CollectionLists: {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -182,6 +182,7 @@ type Section {
   pageDescription: String
   validationErrorInfo: ValidationErrorInfo
   repeatingSection: Boolean
+  allowRepeatingSection: Boolean
   repeatingSectionListId: ID
   comments: [Comment]
 }

--- a/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
+++ b/eq-author-api/tests/utils/contextBuilder/page/queryPage.js
@@ -30,6 +30,7 @@ const getPageQuery = `
       pageType
       section {
         id
+        allowRepeatingSection
       }
       folder {
         id

--- a/eq-author/src/App/page/Design/ListCollectorPageEditor/index.js
+++ b/eq-author/src/App/page/Design/ListCollectorPageEditor/index.js
@@ -752,12 +752,14 @@ UnwrappedListCollectorPageEditor.fragments = {
       additionalGuidancePanelSwitch
       drivingPositive
       drivingNegative
+      drivingQCode
       drivingPositiveDescription
       drivingNegativeDescription
       anotherTitle
       anotherPageDescription
       anotherPositive
       anotherNegative
+      anotherQCode
       anotherPositiveDescription
       anotherNegativeDescription
       addItemTitle
@@ -773,6 +775,7 @@ UnwrappedListCollectorPageEditor.fragments = {
       section {
         id
         position
+        allowRepeatingSection
         questionnaire {
           id
           metadata {

--- a/eq-author/src/App/page/Design/QuestionPageEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/index.js
@@ -216,6 +216,7 @@ UnwrappedQuestionPageEditor.fragments = {
         id
         position
         repeatingSection
+        allowRepeatingSection
         repeatingSectionListId
         questionnaire {
           id

--- a/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
@@ -19,6 +19,7 @@ const InlineField = styled(Field)`
   align-items: center;
   margin-bottom: 0.4rem;
   margin-left: 0;
+  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
 `;
 
 const ToggleWrapper = styled.div`
@@ -115,19 +116,21 @@ const RepeatingSection = ({ section, handleUpdate }) => {
         item from the list forms a section on the Hub. The repeating section is
         used to ask the same questions for each item selected.
       </Caption>
-      <InlineField>
-        <Label htmlFor="repeating-section">Repeating section</Label>
-        <ToggleWrapper>
-          <ToggleSwitch
-            id="repeatingSection"
-            name="repeatingSection"
-            data-test="repeating-section"
-            hideLabels={false}
-            onChange={handleUpdate}
-            checked={section?.repeatingSection}
-          />
-        </ToggleWrapper>
-      </InlineField>
+      <>
+        <InlineField disabled={Boolean(!section.allowRepeatingSection)}>
+          <Label htmlFor="repeating-section">Repeating section</Label>
+          <ToggleWrapper>
+            <ToggleSwitch
+              id="repeatingSection"
+              name="repeatingSection"
+              data-test="repeating-section"
+              hideLabels={false}
+              onChange={handleUpdate}
+              checked={section?.repeatingSection}
+            />
+          </ToggleWrapper>
+        </InlineField>
+      </>
       {section?.repeatingSection && (
         <>
           <Label htmlFor="repeatingSectionListId">Linked collection list</Label>

--- a/eq-author/src/App/section/Design/index.js
+++ b/eq-author/src/App/section/Design/index.js
@@ -232,6 +232,7 @@ export const SECTION_QUERY = gql`
       ...Section
       displayName
       position
+      allowRepeatingSection
       folders {
         id
       }

--- a/eq-author/src/App/settings/TabItems.js
+++ b/eq-author/src/App/settings/TabItems.js
@@ -4,11 +4,13 @@ const tabItems = ({ params, themeErrorCount = 0 }) => [
   {
     title: `General`,
     url: `${buildSettingsPath(params)}/general`,
+    enabled: true,
   },
   {
     title: `Themes, IDs, form types and legal bases`,
     url: `${buildSettingsPath(params)}/themes`,
     errorCount: themeErrorCount,
+    enabled: true,
   },
 ];
 

--- a/eq-author/src/components/QCodeContext/index.js
+++ b/eq-author/src/components/QCodeContext/index.js
@@ -55,6 +55,7 @@ const formatListCollector = (listCollectorPage) => [
     drivingQCode: listCollectorPage.drivingQCode,
     type: RADIO,
     listAnswerType: DRIVING,
+    label: "",
   },
   {
     label: listCollectorPage.drivingPositive,
@@ -72,6 +73,7 @@ const formatListCollector = (listCollectorPage) => [
     anotherQCode: listCollectorPage.anotherQCode,
     type: RADIO,
     listAnswerType: ANOTHER,
+    label:"",
   },
   {
     label: listCollectorPage.anotherPositive,

--- a/eq-author/src/components/VerticalTabs/index.js
+++ b/eq-author/src/components/VerticalTabs/index.js
@@ -83,6 +83,7 @@ const listItems = (tabItems) =>
 
 const VerticalTabs = ({ title, gutters, cols, tabItems }) => {
   return (
+    
     <Column gutters={gutters} cols={cols} tabItems={tabItems}>
       <Title>{title}</Title>
       <StyledTabUl>{listItems(tabItems)}</StyledTabUl>

--- a/eq-author/src/graphql/createFolder.graphql
+++ b/eq-author/src/graphql/createFolder.graphql
@@ -8,6 +8,7 @@ mutation CreateFolder($input: CreateFolderInput!) {
     ...Folder
     section {
       id
+      allowRepeatingSection
       folders {
         id
         position

--- a/eq-author/src/graphql/createListCollectorPage.graphql
+++ b/eq-author/src/graphql/createListCollectorPage.graphql
@@ -15,6 +15,7 @@ mutation CreateListCollectorPage($input: CreateListCollectorPageInput!) {
           id
         }
       }
+      allowRepeatingSection
     }
     validationErrorInfo {
       ...ValidationErrorInfo

--- a/eq-author/src/graphql/getSection.graphql
+++ b/eq-author/src/graphql/getSection.graphql
@@ -12,6 +12,7 @@ query GetSection($input: QueryInput!) {
     introductionContent
     pageDescription
     position
+    allowRepeatingSection
     displayConditions {
       id
       operator


### PR DESCRIPTION
### What is the context of this PR?
Disable the repeating section toggle on the section with list-collector

Please see [Jira Ticket](https://jira.ons.gov.uk/browse/EAR-1993) for further information related to this bug.

### How to review
Follow reproducing steps described in [Jira Ticket](https://jira.ons.gov.uk/browse/EAR-1993)
_Once questionnaire is created with no list collector:_
- [ ] Repeating Section Toggle clickable

_Add list collector to questionnaire:_
- [ ] Repeating Section Toggle isn't clickable

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
