### PR TITLE
Update to handle pulisher failures during publish

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1496,6 +1496,11 @@ const Resolvers = {
         publishResult.errorMessage = `Failed to fetch questionnaire - ${e.message}`;
       });
 
+      if (convertedResponse.status !== 200) {
+        publishResult.success = false;
+        publishResult.errorMessage = `Publisher failed to convert questionnaire - ${convertedResponse.statusText}`;
+      }
+
       if (publishResult.success === false) {
         return ctx.questionnaire;
       }


### PR DESCRIPTION
Added capability to catch publisher failures, IE any status that isn't a 200

To test -
Switch to an old branch of publisher locally that will cause it to fail during convertion.
Publish a test questionnaire and check the output shows internal server failure in the error message,
