### PR TITLE
Add migration and tests

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -47,6 +47,7 @@ const migrations = [
   require("./updateIntroductionEnabledWithValidation"),
   require("./addRepeatingLabelAndInputFields"),
   require("./addCollectionListAnswerRepeatingProperties"),
+  require("./updateIntroductionPreviewQuestionsSettings"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.js
+++ b/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.js
@@ -1,0 +1,21 @@
+module.exports = function updateIntroductionPreviewQuestionsSettings(
+  questionnaire
+) {
+  if (questionnaire.introduction) {
+    if (!questionnaire.introduction.previewQuestions) {
+      questionnaire.introduction.previewQuestions = false;
+    }
+    if (!questionnaire.introduction.disallowPreviewQuestions) {
+      questionnaire.introduction.disallowPreviewQuestions = false;
+    }
+    if (
+      questionnaire.collectionLists &&
+      questionnaire.collectionLists.lists &&
+      questionnaire.collectionLists.lists.length > 0
+    ) {
+      questionnaire.introduction.previewQuestions = false;
+      questionnaire.introduction.disallowPreviewQuestions = true;
+    }
+    return questionnaire;
+  }
+};

--- a/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.test.js
+++ b/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.test.js
@@ -1,0 +1,92 @@
+const updateIntroductionPreviewQuestionsSettings = require("./updateIntroductionPreviewQuestionsSettings");
+
+describe("updateIntroductionPreviewQuestionsSettings", () => {
+  it("should check for introduction", () => {
+    const questionnaire = {};
+    expect(
+      updateIntroductionPreviewQuestionsSettings(questionnaire)
+    ).toBeFalsy();
+  });
+
+  it("should add preview questions equal to false if it doesnt exist", () => {
+    const questionnaire = { introduction: {} };
+    const updateIntroductionPreviewQuestion =
+      updateIntroductionPreviewQuestionsSettings(questionnaire);
+
+    expect(
+      updateIntroductionPreviewQuestion.introduction.previewQuestions
+    ).toBe(false);
+  });
+
+  it("should add disallow preview questions equal to false if it doesnt exist", () => {
+    const questionnaire = { introduction: {} };
+    const updateIntroductionPreviewQuestion =
+      updateIntroductionPreviewQuestionsSettings(questionnaire);
+
+    expect(
+      updateIntroductionPreviewQuestion.introduction.disallowPreviewQuestions
+    ).toBe(false);
+  });
+
+  it("should set previewQuestions to false and disallowPreviewQuestions to true if given a collection list is present", () => {
+    const questionnaire = {
+      introduction: {},
+      collectionLists: {
+        id: "collection-list-1",
+        lists: [
+          {
+            id: "list-1",
+            listName: "List 1",
+            answers: [
+              {
+                id: "list-answer-1",
+                type: "TextField",
+                label: "List answer 1",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const updateIntroductionPreviewQuestion =
+      updateIntroductionPreviewQuestionsSettings(questionnaire);
+
+    expect(
+      updateIntroductionPreviewQuestion.introduction.previewQuestions
+    ).toBe(false);
+    expect(
+      updateIntroductionPreviewQuestion.introduction.disallowPreviewQuestions
+    ).toBe(true);
+  });
+
+  it("should check if preview questions is true, confirm it changes to false as it passes through migration", () => {
+    const questionnaire = {
+      introduction: { previewQuestions: true },
+      collectionLists: {
+        id: "collection-list-1",
+        lists: [
+          {
+            id: "list-1",
+            listName: "List 1",
+            answers: [
+              {
+                id: "list-answer-1",
+                type: "TextField",
+                label: "List answer 1",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const updateIntroductionPreviewQuestion =
+      updateIntroductionPreviewQuestionsSettings(questionnaire);
+
+    expect(
+      updateIntroductionPreviewQuestion.introduction.previewQuestions
+    ).toBe(false);
+    expect(
+      updateIntroductionPreviewQuestion.introduction.disallowPreviewQuestions
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

**Add migration to update previewQuestions default settings.**

The issue that led to this:

With the list collector previewing toggle, if the user currently has a questionnaire with a collection list.

### How to review

To test the above, turn off the migration and import 2 questionnaires, one without a collection list and one with a collection list from pre-prod.
- [ ] Confirm there is no previewQuestions and disallowPreviewQuestions values in the export

Once imported turn on the migration

 1.  Questionnaire without a collection list should:
- [ ] Have previewQuestions = false and disallowPreviewQuestions = false
- [ ] On IntroductionEditor, confirm that it is turned off and allow you to change it.

 2.  Questionnaire with a collection list should:
- [ ] Have previewQuestions = false and disallowPreviewQuestions = true
- [ ] On IntroductionEditor, confirm that it is turned off and disabled 

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
