### PR TITLE
Include Display logic tab

### DIFF
--- a/eq-author/src/App/section/Logic/index.js
+++ b/eq-author/src/App/section/Logic/index.js
@@ -35,6 +35,7 @@ const TABS = (sectionId, questionnaireId, validationErrorInfo) => [
     errorCount: validationErrorInfo?.errors?.filter(
       ({ type }) => type && type.includes("display")
     ).length,
+    enabled: true
   },
 ];
 
@@ -58,6 +59,7 @@ const LogicPage = ({ children, section }) => (
           title="Select your logic"
           cols={2.5}
           tabItems={TABS(
+
             section.id,
             section.questionnaire.id,
             section.validationErrorInfo

--- a/eq-author/src/App/section/Logic/index.js
+++ b/eq-author/src/App/section/Logic/index.js
@@ -59,7 +59,6 @@ const LogicPage = ({ children, section }) => (
           title="Select your logic"
           cols={2.5}
           tabItems={TABS(
-
             section.id,
             section.questionnaire.id,
             section.validationErrorInfo


### PR DESCRIPTION
### What is the context of this PR?
Display logic page vertical tabs does not display the "Display logic" tab item
[Jira ticket](https://jira.ons.gov.uk/browse/EAR-2029)

### How to review

- [ ] Under Section Logic tab, is there a Display logic tab item under "Select your logic"?


### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
