### PR TITLE
EAR-2075 update page descriptions and title

### DIFF
--- a/eq-author/src/App/page/Design/QuestionPageEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/index.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import gql from "graphql-tag";
 import { flowRight } from "lodash";
+import { colors } from "constants/theme";
 
 import getIdForObject from "utils/getIdForObject";
 import withChangeUpdate from "enhancers/withChangeUpdate";
@@ -47,9 +48,18 @@ import ValidationError from "components/ValidationError";
 const QuestionSegment = styled.div`
   padding: 0 2em;
 `;
+const PageTitleSegment = styled.div`
+  padding: 0 2em;
+`;
 
 const AddAnswerSegment = styled.div`
   padding: 0 2em 2em;
+`;
+
+const HorizontalRule = styled.hr`
+  border: 0;
+  border-top: 0.0625em solid ${colors.grey};
+  margin: 1.5em 0;
 `;
 
 const propTypes = {
@@ -123,13 +133,15 @@ export const UnwrappedQuestionPageEditor = (props) => {
             allCalculatedSummaryPages={allCalculatedSummaryPages}
           />
         </QuestionSegment>
-        <PageTitleContainer
-          inCollapsible
-          pageDescription={page.pageDescription}
-          errors={page.validationErrorInfo.errors}
-          onChange={onChange}
-          onUpdate={onUpdate}
-        />
+        <PageTitleSegment>
+          <PageTitleContainer
+            pageDescription={page.pageDescription}
+            errors={page.validationErrorInfo.errors}
+            onChange={onChange}
+            onUpdate={onUpdate}
+          />
+          <HorizontalRule />
+        </PageTitleSegment>
         <QuestionProperties
           page={page}
           onChange={onChange}

--- a/eq-author/src/App/questionConfirmation/Design/Editor.js
+++ b/eq-author/src/App/questionConfirmation/Design/Editor.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { propType } from "graphql-anywhere";
 import { flowRight } from "lodash/fp";
+import { colors } from "constants/theme";
 
 import confirmationFragment from "graphql/fragments/question-confirmation.graphql";
 import withValidationError from "enhancers/withValidationError";
@@ -26,6 +27,12 @@ const OptionsWrapper = styled.div`
 
 const MarginLessConfirmationOption = styled(ConfirmationOption)`
   margin-bottom: 0;
+`;
+
+const HorizontalRule = styled.hr`
+  border: 0;
+  border-top: 0.0625em solid ${colors.grey};
+  margin: 1.5em 0;
 `;
 
 export class UnwrappedEditor extends React.Component {
@@ -70,13 +77,13 @@ export class UnwrappedEditor extends React.Component {
           })}
         />
         <PageTitleContainer
-          inCollapsible
           marginless
           pageDescription={pageDescription}
           errors={this.props.confirmation.validationErrorInfo?.errors}
           onChange={onChange}
           onUpdate={onUpdate}
         />
+        <HorizontalRule />
         <OptionsWrapper>
           <ConfirmationOption
             label="Positive confirmation text"

--- a/eq-author/src/App/questionConfirmation/Design/__snapshots__/Editor.test.js.snap
+++ b/eq-author/src/App/questionConfirmation/Design/__snapshots__/Editor.test.js.snap
@@ -25,11 +25,11 @@ exports[`Editor Editor Component should autoFocus the title when there is not on
     value={null}
   />
   <PageTitleContainer
-    inCollapsible={true}
     marginless={true}
     onChange={[MockFunction]}
     onUpdate={[MockFunction]}
   />
+  <Editor__HorizontalRule />
   <Editor__OptionsWrapper>
     <withValidationError(UnwrappedConfirmationOption)
       confirmationoption={
@@ -107,11 +107,11 @@ exports[`Editor Editor Component should render 1`] = `
     value="My first confirmation"
   />
   <PageTitleContainer
-    inCollapsible={true}
     marginless={true}
     onChange={[MockFunction]}
     onUpdate={[MockFunction]}
   />
+  <Editor__HorizontalRule />
   <Editor__OptionsWrapper>
     <withValidationError(UnwrappedConfirmationOption)
       confirmationoption={

--- a/eq-author/src/components/PageTitle/PageTitleInput.js
+++ b/eq-author/src/components/PageTitle/PageTitleInput.js
@@ -17,6 +17,10 @@ const Heading = styled.h2`
   margin-bottom: 0.4em;
 `;
 
+const PageDescriptionContent = styled.div`
+  margin-bottom: 1.3em;
+`;
+
 const StyledInput = styled.input`
   width: 100%;
   font-size: 1em;
@@ -53,12 +57,12 @@ const PageTitleInput = ({
 }) => (
   <PageTitleContent>
     <Heading data-test="page-title-input-heading">{heading}</Heading>
-    <p>
+    <PageDescriptionContent>
       The page title is the first thing read by screen readers and helps users
       of assistive technology understand what the page is about. It is shown in
       the browser&apos;s title bar or in the page&apos;s tab. Page titles follow
       the structure: &apos;page description - questionnaire title&apos;.
-    </p>
+    </PageDescriptionContent>
     {/* From interaction designer - this will be brought back when the page titles link is fixed */}
     {/* <p>
       For help writing a page description, see our{" "}
@@ -104,7 +108,7 @@ PageTitleInput.propTypes = {
 };
 
 PageTitleInput.defaultProps = {
-  heading: "Descriptions and definitions",
+  heading: "Page title and description",
 };
 
 export default PageTitleInput;

--- a/eq-author/src/components/PageTitle/index.js
+++ b/eq-author/src/components/PageTitle/index.js
@@ -42,13 +42,13 @@ const PageTitleContainer = ({
   return (
     <div
       title="Page description"
-      className="pageDescriptionCollapsible"
+      className="pageDescription"
       dataTestIdPrefix="page-title-"
       defaultOpen
       withoutHideThis
       variant={marginless ? "marginlessContent" : "content"}
     >
-      <PageTitleSegment>
+      <PageTitleSegment data-test="page-title-container">
         <PageTitleInput
           heading={heading}
           pageDescription={pageDescription}

--- a/eq-author/src/components/PageTitle/index.js
+++ b/eq-author/src/components/PageTitle/index.js
@@ -1,23 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import Collapsible from "components/Collapsible";
 import { find } from "lodash";
 
 import PageTitleInput from "./PageTitleInput";
 
 import { pageDescriptionErrors } from "constants/validationMessages";
 
-const PageTitleContainerWithoutCollapsible = styled.div``;
-
-const PageTitleContainerWithCollapsible = styled.div`
-  margin-left: 1em;
-  margin-right: 1em;
+const PageTitleSegment = styled.div`
+  margin-top: 2em;
 `;
 
 const PageTitleContainer = ({
   heading,
-  inCollapsible,
   marginless,
   pageDescription,
   inputTitlePrefix,
@@ -44,49 +39,32 @@ const PageTitleContainer = ({
   );
 
   const errorMessage = pageDescriptionErrors[errorCode];
-
-  if (inCollapsible) {
-    return (
-      <Collapsible
-        title="Page description"
-        className="pageDescriptionCollapsible"
-        dataTestIdPrefix="page-title-"
-        defaultOpen
-        withoutHideThis
-        variant={marginless ? "marginlessContent" : "content"}
-      >
-        <PageTitleContainerWithCollapsible>
-          <PageTitleInput
-            heading={heading}
-            pageDescription={pageDescription}
-            inputTitlePrefix={inputTitlePrefix}
-            altFieldName={altFieldName}
-            onUpdate={onUpdate}
-            onChange={onChange}
-            errorMessage={errorMessage}
-          />
-        </PageTitleContainerWithCollapsible>
-      </Collapsible>
-    );
-  }
   return (
-    <PageTitleContainerWithoutCollapsible>
-      <PageTitleInput
-        heading={heading}
-        pageDescription={pageDescription}
-        inputTitlePrefix={inputTitlePrefix}
-        altFieldName={altFieldName}
-        onUpdate={onUpdate}
-        onChange={onChange}
-        errorMessage={errorMessage}
-      />
-    </PageTitleContainerWithoutCollapsible>
+    <div
+      title="Page description"
+      className="pageDescriptionCollapsible"
+      dataTestIdPrefix="page-title-"
+      defaultOpen
+      withoutHideThis
+      variant={marginless ? "marginlessContent" : "content"}
+    >
+      <PageTitleSegment>
+        <PageTitleInput
+          heading={heading}
+          pageDescription={pageDescription}
+          inputTitlePrefix={inputTitlePrefix}
+          altFieldName={altFieldName}
+          onUpdate={onUpdate}
+          onChange={onChange}
+          errorMessage={errorMessage}
+        />
+      </PageTitleSegment>
+    </div>
   );
 };
 
 PageTitleContainer.propTypes = {
   heading: PropTypes.string,
-  inCollapsible: PropTypes.bool,
   marginless: PropTypes.bool,
   pageDescription: PropTypes.string,
   inputTitlePrefix: PropTypes.string,

--- a/eq-author/src/components/PageTitle/index.test.js
+++ b/eq-author/src/components/PageTitle/index.test.js
@@ -6,7 +6,7 @@ import PageTitleContainer from ".";
 import PageTitleInput from "./PageTitleInput";
 
 describe("Page Title container block", () => {
-  it("should render without a collapsible", () => {
+  it("should render as expected", () => {
     render(
       <PageTitleContainer
         pageDescription="Test page title"
@@ -15,22 +15,7 @@ describe("Page Title container block", () => {
       />
     );
 
-    expect(
-      screen.queryByTestId("page-title-collapsible")
-    ).not.toBeInTheDocument();
-  });
-
-  it("should render with a collapsible", () => {
-    render(
-      <PageTitleContainer
-        inCollapsible
-        pageDescription="Test page title"
-        onChange={jest.fn()}
-        onUpdate={jest.fn()}
-      />
-    );
-
-    expect(screen.queryByTestId("page-title-collapsible")).toBeInTheDocument();
+    expect(screen.queryByTestId("page-title-container")).toBeInTheDocument();
   });
 });
 
@@ -45,7 +30,7 @@ describe("Page title input block", () => {
     );
 
     expect(screen.getByTestId("page-title-input-heading")).toHaveTextContent(
-      "Descriptions and definitions"
+      "Page title and description"
     );
     expect(
       screen.getByTestId("page-title-input-field-label")
@@ -102,7 +87,7 @@ describe("Page title input block", () => {
     );
 
     expect(screen.getByTestId("page-title-input-heading")).toHaveTextContent(
-      "Descriptions and definitions"
+      "Page title and description"
     );
     expect(
       screen.getByTestId("page-title-input-field-label")


### PR DESCRIPTION
https://jira.ons.gov.uk/browse/EAR-2075

### What is the context of this PR?

> Update the current design and guidance for page titles and descriptions by removing the collapsible.

### How to review
For question, calculated summary, confirmation and section pages:

> - [ ] Check the page description section is not in a collapsible 
> - [ ] Check the page description section follows the same design in the figma prototype
> - [ ] Check the page description section has the title 'Page title and description' 



### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
