### PR TITLE
EAR 2043 disable first repeating section

### DIFF
--- a/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
@@ -116,7 +116,13 @@ const RepeatingSection = ({ section, handleUpdate }) => {
         item from the list forms a section on the Hub. The repeating section is
         used to ask the same questions for each item selected.
       </Caption>
-      <InlineField disabled={!section.allowRepeatingSection}>
+      <InlineField
+        disabled={
+          !section.allowRepeatingSection ||
+          (section.position === 0 && !section.repeatingSection)
+        }
+        data-test="repeating-section-toggle-field"
+      >
         <Label htmlFor="repeating-section">Repeating section</Label>
         <ToggleWrapper>
           <ToggleSwitch

--- a/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.test.js
@@ -97,7 +97,7 @@ describe("RepeatingSection", () => {
         "repeating-section-toggle-field"
       );
 
-      expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if !disabled then toggle switch is not disabled
+      expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if disabled is undefined then toggle switch is not disabled
     });
   });
 
@@ -119,6 +119,6 @@ describe("RepeatingSection", () => {
     });
     const repeatingToggleField = getByTestId("repeating-section-toggle-field");
 
-    expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if !disabled then toggle switch is not disabled
+    expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if disabled is undefined then toggle switch is not disabled
   });
 });

--- a/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.test.js
+++ b/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.test.js
@@ -1,0 +1,124 @@
+import React from "react";
+import { render } from "tests/utils/rtl";
+
+import RepeatingSection from ".";
+import { useQuery } from "@apollo/react-hooks";
+
+jest.mock("@apollo/react-hooks", () => ({
+  ...jest.requireActual("@apollo/react-hooks"),
+  useQuery: jest.fn(),
+}));
+
+const collectionLists = {
+  id: "collection-list-1",
+  lists: [
+    {
+      id: "list-1",
+      listName: "List 1",
+      displayName: "List 1",
+      answers: [
+        {
+          id: "list-answer-1",
+          type: "TextField",
+          label: "List answer 1",
+        },
+      ],
+    },
+  ],
+};
+
+useQuery.mockImplementation(() => ({
+  loading: false,
+  error: false,
+  data: {
+    collectionLists,
+  },
+}));
+
+const renderRepeatingSection = (props) => {
+  return render(<RepeatingSection {...props} />);
+};
+
+describe("RepeatingSection", () => {
+  let section;
+
+  beforeEach(() => {
+    section = {
+      id: "section-1",
+      position: 1,
+      allowRepeatingSection: true,
+      repeatingSection: false,
+      folders: [
+        {
+          id: "folder-1",
+          pages: [
+            {
+              id: "page-1",
+              answer: [
+                {
+                  id: "answer-1",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      validationErrorInfo: {
+        errors: [],
+        totalCount: 0,
+      },
+    };
+  });
+
+  describe("First section", () => {
+    it("should disable repeating section toggle switch on first section if repeatingSection is false", () => {
+      section.position = 0;
+
+      const { getByTestId } = renderRepeatingSection({
+        section,
+        handleUpdate: jest.fn(),
+      });
+      const repeatingToggleField = getByTestId(
+        "repeating-section-toggle-field"
+      );
+
+      expect(repeatingToggleField).toHaveAttribute("disabled", ""); // if disabled === "" then toggle switch is disabled
+    });
+
+    it("should not disable repeating section toggle switch on first section if repeatingSection is true", () => {
+      section.position = 0;
+      section.repeatingSection = true;
+
+      const { getByTestId } = renderRepeatingSection({
+        section,
+        handleUpdate: jest.fn(),
+      });
+      const repeatingToggleField = getByTestId(
+        "repeating-section-toggle-field"
+      );
+
+      expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if !disabled then toggle switch is not disabled
+    });
+  });
+
+  it("should disable repeating section toggle switch if allowRepeatingSection is false", () => {
+    section.allowRepeatingSection = false;
+    const { getByTestId } = renderRepeatingSection({
+      section,
+      handleUpdate: jest.fn(),
+    });
+    const repeatingToggleField = getByTestId("repeating-section-toggle-field");
+
+    expect(repeatingToggleField).toHaveAttribute("disabled", ""); // if disabled === "" then toggle switch is disabled
+  });
+
+  it("should not disable repeating section toggle switch if allowRepeatingSection is true", () => {
+    const { getByTestId } = renderRepeatingSection({
+      section,
+      handleUpdate: jest.fn(),
+    });
+    const repeatingToggleField = getByTestId("repeating-section-toggle-field");
+
+    expect(repeatingToggleField).not.toHaveAttribute("disabled"); // if !disabled then toggle switch is not disabled
+  });
+});


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Disable repeating section toggle switch on the first section in a questionnaire

If the repeating section toggle switch is already switched on for the first section, the repeating section toggle switch will not be disabled until it is switched off by the user - this prevents a bug case where a user would have switched on repeating section for the first section in a questionnaire before these changes, but would now be unable to switch off repeating section on the first section due to the toggle switch now being disabled

### How to review

Create a questionnaire with a collection list

**Check:**
- [ ] Repeating section toggle switch is disabled on first section in a questionnaire
- [ ] Repeating section toggle switch is not disabled on later sections in a questionnaire, unless the section includes a list collector question

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
