### PR TITLE
EAR-2130-implement-prepop-schema-processing

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1579,14 +1579,18 @@ const Resolvers = {
       try {
         const response = await fetch(url);
         const prepopSchemaVersion = await response.json();
-        console.log("prepopSchemaVersion", prepopSchemaVersion);
 
         if (prepopSchemaVersion) {
           logger.info(`Schema version data returned - ${prepopSchemaVersion}`);
           ctx.questionnaire.prepopSchema = { ...input };
-          ctx.questionnaire.prepopSchema.data =
-            getPrepopMetadata(prepopSchemaVersion.schema.properties) ||
-            prepopSchemaVersion.schema;
+
+          if (input.surveyId === "999") {
+            ctx.questionnaire.prepopSchema.data =
+              getPrepopMetadata(prepopSchemaVersion.schema.properties) ||
+              prepopSchemaVersion.schema;
+          } else {
+            ctx.questionnaire.prepopSchema = prepopSchemaVersion;
+          }
 
           return prepopSchemaVersion;
         } else {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1547,7 +1547,24 @@ const Resolvers = {
     }),
     updatePrepopSchema: createMutation(async (root, { input }, ctx) => {
       const { id, surveyId } = input;
-      const url = `${process.env.PREPOP_SCHEMA_GATEWAY}schemaVersionGet?id=${id}`;
+      const url = `https://sds-api-mock-gateway-74jbrn8r.nw.gateway.dev/schemaVersionGet?id=${surveyId}`;
+
+      const getPrepopMetadata = (prepopSchemaVersion) => {
+        const prepopSchema = {};
+
+        prepopSchemaVersion.schema.properties.company_name.id = uuidv4();
+        prepopSchemaVersion.schema.properties.company_name.fieldName =
+          "company_name";
+        prepopSchemaVersion.schema.properties.company_name.exampleValue =
+          prepopSchemaVersion.schema.properties.company_name.examples[0];
+        delete prepopSchemaVersion.schema.properties.company_name.minLength;
+        delete prepopSchemaVersion.schema.properties.company_name.examples;
+        prepopSchema.data = [
+          prepopSchemaVersion.schema.properties.company_name,
+        ];
+
+        return prepopSchema;
+      };
 
       try {
         const response = await fetch(url);
@@ -1555,8 +1572,10 @@ const Resolvers = {
 
         if (prepopSchemaVersion) {
           logger.info(`Schema version data returned - ${prepopSchemaVersion}`);
-          ctx.questionnaire.prepopSchema = prepopSchemaVersion;
-          ctx.questionnaire.prepopSchema.surveyId = surveyId;
+          ctx.questionnaire.prepopSchema = {};
+          ctx.questionnaire.prepopSchema =
+            getPrepopMetadata(prepopSchemaVersion);
+          // ctx.questionnaire.prepopSchema.surveyId = surveyId;
           prepopSchemaVersion.surveyId = surveyId;
           return prepopSchemaVersion;
         } else {

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1586,14 +1586,9 @@ const Resolvers = {
             ctx.questionnaire.prepopSchema.data = getPrepopMetadata(
               prepopSchemaVersion.schema.properties
             );
-          } else {
-            ctx.questionnaire.prepopSchema = {
-              surveyId: surveyId,
-              ...prepopSchemaVersion,
-            };
           }
 
-          return prepopSchemaVersion;
+          return ctx.questionnaire.prepopSchema;
         } else {
           logger.info(`Schema version data not found - ${id}`);
         }

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1581,7 +1581,7 @@ const Resolvers = {
         if (prepopSchemaVersion) {
           logger.info(`Schema version data returned - ${prepopSchemaVersion}`);
 
-          if (surveyId === "999") {
+          if (prepopSchemaVersion?.schema?.properties) {
             ctx.questionnaire.prepopSchema = { ...input };
             ctx.questionnaire.prepopSchema.data = getPrepopMetadata(
               prepopSchemaVersion.schema.properties

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1579,16 +1579,15 @@ const Resolvers = {
       try {
         const response = await fetch(url);
         const prepopSchemaVersion = await response.json();
+        console.log("prepopSchemaVersion", prepopSchemaVersion);
 
         if (prepopSchemaVersion) {
           logger.info(`Schema version data returned - ${prepopSchemaVersion}`);
-          ctx.questionnaire.prepopSchema = {};
-          ctx.questionnaire.prepopSchema.data = getPrepopMetadata(
-            prepopSchemaVersion.schema.properties
-          );
-          ctx.questionnaire.prepopSchema.surveyId = surveyId;
-          prepopSchemaVersion.surveyId = surveyId;
-          prepopSchemaVersion.id = uuidv4();
+          ctx.questionnaire.prepopSchema = { ...input };
+          ctx.questionnaire.prepopSchema.data =
+            getPrepopMetadata(prepopSchemaVersion.schema.properties) ||
+            prepopSchemaVersion.schema;
+
           return prepopSchemaVersion;
         } else {
           logger.info(`Schema version data not found - ${id}`);

--- a/eq-author-api/schema/tests/prePopSchema.test.js
+++ b/eq-author-api/schema/tests/prePopSchema.test.js
@@ -25,6 +25,13 @@ describe("questionnaire", () => {
     await deleteQuestionnaire(ctx, questionnaire.id);
   });
 
+  let input = {
+    id: "121-222-789",
+    surveyId: "121",
+    dateCreated: null,
+    version: null,
+  };
+
   fetch.mockImplementation(() =>
     Promise.resolve({
       status: 200,
@@ -76,10 +83,56 @@ describe("questionnaire", () => {
 
   describe("should update the prepop schema", () => {
     it("should update the prepopSchema", async () => {
-      const updatedPrepopSchema = await updatePrepopSchema(
-        ctx,
-        prepopSchemaData
+      const updatedPrepopSchema = await updatePrepopSchema(ctx, input);
+      expect(updatedPrepopSchema).toEqual({ ...prepopSchemaData, ...input });
+    });
+
+    it("should update the prepop schema when surveyId is equal to 999", async () => {
+      input = {
+        id: "999-222-789",
+        surveyId: "999",
+      };
+
+      const prepopSchemaData = {
+        id: "999-222-789",
+        surveyId: "999",
+        dateCreated: "2023-01-12T13:37:27+00:00",
+        version: "1",
+        schema: {
+          properties: {
+            companyName: {
+              type: "string",
+              exampleValue: "Joe Bloggs PLC",
+              fieldName: "companyName",
+              id: expect.any(String),
+            },
+          },
+        },
+      };
+
+      fetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => ({
+            id: "999-222-789",
+            surveyId: "999",
+            dateCreated: "2023-01-12T13:37:27+00:00",
+            version: "1",
+            schema: {
+              properties: {
+                companyName: {
+                  type: "string",
+                  minLength: 1,
+                  examples: ["Joe Bloggs PLC"],
+                },
+              },
+            },
+          }),
+        })
       );
+
+      const updatedPrepopSchema = await updatePrepopSchema(ctx, input);
+
       expect(updatedPrepopSchema).toEqual(prepopSchemaData);
     });
   });

--- a/eq-author-api/schema/tests/prePopSchema.test.js
+++ b/eq-author-api/schema/tests/prePopSchema.test.js
@@ -28,8 +28,8 @@ describe("questionnaire", () => {
   let input = {
     id: "121-222-789",
     surveyId: "121",
-    dateCreated: null,
-    version: null,
+    version: "1",
+    dateCreated: "2023-01-12T13:37:27+00:00",
   };
 
   fetch.mockImplementation(() =>
@@ -39,17 +39,86 @@ describe("questionnaire", () => {
         id: "121-222-789",
         surveyId: "121",
         schema: {
-          id: "121-222-789",
-          version: "1",
-          dateCreated: "2023-01-12T13:37:27+00:00",
-          turnover: {
-            type: "number",
-            example: "1000",
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          $id: "roofing_tiles_and_slate.json",
+          title: "SDS schema for the Roofing Tiles + Slate survey",
+          type: "object",
+          properties: {
+            identifier: {
+              type: "string",
+              description:
+                "The unique top-level identifier. This is the reporting unit reference without the check letter appended",
+              minLength: 11,
+              pattern: "^[a-zA-Z0-9]+$",
+              examples: ["34942807969"],
+            },
+            companyName: {
+              type: "string",
+              minLength: 1,
+              examples: ["Joe Bloggs PLC"],
+            },
+            companyType: {
+              type: "string",
+              minLength: 1,
+              examples: ["Public Limited Company"],
+            },
+            items: {
+              type: "object",
+              properties: {
+                localUnits: {
+                  type: "array",
+                  description: "The data about each item",
+                  minItems: 1,
+                  uniqueItems: true,
+                  items: {
+                    type: "object",
+                    properties: {
+                      identifier: {
+                        type: "string",
+                        minLength: 1,
+                        description:
+                          "The unique identifier for the items. This is the local unit reference.",
+                        examples: ["3340224"],
+                      },
+                      luName: {
+                        type: "string",
+                        minLength: 1,
+                        description: "Name of the local unit",
+                        examples: ["STUBBS BUILDING PRODUCTS LTD"],
+                      },
+                      luAddress: {
+                        type: "array",
+                        description:
+                          "The fields of the address for the local unit",
+                        items: {
+                          type: "string",
+                          minLength: 1,
+                        },
+                        minItems: 1,
+                        uniqueItems: true,
+                        examples: [
+                          [
+                            "WELLINGTON ROAD",
+                            "LOCHMABEN",
+                            "SWINDON",
+                            "BEDS",
+                            "GLOS",
+                            "DE41 2WA",
+                          ],
+                        ],
+                      },
+                    },
+                    additionalProperties: false,
+                    required: ["identifier", "lu_name", "lu_address"],
+                  },
+                },
+              },
+              additionalProperties: false,
+              required: ["local_units"],
+            },
           },
-          employeeCount: {
-            type: "number",
-            example: "50",
-          },
+          additionalProperties: false,
+          required: ["schema_version", "identifier", "items"],
         },
       }),
     })
@@ -58,19 +127,22 @@ describe("questionnaire", () => {
   const prepopSchemaData = {
     id: "121-222-789",
     surveyId: "121",
-    schema: {
-      id: "121-222-789",
-      version: "1",
-      dateCreated: "2023-01-12T13:37:27+00:00",
-      turnover: {
-        type: "number",
-        example: "1000",
+    version: "1",
+    dateCreated: "2023-01-12T13:37:27+00:00",
+    data: [
+      {
+        fieldName: "companyName",
+        type: "string",
+        id: expect.any(String),
+        exampleValue: "Joe Bloggs PLC",
       },
-      employeeCount: {
-        type: "number",
-        example: "50",
+      {
+        type: "string",
+        fieldName: "companyType",
+        id: expect.any(String),
+        exampleValue: "Public Limited Company",
       },
-    },
+    ],
   };
 
   describe("should query the prepop schema", () => {
@@ -84,55 +156,6 @@ describe("questionnaire", () => {
   describe("should update the prepop schema", () => {
     it("should update the prepopSchema", async () => {
       const updatedPrepopSchema = await updatePrepopSchema(ctx, input);
-      expect(updatedPrepopSchema).toEqual({ ...prepopSchemaData, ...input });
-    });
-
-    it("should update the prepop schema when surveyId is equal to 999", async () => {
-      input = {
-        id: "999-222-789",
-        surveyId: "999",
-      };
-
-      const prepopSchemaData = {
-        id: "999-222-789",
-        surveyId: "999",
-        dateCreated: "2023-01-12T13:37:27+00:00",
-        version: "1",
-        schema: {
-          properties: {
-            companyName: {
-              type: "string",
-              exampleValue: "Joe Bloggs PLC",
-              fieldName: "companyName",
-              id: expect.any(String),
-            },
-          },
-        },
-      };
-
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          status: 200,
-          json: () => ({
-            id: "999-222-789",
-            surveyId: "999",
-            dateCreated: "2023-01-12T13:37:27+00:00",
-            version: "1",
-            schema: {
-              properties: {
-                companyName: {
-                  type: "string",
-                  minLength: 1,
-                  examples: ["Joe Bloggs PLC"],
-                },
-              },
-            },
-          }),
-        })
-      );
-
-      const updatedPrepopSchema = await updatePrepopSchema(ctx, input);
-
       expect(updatedPrepopSchema).toEqual(prepopSchemaData);
     });
   });

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -764,6 +764,9 @@ type PrepopSchema {
   id: ID
   surveyId: ID
   schema: JSON
+  data: [JSON]
+  dateCreated: String
+  version: String
 }
 
 type PublishHistoryEvent {
@@ -1675,6 +1678,8 @@ input deleteHistoryNoteInput {
 input UpdatePrepopSchemaInput {
   id: ID!
   surveyId: ID!
+  version: String
+  dateCreated: String
   schema: JSON
 }
 `;

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -763,7 +763,6 @@ type PrepopSchemaVersions {
 type PrepopSchema {
   id: ID
   surveyId: ID
-  schema: JSON
   data: [JSON]
   dateCreated: String
   version: String
@@ -1680,6 +1679,6 @@ input UpdatePrepopSchemaInput {
   surveyId: ID!
   version: String
   dateCreated: String
-  schema: JSON
+  data: [JSON]
 }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/prepopSchema/query.js
+++ b/eq-author-api/tests/utils/contextBuilder/prepopSchema/query.js
@@ -5,7 +5,9 @@ const getPrepopSchemaQuery = `
     prepopSchema {
       id
       surveyId
-      schema
+      dateCreated
+      version
+      data  
     }
 }`;
 

--- a/eq-author-api/tests/utils/contextBuilder/prepopSchema/unlink.js
+++ b/eq-author-api/tests/utils/contextBuilder/prepopSchema/unlink.js
@@ -7,7 +7,9 @@ const unlinkPrepopSchemaMutation = `
       prepopSchema {
         id
         surveyId
-        schema        
+        dateCreated
+        version
+        data    
       }
     }
   }

--- a/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
+++ b/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
@@ -5,7 +5,7 @@ const updatePrepopSchemaMutation = `
     updatePrepopSchema(input: $input) {
       id
       surveyId
-      schema
+      data
       dateCreated
       version
     }
@@ -14,6 +14,7 @@ const updatePrepopSchemaMutation = `
 
 const updatePrepopSchema = async (ctx, input) => {
   const result = await executeQuery(updatePrepopSchemaMutation, { input }, ctx);
+  console.log("result", result);
   return result.data.updatePrepopSchema;
 };
 

--- a/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
+++ b/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
@@ -6,6 +6,8 @@ const updatePrepopSchemaMutation = `
       id
       surveyId
       schema
+      dateCreated
+      version
     }
   }
 `;

--- a/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
+++ b/eq-author-api/tests/utils/contextBuilder/prepopSchema/update.js
@@ -14,7 +14,6 @@ const updatePrepopSchemaMutation = `
 
 const updatePrepopSchema = async (ctx, input) => {
   const result = await executeQuery(updatePrepopSchemaMutation, { input }, ctx);
-  console.log("result", result);
   return result.data.updatePrepopSchema;
 };
 

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/createQuestionnaire.js
@@ -54,7 +54,10 @@ const createQuestionnaireMutation = `
       }
       prepopSchema {
         id
-        schema
+        surveyId
+        data
+        dateCreated
+        version
       }
     }
   }

--- a/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
+++ b/eq-author-api/tests/utils/contextBuilder/questionnaire/queryQuestionnaire.js
@@ -44,7 +44,9 @@ const getQuestionnaireQuery = `
       prepopSchema {
         id
         surveyId
-        schema
+        data
+        dateCreated
+        version
       }
       locked
       validationErrorInfo {

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -136,6 +136,7 @@ const ONSDatasetPage = () => {
     variables: {
       id: surveyID || "surveyID",
     },
+    fetchPolicy: "network-only",
   });
 
   const [linkPrepopSchema] = useMutation(UPDATE_PREPOP_SCHEMA, {

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -72,8 +72,6 @@ const StyledTableBody = styled(TableBody)`
 
 const SpacedTableColumn = styled(TableColumn)`
   padding: 0.5em 0.5em 0.2em;
-
-  /* font-weight: bold; */
   color: ${colors.text};
   word-break: break-word;
   border: 1px solid ${colors.bordersDark};

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -73,13 +73,13 @@ const StyledTableBody = styled(TableBody)`
 const SpacedTableColumn = styled(TableColumn)`
   padding: 0.5em 0.5em 0.2em;
 
-  font-weight: bold;
-  color: ${colors.textLight};
+  /* font-weight: bold; */
+  color: ${colors.text};
   word-break: break-word;
   border: 1px solid ${colors.bordersDark};
+  padding-left: 1.2em;
   :not(:last-of-type) {
     border-right: 1px solid ${colors.bordersDark};
-    padding-left: 1em;
   }
 `;
 
@@ -96,6 +96,12 @@ const StyledButton = styled(Button)`
   left: 30%;
 `;
 
+const StyledUl = styled.ul`
+  margin: 0;
+  padding: 0 0 0 1.5em;
+`;
+const StyledLi = styled.li``;
+
 const formatDate = (date) => moment(date).locale("en-gb").format("DD/MM/YYYY");
 
 const CustomGrid = styled(Grid)`
@@ -108,6 +114,10 @@ const CustomColumn = styled(Column)`
 
 const UnlinkButtonWrapper = styled.div`
   text-align: right;
+`;
+
+const DataFieldsWrapper = styled.div`
+  margin-top: 1em;
 `;
 
 const ONSDatasetPage = () => {
@@ -156,14 +166,7 @@ const ONSDatasetPage = () => {
     let schemaData;
     if (prepopSchema?.prepopSchema?.data) {
       schemaData = prepopSchema ? prepopSchema.prepopSchema : null;
-    } else {
-      schemaData = prepopSchema
-        ? prepopSchema.prepopSchema
-          ? prepopSchema.prepopSchema.schema
-          : null
-        : null;
     }
-
     if (schemaData) {
       schemaData.surveyId = prepopSchema.prepopSchema?.surveyId;
     }
@@ -171,6 +174,8 @@ const ONSDatasetPage = () => {
   };
 
   const tableData = buildData();
+
+  const dataFields = tableData?.data;
 
   const handleUnlinkClick = () => {
     setShowUnlinkModal(true);
@@ -269,15 +274,15 @@ const ONSDatasetPage = () => {
                                               key={version.id}
                                               data-test={`dataset-row`}
                                             >
-                                              <SpacedTableColumn>
+                                              <SpacedTableColumn bold>
                                                 {version.version}
                                               </SpacedTableColumn>
-                                              <SpacedTableColumn>
+                                              <SpacedTableColumn bold>
                                                 {formatDate(
                                                   version.dateCreated
                                                 )}
                                               </SpacedTableColumn>
-                                              <SpacedTableColumn>
+                                              <SpacedTableColumn bold>
                                                 <StyledButton
                                                   onClick={() =>
                                                     linkPrepopSchema({
@@ -354,6 +359,122 @@ const ONSDatasetPage = () => {
                                 {formatDate(tableData.dateCreated)}
                               </CustomColumn>
                             </CustomGrid>
+                            <DataFieldsWrapper>
+                              <StyledTitle>
+                                Data fields available for piping
+                              </StyledTitle>
+                              <Common.TabContent>
+                                A respondent&apos;s answers to previous
+                                questions are stored in ONS datasets as data
+                                fields. Data fields can be piped into question
+                                and section pages using the toolbar.
+                              </Common.TabContent>
+                              <Common.TabContent>
+                                Data fields are defined as either:
+                                <StyledUl>
+                                  <StyledLi>
+                                    single data fields, which have one entry
+                                    with no restrictions on piping
+                                  </StyledLi>
+                                  <StyledLi>
+                                    multivalued data fields, which have one or
+                                    more entities and are only available for
+                                    piping in repeating sections
+                                  </StyledLi>
+                                </StyledUl>
+                              </Common.TabContent>
+                              <Common.TabContent>
+                                The data field name will be used as a temporary
+                                placeholder when piping into question and
+                                section pages.
+                              </Common.TabContent>
+                              <Common.TabContent>
+                                The value assigned to the piped data field will
+                                replace the relevant placeholder when previewing
+                                the questionnaire in eQ. The value will then be
+                                replaced by relevant sample file data when the
+                                respondent views the live questionnaire.
+                              </Common.TabContent>
+                              <Table data-test="data-fields-table">
+                                <TableHead>
+                                  <TableRow>
+                                    <StyledTableHeadColumn width="30%">
+                                      Data field name
+                                    </StyledTableHeadColumn>
+                                    <StyledTableHeadColumn width="30%">
+                                      Answer type
+                                    </StyledTableHeadColumn>
+                                    <StyledTableHeadColumn width="40%">
+                                      Example value
+                                    </StyledTableHeadColumn>
+                                  </TableRow>
+                                </TableHead>
+                                {dataFields.map((field) => {
+                                  return (
+                                    <TableRow
+                                      key={field.id}
+                                      data-test={`data-field-row`}
+                                    >
+                                      <SpacedTableColumn>
+                                        {field.fieldName}
+                                      </SpacedTableColumn>
+                                      <SpacedTableColumn>
+                                        {field.type === "string" && "Text"}
+                                      </SpacedTableColumn>
+                                      <SpacedTableColumn>
+                                        {field.exampleValue}
+                                      </SpacedTableColumn>
+                                    </TableRow>
+                                  );
+                                })}
+                                {/* {surveyData?.prepopSchemaVersions && (
+                                  <StyledTableBody> */}
+                                {/* {surveyData?.prepopSchemaVersions?.versions?.map(
+                                        (version) => {
+                                          return (
+                                            <TableRow
+                                              key={version.id}
+                                              data-test={`dataset-row`}
+                                            >
+                                              <SpacedTableColumn>
+                                                {version.version}
+                                              </SpacedTableColumn>
+                                              <SpacedTableColumn>
+                                                {formatDate(
+                                                  version.dateCreated
+                                                )}
+                                              </SpacedTableColumn>
+                                              <SpacedTableColumn>
+                                                <StyledButton
+                                                  onClick={() =>
+                                                    linkPrepopSchema({
+                                                      variables: {
+                                                        input: {
+                                                          id: version.id,
+                                                          surveyId: surveyID,
+                                                          version:
+                                                            version.version,
+                                                          dateCreated:
+                                                            version.dateCreated,
+                                                        },
+                                                      },
+                                                    })
+                                                  }
+                                                  type="button"
+                                                  variant="secondary"
+                                                  data-test="btn-link"
+                                                >
+                                                  Link
+                                                </StyledButton>
+                                              </SpacedTableColumn>
+                                            </TableRow>
+                                          );
+                                        }
+                                      )} */}
+                                {/* </StyledTableBody>
+                                )} */}
+                              </Table>
+                            </DataFieldsWrapper>
                           </>
                         )}
                       </Common.StyledPanel>

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -154,8 +154,7 @@ const ONSDatasetPage = () => {
 
   const buildData = () => {
     let schemaData;
-
-    if (prepopSchema?.prepopSchema?.surveyId === "999") {
+    if (prepopSchema?.prepopSchema?.data) {
       schemaData = prepopSchema ? prepopSchema.prepopSchema : null;
     } else {
       schemaData = prepopSchema

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -153,12 +153,8 @@ const ONSDatasetPage = () => {
   });
 
   const buildData = () => {
-    const schemaData = prepopSchema
-      ? prepopSchema.prepopSchema
-        ? prepopSchema.prepopSchema.schema
-        : null
-      : null;
-
+    console.log("prepopSchema", prepopSchema);
+    const schemaData = prepopSchema ? prepopSchema.prepopSchema : null;
     if (schemaData) {
       schemaData.surveyId = prepopSchema.prepopSchema?.surveyId;
     }
@@ -280,6 +276,10 @@ const ONSDatasetPage = () => {
                                                         input: {
                                                           id: version.id,
                                                           surveyId: surveyID,
+                                                          version:
+                                                            version.version,
+                                                          dateCreated:
+                                                            version.dateCreated,
                                                         },
                                                       },
                                                     })

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -376,7 +376,7 @@ const ONSDatasetPage = () => {
                                   </StyledLi>
                                   <StyledLi>
                                     multivalued data fields, which have one or
-                                    more entities and are only available for
+                                    more entries and are only available for
                                     piping in repeating sections
                                   </StyledLi>
                                 </StyledUl>

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -425,52 +425,6 @@ const ONSDatasetPage = () => {
                                     </TableRow>
                                   );
                                 })}
-                                {/* {surveyData?.prepopSchemaVersions && (
-                                  <StyledTableBody> */}
-                                {/* {surveyData?.prepopSchemaVersions?.versions?.map(
-                                        (version) => {
-                                          return (
-                                            <TableRow
-                                              key={version.id}
-                                              data-test={`dataset-row`}
-                                            >
-                                              <SpacedTableColumn>
-                                                {version.version}
-                                              </SpacedTableColumn>
-                                              <SpacedTableColumn>
-                                                {formatDate(
-                                                  version.dateCreated
-                                                )}
-                                              </SpacedTableColumn>
-                                              <SpacedTableColumn>
-                                                <StyledButton
-                                                  onClick={() =>
-                                                    linkPrepopSchema({
-                                                      variables: {
-                                                        input: {
-                                                          id: version.id,
-                                                          surveyId: surveyID,
-                                                          version:
-                                                            version.version,
-                                                          dateCreated:
-                                                            version.dateCreated,
-                                                        },
-                                                      },
-                                                    })
-                                                  }
-                                                  type="button"
-                                                  variant="secondary"
-                                                  data-test="btn-link"
-                                                >
-                                                  Link
-                                                </StyledButton>
-                                              </SpacedTableColumn>
-                                            </TableRow>
-                                          );
-                                        }
-                                      )} */}
-                                {/* </StyledTableBody>
-                                )} */}
                               </Table>
                             </DataFieldsWrapper>
                           </>

--- a/eq-author/src/App/dataSettings/ONSDataset/index.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.js
@@ -153,8 +153,18 @@ const ONSDatasetPage = () => {
   });
 
   const buildData = () => {
-    console.log("prepopSchema", prepopSchema);
-    const schemaData = prepopSchema ? prepopSchema.prepopSchema : null;
+    let schemaData;
+
+    if (prepopSchema?.prepopSchema?.surveyId === "999") {
+      schemaData = prepopSchema ? prepopSchema.prepopSchema : null;
+    } else {
+      schemaData = prepopSchema
+        ? prepopSchema.prepopSchema
+          ? prepopSchema.prepopSchema.schema
+          : null
+        : null;
+    }
+
     if (schemaData) {
       schemaData.surveyId = prepopSchema.prepopSchema?.surveyId;
     }

--- a/eq-author/src/App/dataSettings/ONSDataset/index.test.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.test.js
@@ -299,6 +299,8 @@ describe("ONS dataset page", () => {
       expect(getByText("ID:")).toBeTruthy();
       expect(getByText("Version:")).toBeTruthy();
       expect(getByText("Date created:")).toBeTruthy();
+      expect(getByText("Data fields available for piping")).toBeTruthy();
+      expect(getByText("Public Limited Company")).toBeTruthy();
     });
   });
 

--- a/eq-author/src/App/dataSettings/ONSDataset/index.test.js
+++ b/eq-author/src/App/dataSettings/ONSDataset/index.test.js
@@ -145,29 +145,100 @@ describe("ONS dataset page", () => {
               input: {
                 id: "123-333-789",
                 surveyId: "123",
+                version: "1",
+                dateCreated: "2023-01-12T13:37:27+00:00",
               },
             },
           },
           result: () => {
             return {
               data: {
-                updatePrepopSchema: {
-                  id: "123-333-789",
-                  surveyId: "123",
-                  schema: {
-                    id: "123-333-789",
-                    version: "1",
-                    dateCreated: "2023-01-12T13:37:27+00:00",
-                    turnover: {
-                      type: "number",
-                      example: "1000",
+                id: "121",
+                schema: {
+                  $schema: "https://json-schema.org/draft/2020-12/schema",
+                  $id: "roofing_tiles_and_slate.json",
+                  title: "SDS schema for the Roofing Tiles + Slate survey",
+                  type: "object",
+                  properties: {
+                    schemaVersion: {
+                      const: "v1",
+                      description: "Version of the schema spec",
                     },
-                    employeeCount: {
-                      type: "number",
-                      example: "50",
+                    identifier: {
+                      type: "string",
+                      description:
+                        "The unique top-level identifier. This is the reporting unit reference without the check letter appended",
+                      minLength: 11,
+                      pattern: "^[a-zA-Z0-9]+$",
+                      examples: ["34942807969"],
+                    },
+                    companyName: {
+                      type: "string",
+                      minLength: 1,
+                      examples: ["Joe Bloggs PLC"],
+                    },
+                    companyType: {
+                      type: "string",
+                      minLength: 1,
+                      examples: ["Public Limited Company"],
+                    },
+                    items: {
+                      type: "object",
+                      properties: {
+                        localUnits: {
+                          type: "array",
+                          description: "The data about each item",
+                          minItems: 1,
+                          uniqueItems: true,
+                          items: {
+                            type: "object",
+                            properties: {
+                              identifier: {
+                                type: "string",
+                                minLength: 1,
+                                description:
+                                  "The unique identifier for the items. This is the local unit reference.",
+                                examples: ["3340224"],
+                              },
+                              luName: {
+                                type: "string",
+                                minLength: 1,
+                                description: "Name of the local unit",
+                                examples: ["STUBBS BUILDING PRODUCTS LTD"],
+                              },
+                              luAddress: {
+                                type: "array",
+                                description:
+                                  "The fields of the address for the local unit",
+                                items: {
+                                  type: "string",
+                                  minLength: 1,
+                                },
+                                minItems: 1,
+                                uniqueItems: true,
+                                examples: [
+                                  [
+                                    "WELLINGTON ROAD",
+                                    "LOCHMABEN",
+                                    "SWINDON",
+                                    "BEDS",
+                                    "GLOS",
+                                    "DE41 2WA",
+                                  ],
+                                ],
+                              },
+                            },
+                            additionalProperties: false,
+                            required: ["identifier", "lu_name", "lu_address"],
+                          },
+                        },
+                      },
+                      additionalProperties: false,
+                      required: ["local_units"],
                     },
                   },
-                  __typename: "PrepopSchema",
+                  additionalProperties: false,
+                  required: ["schema_version", "identifier", "items"],
                 },
               },
             };
@@ -197,19 +268,23 @@ describe("ONS dataset page", () => {
         data: {
           prepopSchema: {
             id: "121-222-789",
-            schema: {
-              id: "121-222-789",
-              version: "1",
-              dateCreated: "2023-01-12T13:37:27+00:00",
-              turnover: {
-                type: "number",
-                example: "1000",
+            surveyId: "121",
+            version: "2",
+            dateCreated: "2023-01-12T13:37:27+00:00",
+            data: [
+              {
+                fieldName: "company_name",
+                type: "string",
+                id: "84b92922-308d-40bb-bd6d-6c0f06e37c75",
+                exampleValue: "Joe Bloggs PLC",
               },
-              employeeCount: {
-                type: "number",
-                example: "50",
+              {
+                type: "string",
+                fieldName: "company_type",
+                id: "5a92b57f-5e16-4bc2-a159-01bf63a5af13",
+                exampleValue: "Public Limited Company",
               },
-            },
+            ],
           },
         },
       }));
@@ -220,7 +295,7 @@ describe("ONS dataset page", () => {
         user,
         mocks
       );
-      expect(getByText("Dataset for survey ID")).toBeTruthy();
+      expect(getByText("Dataset for survey ID 121")).toBeTruthy();
       expect(getByText("ID:")).toBeTruthy();
       expect(getByText("Version:")).toBeTruthy();
       expect(getByText("Date created:")).toBeTruthy();
@@ -235,19 +310,23 @@ describe("ONS dataset page", () => {
         data: {
           prepopSchema: {
             id: "121-222-789",
-            schema: {
-              id: "121-222-789",
-              version: "1",
-              dateCreated: "2023-01-12T13:37:27+00:00",
-              turnover: {
-                type: "number",
-                example: "1000",
+            surveyId: "121",
+            version: "2",
+            dateCreated: "2023-01-12T13:37:27+00:00",
+            data: [
+              {
+                fieldName: "company_name",
+                type: "string",
+                id: "84b92922-308d-40bb-bd6d-6c0f06e37c75",
+                exampleValue: "Joe Bloggs PLC",
               },
-              employeeCount: {
-                type: "number",
-                example: "50",
+              {
+                type: "string",
+                fieldName: "company_type",
+                id: "5a92b57f-5e16-4bc2-a159-01bf63a5af13",
+                exampleValue: "Public Limited Company",
               },
-            },
+            ],
           },
         },
       }));
@@ -288,6 +367,32 @@ describe("ONS dataset page", () => {
     });
 
     it("should close the Unlink dataset modal", async () => {
+      useQuery.mockImplementationOnce(() => ({
+        loading: false,
+        error: false,
+        data: {
+          prepopSchema: {
+            id: "121-222-789",
+            surveyId: "121",
+            version: "2",
+            dateCreated: "2023-01-12T13:37:27+00:00",
+            data: [
+              {
+                fieldName: "company_name",
+                type: "string",
+                id: "84b92922-308d-40bb-bd6d-6c0f06e37c75",
+                exampleValue: "Joe Bloggs PLC",
+              },
+              {
+                type: "string",
+                fieldName: "company_type",
+                id: "5a92b57f-5e16-4bc2-a159-01bf63a5af13",
+                exampleValue: "Public Limited Company",
+              },
+            ],
+          },
+        },
+      }));
       const { getByTestId, queryByTestId } = renderONSDatasetPage(
         questionnaire,
         props,

--- a/eq-author/src/constants/surveyIDs.js
+++ b/eq-author/src/constants/surveyIDs.js
@@ -1,1 +1,1 @@
-export const SURVEY_IDS = ["121", "122", "123"];
+export const SURVEY_IDS = ["121", "122", "123", "999"];

--- a/eq-author/src/constants/surveyIDs.js
+++ b/eq-author/src/constants/surveyIDs.js
@@ -1,1 +1,1 @@
-export const SURVEY_IDS = ["121", "122", "123", "999"];
+export const SURVEY_IDS = ["121", "122", "123"];

--- a/eq-author/src/graphql/fragments/prepopSchema.graphql
+++ b/eq-author/src/graphql/fragments/prepopSchema.graphql
@@ -2,4 +2,7 @@ fragment PrepopSchema on PrepopSchema {
   id
   surveyId
   schema
+  data
+  dateCreated
+  version
 }

--- a/eq-author/src/graphql/fragments/prepopSchema.graphql
+++ b/eq-author/src/graphql/fragments/prepopSchema.graphql
@@ -1,7 +1,6 @@
 fragment PrepopSchema on PrepopSchema {
   id
   surveyId
-  schema
   data
   dateCreated
   version


### PR DESCRIPTION
### What is the context of this PR?

This PR is linked to this [Jira ticket](https://jira.ons.gov.uk/browse/EAR-2130)

### How to review

Checkout `EAR-2130-implement-prepop-schema-processing`

- Enable the `dataset` feature flag and:
  - navigate to the ONS dataset page
  - from the survey id drop drown select a survey and link one of the datasets
  - check that the data fields text and table is displayed
- Open the author schema while the dataset is still linked and:
  - ensure that the prepop schema has the following fields id, surveyId, version, datecreated and data
  - under the `data` block, ensure that the array is populated with objects that have one of `company_name` and `company_type` as the `fieldName`
     - Check that the `exampleValue` and `fieldName` match the values displayed on the front end 
     - ensure that the `company_name` and `company_type` objects adopt their respective attributes which can be found in the `properties` block in this [SDS schema](https://sds-api-mock-gateway-74jbrn8r.nw.gateway.dev/schemaVersionGet?id=121) 
- Confirm that when you unlink the dataset, the `prepopSchema` block is deleted

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
