### PR TITLE
Change default setting for Previewing Questions and add guidance

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1030,7 +1030,7 @@ const Resolvers = {
       };
     }),
     createList: createMutation(async (root, _, ctx) => {
-      const list = createList();
+      const list = createList(ctx);
       if (!ctx.questionnaire.collectionLists) {
         ctx.questionnaire.collectionLists = {
           id: uuidv4(),

--- a/eq-author-api/schema/tests/lists.test.js
+++ b/eq-author-api/schema/tests/lists.test.js
@@ -38,6 +38,9 @@ describe("Lists", () => {
     const { lists } = await createList(ctx);
     expect(lists[0].listName).toBeNull();
     expect(ctx.questionnaire.collectionLists.lists.length).toEqual(1);
+    //TODO: previewQuestions
+    expect(ctx.questionnaire.introduction.previewQuestions).toBe(false);
+    expect(ctx.questionnaire.introduction.disallowPreviewQuestions).toBe(true);
   });
 
   it("Can update a list", async () => {
@@ -55,6 +58,9 @@ describe("Lists", () => {
     expect(ctx.questionnaire.collectionLists.lists.length).toEqual(1);
     await deleteList(ctx, input);
     expect(ctx.questionnaire.collectionLists.lists.length).toEqual(0);
+    //TODO: previewQuestions
+    expect(ctx.questionnaire.introduction.previewQuestions).toBe(false);
+    expect(ctx.questionnaire.introduction.disallowPreviewQuestions).toBe(false);
   });
 
   it("Can add an answer to a list", async () => {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -715,6 +715,7 @@ type QuestionnaireIntroduction {
   tertiaryTitle: String!
   tertiaryDescription: String!
   previewQuestions: Boolean
+  disallowPreviewQuestions: Boolean
   questionnaire: Questionnaire
   validationErrorInfo: ValidationErrorInfo
   comments: [Comment]

--- a/eq-author-api/src/businessLogic/createList.js
+++ b/eq-author-api/src/businessLogic/createList.js
@@ -1,9 +1,13 @@
 const { v4: uuidv4 } = require("uuid");
 
-const createList = () => ({
-  id: uuidv4(),
-  listName: null,
-  answers: [],
-});
+const createList = (ctx) => {
+  ctx.questionnaire.introduction.previewQuestions = false;
+  ctx.questionnaire.introduction.disallowPreviewQuestions = true;
+  return {
+    id: uuidv4(),
+    listName: null,
+    answers: [],
+  };
+};
 
 module.exports = createList;

--- a/eq-author-api/src/businessLogic/onListDeleted.js
+++ b/eq-author-api/src/businessLogic/onListDeleted.js
@@ -22,4 +22,11 @@ module.exports = (ctx, list) => {
       onAnswerDeleted(ctx, list, answer, pages);
     });
   }
+
+  if (
+    ctx.questionnaire.lists === undefined ||
+    ctx.questionnaire.lists.length === 0
+  ) {
+    ctx.questionnaire.introduction.disallowPreviewQuestions = false;
+  }
 };

--- a/eq-author-api/utils/createQuestionnaireIntroduction.js
+++ b/eq-author-api/utils/createQuestionnaireIntroduction.js
@@ -27,6 +27,7 @@ module.exports = (metadata) => {
     legalBasis: NOTICE_1,
     // TODO: previewQuestions
     previewQuestions: false,
+    disallowPreviewQuestions: false,
     secondaryTitle: "<p>Information you need</p>",
     secondaryDescription:
       "<p>You can select the dates of the period you are reporting for, if the given dates are not appropriate.</p>",

--- a/eq-author-api/utils/createQuestionnaireIntroduction.js
+++ b/eq-author-api/utils/createQuestionnaireIntroduction.js
@@ -26,7 +26,7 @@ module.exports = (metadata) => {
       "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. </li><li>You can provide info estimates if actual figures are not available.</li><li>We will treat your data securely and confidentially.</li></ul>",
     legalBasis: NOTICE_1,
     // TODO: previewQuestions
-    // previewQuestions: true,
+    previewQuestions: false,
     secondaryTitle: "<p>Information you need</p>",
     secondaryDescription:
       "<p>You can select the dates of the period you are reporting for, if the given dates are not appropriate.</p>",

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/index.js
@@ -28,6 +28,7 @@ const Detail = styled.div`
   position: relative;
 `;
 
+
 const DetailHeader = styled.div`
   position: absolute;
   top: 0.5em;

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -203,6 +203,56 @@ exports[`IntroductionEditor should render 1`] = `
   </IntroductionEditor__Section>
   <IntroductionEditor__Section>
     <IntroductionEditor__Padding>
+      <IntroductionEditor__InlineField
+        disabled={true}
+        style={
+          Object {
+            "marginBottom": "0",
+          }
+        }
+      >
+        <Label
+          bold={true}
+          labelFor="toggle-preview-questions"
+          style={
+            Object {
+              "color": "#7a7a7a",
+              "marginBottom": "0",
+            }
+          }
+        >
+          Include a link to a page for previewing the questions
+        </Label>
+        <ToggleSwitch
+          blockDisplay={false}
+          checked={true}
+          hideLabels={false}
+          id="toggle-preview-questions"
+          name="toggle-preview-questions"
+          onChange={[Function]}
+        />
+      </IntroductionEditor__InlineField>
+      <IntroductionEditor__SectionDescription
+        style={
+          Object {
+            "color": "#7a7a7a",
+            "marginBottom": "1em",
+          }
+        }
+      >
+        Each section is represented as a collapsible element, allowing users to show and hide its respective questions.
+      </IntroductionEditor__SectionDescription>
+      <Panel
+        variant="warning"
+        withList={false}
+        withPanelMargin={true}
+      >
+        Adding a collection list will automatically turn off and disable this previewing questions setting.
+      </Panel>
+    </IntroductionEditor__Padding>
+  </IntroductionEditor__Section>
+  <IntroductionEditor__Section>
+    <IntroductionEditor__Padding>
       <IntroductionEditor__SectionTitle
         style={
           Object {

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -44,6 +44,7 @@ exports[`IntroductionEditor should render 1`] = `
         withoutMargin={true}
       />
       <Panel
+        data-testid="introduction-content-info-panel"
         variant="warning"
         withList={false}
         withPanelMargin={true}
@@ -196,9 +197,15 @@ exports[`IntroductionEditor should render 1`] = `
       <IntroductionEditor__SectionTitle>
         Legal basis
       </IntroductionEditor__SectionTitle>
-      <InformationPanel>
+      <Panel
+        data-testid="legal-basis-info-panel"
+        variant="info"
+        withLeftBorder={true}
+        withList={false}
+        withPanelMargin={true}
+      >
         The legal basis can be changed on the Settings page
-      </InformationPanel>
+      </Panel>
     </IntroductionEditor__Padding>
   </IntroductionEditor__Section>
   <IntroductionEditor__Section>
@@ -233,6 +240,7 @@ exports[`IntroductionEditor should render 1`] = `
         />
       </IntroductionEditor__InlineField>
       <IntroductionEditor__SectionDescription
+        data-testid=""
         style={
           Object {
             "color": "#7a7a7a",
@@ -243,11 +251,12 @@ exports[`IntroductionEditor should render 1`] = `
         Each section is represented as a collapsible element, allowing users to show and hide its respective questions.
       </IntroductionEditor__SectionDescription>
       <Panel
+        data-testid="preview-questions-warn-panel"
         variant="warning"
         withList={false}
         withPanelMargin={true}
       >
-        Adding a collection list will automatically turn off and disable this previewing questions setting.
+        Adding a collection list will automatically turn off and disable this setting.
       </Panel>
     </IntroductionEditor__Padding>
   </IntroductionEditor__Section>

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -198,7 +198,6 @@ exports[`IntroductionEditor should render 1`] = `
         Legal basis
       </IntroductionEditor__SectionTitle>
       <Panel
-        data-testid="legal-basis-info-panel"
         variant="info"
         withLeftBorder={true}
         withList={false}
@@ -208,7 +207,9 @@ exports[`IntroductionEditor should render 1`] = `
       </Panel>
     </IntroductionEditor__Padding>
   </IntroductionEditor__Section>
-  <IntroductionEditor__Section>
+  <IntroductionEditor__Section
+    name="previewQuestions-section"
+  >
     <IntroductionEditor__Padding>
       <IntroductionEditor__InlineField
         disabled={true}
@@ -240,7 +241,6 @@ exports[`IntroductionEditor should render 1`] = `
         />
       </IntroductionEditor__InlineField>
       <IntroductionEditor__SectionDescription
-        data-testid=""
         style={
           Object {
             "color": "#7a7a7a",
@@ -252,6 +252,7 @@ exports[`IntroductionEditor should render 1`] = `
       </IntroductionEditor__SectionDescription>
       <Panel
         data-testid="preview-questions-warn-panel"
+        name="preview-questions-warn-panel"
         variant="warning"
         withList={false}
         withPanelMargin={true}

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -347,13 +347,13 @@ const IntroductionEditor = ({ introduction, history }) => {
           />
 
           <SectionTitle>Legal basis</SectionTitle>
-          <Panel withLeftBorder data-testid="legal-basis-info-panel">
+          <Panel withLeftBorder>
             The legal basis can be changed on the Settings page
           </Panel>
         </Padding>
       </Section>
       {/* //TODO: previewQuestions */}
-      <Section>
+      <Section name="previewQuestions-section">
         <Padding>
           <InlineField
             style={{ marginBottom: "0" }}
@@ -387,7 +387,6 @@ const IntroductionEditor = ({ introduction, history }) => {
             />
           </InlineField>
           <SectionDescription
-            data-testid=""
             style={{
               color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
               marginBottom: "1em",
@@ -397,7 +396,11 @@ const IntroductionEditor = ({ introduction, history }) => {
             to show and hide its respective questions.
           </SectionDescription>
           {previewQuestions ? (
-            <Panel data-testid="preview-questions-warn-panel" variant="warning">
+            <Panel
+              data-testid="preview-questions-warn-panel"
+              name="preview-questions-warn-panel"
+              variant="warning"
+            >
               Adding a collection list will automatically turn off and disable
               this setting.
             </Panel>

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -352,26 +352,21 @@ const IntroductionEditor = ({ introduction, history }) => {
       {/* //TODO: previewQuestions */}
       <Section>
         <Padding>
-          <SectionTitle
-            style={{
-              color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
-            }}
-          >
-            Include a link to a page for previewing the questions
-          </SectionTitle>
-          <SectionDescription
-            style={{
-              color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
-            }}
-          >
-            Each section is represented as a collapsible element, allowing users
-            to show and hide its respective questions.
-          </SectionDescription>
           <InlineField
             style={{ marginBottom: "0" }}
             disabled={disallowPreviewQuestions}
           >
-            <Label>Preview questions</Label>
+            <Label
+              labelFor="toggle-preview-questions"
+              style={{
+                color: disallowPreviewQuestions
+                  ? colors.mediumGrey
+                  : colors.text,
+                marginBottom: "0",
+              }}
+            >
+              Include a link to a page for previewing the questions
+            </Label>
             <ToggleSwitch
               id="toggle-preview-questions"
               name="toggle-preview-questions"
@@ -388,6 +383,15 @@ const IntroductionEditor = ({ introduction, history }) => {
               checked={previewQuestions}
             />
           </InlineField>
+          <SectionDescription
+            style={{
+              color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
+              marginBottom: "0",
+            }}
+          >
+            Each section is represented as a collapsible element, allowing users
+            to show and hide its respective questions.
+          </SectionDescription>
           {disallowPreviewQuestions ? (
             <InformationPanel>
               A link for previewing the questions cannot be provided for

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -13,6 +13,7 @@ import { buildSettingsPath } from "utils/UrlUtils";
 import RichTextEditor from "components/RichTextEditor";
 import ValidationError from "components/ValidationError";
 import { InformationPanel } from "components/Panel";
+
 import { Field, Input, Label } from "components/Forms";
 import ToggleSwitch from "components/buttons/ToggleSwitch";
 import Panel from "components-themed/panels";
@@ -386,13 +387,18 @@ const IntroductionEditor = ({ introduction, history }) => {
           <SectionDescription
             style={{
               color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
-              marginBottom: "0",
+              marginBottom: "1em",
             }}
           >
             Each section is represented as a collapsible element, allowing users
             to show and hide its respective questions.
           </SectionDescription>
-          {disallowPreviewQuestions ? (
+          {previewQuestions ? (
+            <Panel variant="warning">
+              Adding a collection list will automatically turn off and disable
+              this previewing questions setting.
+            </Panel>
+          ) : disallowPreviewQuestions ? (
             <InformationPanel>
               A link for previewing the questions cannot be provided for
               questionnaires that contain list collector question patterns.

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import { useQuery, useMutation } from "@apollo/react-hooks";
+import { useMutation } from "@apollo/react-hooks";
 import { useParams, Link } from "react-router-dom";
 
 import { colors } from "constants/theme";
@@ -21,9 +21,6 @@ import IntroductionHeader from "../../IntroductionHeader";
 import CollapsiblesEditor from "./CollapsiblesEditor";
 
 import UPDATE_INTRODUCTION_MUTATION from "graphql/updateQuestionnaireIntroduction.graphql";
-import COLLECTION_LISTS from "graphql/lists/collectionLists.graphql";
-
-const { logger } = require("../../../../utils/logger");
 
 const Section = styled.section`
   &:not(:last-of-type) {
@@ -106,8 +103,8 @@ const IntroductionEditor = ({ introduction, history }) => {
     contactDetailsIncludeRuRef,
     additionalGuidancePanel,
     additionalGuidancePanelSwitch,
-    // TODO: previewQuestions
     previewQuestions,
+    disallowPreviewQuestions,
     secondaryTitle,
     secondaryDescription,
     tertiaryTitle,
@@ -122,8 +119,6 @@ const IntroductionEditor = ({ introduction, history }) => {
   const [phoneNumber, setPhoneNumber] = useState(contactDetailsPhoneNumber);
   const [email, setEmail] = useState(contactDetailsEmailAddress);
   const [emailSubject, setEmailSubject] = useState(contactDetailsEmailSubject);
-  const [disablePreviewQuestions, setDisablePreviewQuestions] = useState(false);
-  const [lists, setLists] = useState([]);
 
   const { errors } = validationErrorInfo;
 
@@ -136,32 +131,6 @@ const IntroductionEditor = ({ introduction, history }) => {
   };
 
   const params = useParams();
-
-  // TODO: previewQuestions
-  const { data } = useQuery(COLLECTION_LISTS, {
-    fetchPolicy: "cache-and-network",
-  });
-
-  useEffect(() => {
-    if (data) {
-      setLists(data.collectionLists?.lists || []);
-    }
-  
-    if (lists.length > 0) {
-      setDisablePreviewQuestions(true);
-      updateQuestionnaireIntroduction({
-        variables: {
-          input: {
-            previewQuestions: false,
-          },
-        },
-      })
-    }else{
-      setDisablePreviewQuestions(false);
-    }
-    
-  },[data, lists, disablePreviewQuestions,updateQuestionnaireIntroduction] )
-
   return (
     <>
       <IntroductionHeader history={history} />
@@ -380,12 +349,29 @@ const IntroductionEditor = ({ introduction, history }) => {
           </InformationPanel>
         </Padding>
       </Section>
-      {/* //TODO: previewQuestions */ }
-      
+      {/* //TODO: previewQuestions */}
       <Section>
         <Padding>
-          <InlineField open={previewQuestions} style={{ marginBottom: "0" }} disabled={disablePreviewQuestions}>
-            <Label htmlFor="toggle-preview-questions">Preview questions</Label>
+          <SectionTitle
+            style={{
+              color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
+            }}
+          >
+            Include a link to a page for previewing the questions
+          </SectionTitle>
+          <SectionDescription
+            style={{
+              color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
+            }}
+          >
+            Each section is represented as a collapsible element, allowing users
+            to show and hide its respective questions.
+          </SectionDescription>
+          <InlineField
+            style={{ marginBottom: "0" }}
+            disabled={disallowPreviewQuestions}
+          >
+            <Label>Preview questions</Label>
             <ToggleSwitch
               id="toggle-preview-questions"
               name="toggle-preview-questions"
@@ -402,11 +388,12 @@ const IntroductionEditor = ({ introduction, history }) => {
               checked={previewQuestions}
             />
           </InlineField>
-          <SectionDescription>
-            This displays a link on the introduction page that takes respondents
-            to a preview of all the questions on one page in a collapsible
-            format.
-          </SectionDescription>
+          {disallowPreviewQuestions ? (
+            <InformationPanel>
+              A link for previewing the questions cannot be provided for
+              questionnaires that contain list collector question patterns.
+            </InformationPanel>
+          ) : null}
         </Padding>
       </Section>
       <Section>

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -12,7 +12,6 @@ import { buildSettingsPath } from "utils/UrlUtils";
 
 import RichTextEditor from "components/RichTextEditor";
 import ValidationError from "components/ValidationError";
-import { InformationPanel } from "components/Panel";
 
 import { Field, Input, Label } from "components/Forms";
 import ToggleSwitch from "components/buttons/ToggleSwitch";
@@ -173,7 +172,10 @@ const IntroductionEditor = ({ introduction, history }) => {
             testSelector="txt-intro-title"
             withoutMargin
           />
-          <Panel variant="warning">
+          <Panel
+            data-testid="introduction-content-info-panel"
+            variant="warning"
+          >
             You can have this page display on the Hub via the&nbsp;
             <Link to={`${buildSettingsPath(params)}`}>Settings page</Link>
           </Panel>
@@ -345,9 +347,9 @@ const IntroductionEditor = ({ introduction, history }) => {
           />
 
           <SectionTitle>Legal basis</SectionTitle>
-          <InformationPanel>
+          <Panel withLeftBorder data-testid="legal-basis-info-panel">
             The legal basis can be changed on the Settings page
-          </InformationPanel>
+          </Panel>
         </Padding>
       </Section>
       {/* //TODO: previewQuestions */}
@@ -385,6 +387,7 @@ const IntroductionEditor = ({ introduction, history }) => {
             />
           </InlineField>
           <SectionDescription
+            data-testid=""
             style={{
               color: disallowPreviewQuestions ? colors.mediumGrey : colors.text,
               marginBottom: "1em",
@@ -394,15 +397,15 @@ const IntroductionEditor = ({ introduction, history }) => {
             to show and hide its respective questions.
           </SectionDescription>
           {previewQuestions ? (
-            <Panel variant="warning">
+            <Panel data-testid="preview-questions-warn-panel" variant="warning">
               Adding a collection list will automatically turn off and disable
-              this previewing questions setting.
+              this setting.
             </Panel>
           ) : disallowPreviewQuestions ? (
-            <InformationPanel>
+            <Panel data-testid="preview-questions-info-panel" withLeftBorder>
               A link for previewing the questions cannot be provided for
               questionnaires that contain list collector question patterns.
-            </InformationPanel>
+            </Panel>
           ) : null}
         </Padding>
       </Section>

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.test.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.test.js
@@ -31,6 +31,7 @@ describe("IntroductionEditor", () => {
         contactDetailsIncludeRuRef: false,
         additionalGuidancePanelSwitch: false,
         previewQuestions: true,
+        disallowPreviewQuestions: true,
         additionalGuidancePanel: "additionalGuidancePanel",
         description: "description",
         secondaryTitle: "secondary title",
@@ -159,18 +160,18 @@ describe("IntroductionEditor", () => {
     expect(mockUseMutation).toHaveBeenCalledTimes(3);
   });
 
-  // TODO: previewQuestions
-  // it("should toggle preview questions", () => {
-  //   const mockUseMutation = jest.fn();
-  //   useMutation.mockImplementationOnce(jest.fn(() => [mockUseMutation]));
+  //TODO: previewQuestions;
+  it("should toggle preview questions", () => {
+    const mockUseMutation = jest.fn();
+    useMutation.mockImplementationOnce(jest.fn(() => [mockUseMutation]));
 
-  //   const wrapper = shallow(<IntroductionEditor {...props} />);
-  //   expect(
-  //     wrapper.find('[name="toggle-preview-questions"]').exists()
-  //   ).toBeTruthy();
-  //   wrapper
-  //     .find("#toggle-preview-questions")
-  //     .simulate("change", { target: { checked: false } });
-  //   expect(mockUseMutation).toHaveBeenCalledTimes(1);
-  // });
+    const wrapper = shallow(<IntroductionEditor {...props} />);
+    expect(
+      wrapper.find('[name="toggle-preview-questions"]').exists()
+    ).toBeTruthy();
+    wrapper
+      .find("#toggle-preview-questions")
+      .simulate("change", { target: { checked: false } });
+    expect(mockUseMutation).toHaveBeenCalledTimes(1);
+  });
 });

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.test.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.test.js
@@ -30,7 +30,7 @@ describe("IntroductionEditor", () => {
         contactDetailsEmailSubject: "Change of details",
         contactDetailsIncludeRuRef: false,
         additionalGuidancePanelSwitch: false,
-        previewQuestions: true,
+        previewQuestions: false,
         disallowPreviewQuestions: true,
         additionalGuidancePanel: "additionalGuidancePanel",
         description: "description",
@@ -58,7 +58,16 @@ describe("IntroductionEditor", () => {
   const { PHONE_NOT_ENTERED, EMAIL_NOT_ENTERED } = introductionErrors;
 
   it("should render", () => {
-    expect(shallow(<IntroductionEditor {...props} />)).toMatchSnapshot();
+    const propsWithPreviewQuestions = {
+      ...props,
+      introduction: {
+        ...props.introduction,
+        previewQuestions: true,
+      },
+    };
+    expect(
+      shallow(<IntroductionEditor {...propsWithPreviewQuestions} />)
+    ).toMatchSnapshot();
   });
 
   it("should toggle the additional guidance panel", () => {
@@ -161,17 +170,79 @@ describe("IntroductionEditor", () => {
   });
 
   //TODO: previewQuestions;
-  it("should toggle preview questions", () => {
-    const mockUseMutation = jest.fn();
-    useMutation.mockImplementationOnce(jest.fn(() => [mockUseMutation]));
+  describe("previewingQuestions", () => {
+    it("Should render previewQuestions section", () => {
+      const wrapper = shallow(<IntroductionEditor {...props} />);
+      expect(wrapper.find('[name="previewQuestions-section"]')).toBeTruthy();
+    });
 
-    const wrapper = shallow(<IntroductionEditor {...props} />);
-    expect(
-      wrapper.find('[name="toggle-preview-questions"]').exists()
-    ).toBeTruthy();
-    wrapper
-      .find("#toggle-preview-questions")
-      .simulate("change", { target: { checked: false } });
-    expect(mockUseMutation).toHaveBeenCalledTimes(1);
+    it("Should render previewQuestions toggle in off state", () => {
+      const wrapper = shallow(<IntroductionEditor {...props} />);
+      expect(
+        wrapper.find('[name="toggle-preview-questions"]').prop("checked")
+      ).toBe(false);
+    });
+
+    it("Should toggle preview questions", () => {
+      const mockUseMutation = jest.fn();
+      useMutation.mockImplementationOnce(jest.fn(() => [mockUseMutation]));
+
+      const wrapper = shallow(<IntroductionEditor {...props} />);
+      expect(
+        wrapper.find('[name="toggle-preview-questions"]').exists()
+      ).toBeTruthy();
+      wrapper
+        .find("#toggle-preview-questions")
+        .simulate("change", { target: { checked: false } });
+      expect(mockUseMutation).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should render the warning panel when previewQuestions is true", () => {
+      const propsWithPreviewQuestions = {
+        ...props,
+        introduction: {
+          ...props.introduction,
+          previewQuestions: true,
+        },
+      };
+      const wrapper = shallow(
+        <IntroductionEditor {...propsWithPreviewQuestions} />
+      );
+      expect(
+        wrapper.find('[data-testid="preview-questions-warn-panel"]').exists()
+      ).toBeTruthy();
+    });
+
+    it("Should render the disallow info panel when disallowPreviewQuestions is true", () => {
+      const propsWithDisallowPreviewQuestions = {
+        ...props,
+        introduction: {
+          ...props.introduction,
+          disallowPreviewQuestions: true,
+        },
+      };
+      const wrapper = shallow(
+        <IntroductionEditor {...propsWithDisallowPreviewQuestions} />
+      );
+      expect(
+        wrapper.find('[data-testid="preview-questions-info-panel"]').exists()
+      ).toBeTruthy();
+    });
+
+    it("should not render the warning panel when previewQuestions is false", () => {
+      const propsWithPreviewQuestions = {
+        ...props,
+        introduction: {
+          ...props.introduction,
+          previewQuestions: false,
+        },
+      };
+      const wrapper = shallow(
+        <IntroductionEditor {...propsWithPreviewQuestions} />
+      );
+      expect(
+        wrapper.find('[data-testid="preview-questions-warn-panel"]').exists()
+      ).toBeFalsy();
+    });
   });
 });

--- a/eq-author/src/graphql/fragments/introduction.graphql
+++ b/eq-author/src/graphql/fragments/introduction.graphql
@@ -14,6 +14,7 @@ fragment Introduction on QuestionnaireIntroduction {
   secondaryTitle
   secondaryDescription
   previewQuestions
+  disallowPreviewQuestions
   collapsibles {
     ...CollapsibleEditor
   }

--- a/eq-author/src/graphql/updateQuestionnaireIntroduction.graphql
+++ b/eq-author/src/graphql/updateQuestionnaireIntroduction.graphql
@@ -14,6 +14,7 @@ mutation UpdateQuestionnaireIntroduction(
     additionalGuidancePanel
     description
     previewQuestions
+    disallowPreviewQuestions
     secondaryTitle
     secondaryDescription
     showOnHub


### PR DESCRIPTION
### What is the context of this PR?

> Describe what you have changed as part of this task and why; include a link to the Trello card/GitHub issue, related pull requests, etc as required.
>

### How to review
[Jira Ticket ](https://jira.ons.gov.uk/browse/EAR-2148)
Create Questionnaire

1. Introduction Editor Page:
  - [ ] Include a link to a page for previewing the questions - Toggle by default should be off.
  - [ ] Include a link to a page for previewing the questions - Default text should not be greyed out.
  - [ ] Include a link to a page for previewing the questions - Should not have a warning or guidance message
  - [ ] Toggle on - Guidance warning should appear.
2. Collections List Page:
  - [ ] Add a new collection list.
3. Introduction Editor Page:
  - [ ] Include a link to a page for previewing the questions - Toggle should be off and disabled.
  - [ ] Include a link to a page for previewing the questions - Default text should be greyed out.
  - [ ] Include a link to a page for previewing the questions - Should have a Guidance message as per Jira Ticket/Figma
4. Collection List Page:
  - [ ] Delete the created list.
5. Introduction Editor Page:
  - [ ] Include a link to a page for previewing the questions - Toggle should be off and not disabled.
  - [ ] Include a link to a page for previewing the questions - Default text should not be greyed out.
  - [ ] Include a link to a page for previewing the questions - Should not have a warning or guidance message

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
