### PR TITLE
EAR 2128 Add preview questions

### DIFF
--- a/eq-author-api/schema/tests/section.test.js
+++ b/eq-author-api/schema/tests/section.test.js
@@ -15,6 +15,10 @@ const {
   moveSection,
 } = require("../../tests/utils/contextBuilder/section");
 
+const {
+  updateQuestionnaireIntroduction,
+} = require("../../tests/utils/contextBuilder/questionnaireIntroduction");
+
 const { NUMBER } = require("../../constants/answerTypes");
 
 describe("section", () => {
@@ -236,7 +240,30 @@ describe("section", () => {
         ctx.comments = {};
       });
 
-      it("should not validate the section title if Hub is off", async () => {
+      it("should not validate the section title if Hub is off and preview questions is off", async () => {
+        ctx = await buildContext({
+          sections: [
+            {
+              title: "",
+            },
+          ],
+          introduction: {
+            previewQuestions: false,
+          },
+          hub: false,
+        });
+
+        questionnaire = ctx.questionnaire;
+        const section = questionnaire.sections[0];
+
+        const queriedSection = await querySection(ctx, section.id);
+        expect(queriedSection.validationErrorInfo).toMatchObject({
+          totalCount: 0,
+        });
+        expect(queriedSection.validationErrorInfo.errors).toHaveLength(0);
+      });
+
+      it("should not validate the section title if Hub is off and preview questions is on", async () => {
         ctx = await buildContext({
           sections: [
             {
@@ -251,9 +278,9 @@ describe("section", () => {
 
         const queriedSection = await querySection(ctx, section.id);
         expect(queriedSection.validationErrorInfo).toMatchObject({
-          totalCount: 0,
+          totalCount: 1,
         });
-        expect(queriedSection.validationErrorInfo.errors).toHaveLength(0);
+        expect(queriedSection.validationErrorInfo.errors).toHaveLength(1);
       });
 
       describe("Section introduction", () => {
@@ -266,6 +293,9 @@ describe("section", () => {
             introductionContent: "",
             introductionPageDescription: "",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({
@@ -284,6 +314,9 @@ describe("section", () => {
             introductionContent: "introduction content",
             introductionPageDescription: "introduction description",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({
@@ -302,6 +335,9 @@ describe("section", () => {
             introductionContent: "",
             introductionPageDescription: "introduction description",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({
@@ -320,6 +356,9 @@ describe("section", () => {
             introductionContent: "introduction content",
             introductionPageDescription: "introduction description",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({
@@ -338,6 +377,9 @@ describe("section", () => {
             introductionContent: "introduction content",
             introductionPageDescription: "",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({
@@ -356,6 +398,9 @@ describe("section", () => {
             sectionSummary: false,
             sectionSummaryPageDescription: "",
           };
+          await updateQuestionnaireIntroduction(ctx, {
+            previewQuestions: false,
+          });
           const updatedSection = await updateSection(ctx, update);
 
           expect(updatedSection.validationErrorInfo).toMatchObject({

--- a/eq-author-api/schema/tests/section.test.js
+++ b/eq-author-api/schema/tests/section.test.js
@@ -263,7 +263,7 @@ describe("section", () => {
         expect(queriedSection.validationErrorInfo.errors).toHaveLength(0);
       });
 
-      it("should not validate the section title if Hub is off and preview questions is on", async () => {
+      it("should validate the section title if Hub is off and preview questions is on", async () => {
         ctx = await buildContext({
           sections: [
             {

--- a/eq-author-api/src/validation/customKeywords/index.js
+++ b/eq-author-api/src/validation/customKeywords/index.js
@@ -18,4 +18,5 @@ module.exports = (ajv) => {
   require("./requiredWhenSectionSetting")(ajv);
   require("./validateSecondaryCondition")(ajv);
   require("./validatePageDescription")(ajv);
+  require("./requiredWhenIntroductionSetting")(ajv);
 };

--- a/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
+++ b/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
@@ -1,0 +1,12 @@
+module.exports = (ajv) =>
+  ajv.addKeyword({
+    keyword: "requiredWhenIntroductionSetting",
+    validate: function validate(
+      settingName,
+      data,
+      _parentSchema,
+      { rootData: questionnaire }
+    ) {
+      return Boolean(data?.length || !questionnaire.introduction[settingName]);
+    },
+  });

--- a/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
+++ b/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
@@ -7,6 +7,10 @@ module.exports = (ajv) =>
       _parentSchema,
       { rootData: questionnaire }
     ) {
-      return Boolean(data?.length || !questionnaire.introduction[settingName]);
+      if (questionnaire.introduction) {
+        return Boolean(
+          data?.length || !questionnaire.introduction[settingName]
+        );
+      }
     },
   });

--- a/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
+++ b/eq-author-api/src/validation/customKeywords/requiredWhenIntroductionSetting.js
@@ -11,6 +11,8 @@ module.exports = (ajv) =>
         return Boolean(
           data?.length || !questionnaire.introduction[settingName]
         );
+      } else {
+        return true;
       }
     },
   });

--- a/eq-author-api/src/validation/schemas/section.json
+++ b/eq-author-api/src/validation/schemas/section.json
@@ -16,6 +16,9 @@
           "requiredWhenQuestionnaireSetting": "hub"
         },
         {
+          "requiredWhenIntroductionSetting": "previewQuestions"
+        },
+        {
           "requiredWhenQuestionnaireSetting": "collapsibleSummary"
         },
         {

--- a/eq-author-api/tests/utils/contextBuilder/index.js
+++ b/eq-author-api/tests/utils/contextBuilder/index.js
@@ -188,7 +188,6 @@ const buildContext = async (questionnaireConfig, userConfig = {}) => {
     const { collapsibles, ...introductionProps } = introduction;
     if (Object.keys(introductionProps).length > 0) {
       await updateQuestionnaireIntroduction(ctx, {
-        id: questionnaire.introduction.id,
         ...introductionProps,
       });
     }

--- a/eq-author-api/utils/createQuestionnaireIntroduction.js
+++ b/eq-author-api/utils/createQuestionnaireIntroduction.js
@@ -25,8 +25,7 @@ module.exports = (metadata) => {
     description:
       "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. </li><li>You can provide info estimates if actual figures are not available.</li><li>We will treat your data securely and confidentially.</li></ul>",
     legalBasis: NOTICE_1,
-    // TODO: When preview questions feature is implemented, uncomment this line - this line will enable previewQuestions by default when a questionnaire is created
-    // previewQuestions: true,
+    previewQuestions: true,
     secondaryTitle: "<p>Information you need</p>",
     secondaryDescription:
       "<p>You can select the dates of the period you are reporting for, if the given dates are not appropriate.</p>",

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -203,6 +203,36 @@ exports[`IntroductionEditor should render 1`] = `
   </IntroductionEditor__Section>
   <IntroductionEditor__Section>
     <IntroductionEditor__Padding>
+      <IntroductionEditor__InlineField
+        open={false}
+        style={
+          Object {
+            "marginBottom": "0",
+          }
+        }
+      >
+        <Label
+          bold={true}
+          htmlFor="toggle-preview-questions"
+        >
+          Preview questions
+        </Label>
+        <ToggleSwitch
+          blockDisplay={false}
+          checked={true}
+          hideLabels={false}
+          id="toggle-preview-questions"
+          name="toggle-preview-questions"
+          onChange={[Function]}
+        />
+      </IntroductionEditor__InlineField>
+      <IntroductionEditor__SectionDescription>
+        This displays a link on the introduction page that takes respondents to a preview of all the questions on one page in a collapsible format.
+      </IntroductionEditor__SectionDescription>
+    </IntroductionEditor__Padding>
+  </IntroductionEditor__Section>
+  <IntroductionEditor__Section>
+    <IntroductionEditor__Padding>
       <IntroductionEditor__SectionTitle
         style={
           Object {

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -22,8 +22,6 @@ import CollapsiblesEditor from "./CollapsiblesEditor";
 
 import UPDATE_INTRODUCTION_MUTATION from "graphql/updateQuestionnaireIntroduction.graphql";
 
-import { enableOn } from "utils/featureFlags";
-
 const Section = styled.section`
   &:not(:last-of-type) {
     border-bottom: 1px solid #e0e0e0;
@@ -350,40 +348,36 @@ const IntroductionEditor = ({ introduction, history }) => {
           </InformationPanel>
         </Padding>
       </Section>
-      {enableOn(["previewQuestions"]) && (
-        <Section>
-          <Padding>
-            <InlineField
-              open={contactDetailsIncludeRuRef}
-              style={{ marginBottom: "0" }}
-            >
-              <Label htmlFor="toggle-preview-questions">
-                Preview questions
-              </Label>
-              <ToggleSwitch
-                id="toggle-preview-questions"
-                name="toggle-preview-questions"
-                hideLabels={false}
-                onChange={() =>
-                  updateQuestionnaireIntroduction({
-                    variables: {
-                      input: {
-                        previewQuestions: !previewQuestions,
-                      },
+      <Section>
+        <Padding>
+          <InlineField
+            open={contactDetailsIncludeRuRef}
+            style={{ marginBottom: "0" }}
+          >
+            <Label htmlFor="toggle-preview-questions">Preview questions</Label>
+            <ToggleSwitch
+              id="toggle-preview-questions"
+              name="toggle-preview-questions"
+              hideLabels={false}
+              onChange={() =>
+                updateQuestionnaireIntroduction({
+                  variables: {
+                    input: {
+                      previewQuestions: !previewQuestions,
                     },
-                  })
-                }
-                checked={previewQuestions}
-              />
-            </InlineField>
-            <SectionDescription>
-              This displays a link on the introduction page that takes
-              respondents to a preview of all the questions on one page in a
-              collapsible format.
-            </SectionDescription>
-          </Padding>
-        </Section>
-      )}
+                  },
+                })
+              }
+              checked={previewQuestions}
+            />
+          </InlineField>
+          <SectionDescription>
+            This displays a link on the introduction page that takes respondents
+            to a preview of all the questions on one page in a collapsible
+            format.
+          </SectionDescription>
+        </Padding>
+      </Section>
       <Section>
         <Padding>
           <SectionTitle style={{ marginBottom: "0" }}>


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Add preview questions toggle switch to introduction page

Validate empty section title when preview questions is enabled and questionnaire has one section - preview questions gives an error in eQ when a section does not have a title

### How to review

Run the instructions for the Publisher PR (https://github.com/ONSdigital/eq-publisher-v3/pull/163)

**Check:**
- [ ] Empty section title is validated when preview questions is enabled and the questionnaire has only one section
- [ ] Viewing the questionnaire in eQ displays the preview pages link and clicking the link displays a preview of questions
- [ ] The questionnaire does not display an error when it does not include an introduction page

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
