### PR TITLE
fix for firestore date bug

### DIFF
--- a/eq-author-api/db/datastore/datastore-firestore.js
+++ b/eq-author-api/db/datastore/datastore-firestore.js
@@ -121,6 +121,13 @@ const transformedQuestionnaire = (sections, version) => {
     ? version.createdAt.toDate()
     : new Date(version.createdAt);
   version.editors = version.editors || [];
+
+  version?.publishHistory?.forEach((publishHistoryEvent) => {
+    publishHistoryEvent.publishDate = publishHistoryEvent.publishDate.seconds
+      ? publishHistoryEvent.publishDate.toDate()
+      : new Date(publishHistoryEvent.publishDate);
+  });
+
   return {
     ...version,
     sections: newSections || [],


### PR DESCRIPTION
When using firestore as a backend the publish date is not being returned correctly in the schema, 

This bug fixes it. 

To Test
Switch your local database to fire store and use the publish function, You can then check the push history shows the date in the correct format. 