### PR TITLE
Ear 1998 adjust max digit limit

### DIFF
--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -429,7 +429,7 @@ type MinValueValidationRule implements ValidationRule {
   id: ID!
   enabled: Boolean!
   inclusive: Boolean!
-  custom: Int
+  custom: Float
   previousAnswer: BasicAnswer
   entityType: ValidationRuleEntityType!
   validationErrorInfo: ValidationErrorInfo
@@ -439,7 +439,7 @@ type MaxValueValidationRule implements ValidationRule {
   id: ID!
   enabled: Boolean!
   inclusive: Boolean!
-  custom: Int
+  custom: Float
   previousAnswer: BasicAnswer
   entityType: ValidationRuleEntityType!
   validationErrorInfo: ValidationErrorInfo
@@ -503,7 +503,7 @@ type TotalValidationRule implements ValidationRule {
   id: ID!
   enabled: Boolean!
   entityType: ValidationRuleEntityType!
-  custom: Int
+  custom: Float
   previousAnswer: Answer
   condition: ValidationCondition!
   validationErrorInfo: ValidationErrorInfo
@@ -1453,14 +1453,14 @@ input UpdateValidationRuleInput {
 
 input UpdateMinValueInput {
   inclusive: Boolean!
-  custom: Int
+  custom: Float
   entityType: ValidationRuleEntityType
   previousAnswer: ID
 }
 
 input UpdateMaxValueInput {
   inclusive: Boolean!
-  custom: Int
+  custom: Float
   entityType: ValidationRuleEntityType
   previousAnswer: ID
 }
@@ -1498,7 +1498,7 @@ input DurationInput {
 
 input UpdateTotalValidationInput {
   entityType: ValidationRuleEntityType!
-  custom: Int
+  custom: Float
   previousAnswer: ID
   condition: ValidationCondition!
   allowUnanswered: Boolean

--- a/eq-author/src/App/page/Design/Validation/NumericValidation/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/page/Design/Validation/NumericValidation/__snapshots__/index.test.js.snap
@@ -41,7 +41,7 @@ exports[`AnswerValidation should render 1`] = `
       },
     }
   }
-  limit={999999999}
+  limit={999999999999999}
   onChange={[MockFunction]}
   onChangeUpdate={[MockFunction]}
   onCustomNumberValueChange={[Function]}

--- a/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.js
+++ b/eq-author/src/App/page/Design/Validation/withCustomNumberValueChange.js
@@ -5,7 +5,7 @@ import { inRange, isNaN } from "lodash";
 const withCustomNumberValueChange = (WrappedComponent) => {
   return class extends React.Component {
     static defaultProps = {
-      limit: 999999999,
+      limit: 999999999999999,
     };
 
     static propTypes = {


### PR DESCRIPTION
### What is the context of this PR?

This PR is linked to this [Jira ticket](https://jira.ons.gov.uk/browse/EAR-1998)


### How to review

- Checkout `ear-1998-adjust-max-digit-limit`:
  - Check that the maximum digit limit can be set to 15 digits for units, currency, percentage and number answer types
  - ensure that the runner schema is unaffected

