### PR TITLE
Fix repeating section toggle

### DIFF
--- a/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/RepeatingSection/index.js
@@ -130,7 +130,9 @@ const RepeatingSection = ({ section, handleUpdate }) => {
             name="repeatingSection"
             data-test="repeating-section"
             hideLabels={false}
-            onChange={handleUpdate}
+            onChange={({ value }) =>
+              handleUpdate({ name: "repeatingSection", value })
+            }
             checked={section?.repeatingSection}
           />
         </ToggleWrapper>


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes bug preventing the repeating section toggle switch from updating data

### How to review

Check the repeating section toggle switch can enable and disable repeating sections

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
