### PR TITLE
EAR-2125 Empty decimal places error

### DIFF
--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1072,7 +1072,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should not validate if one of the two is disabled", () => {
+      it("should validate if one of the two is disabled", () => {
         ["minValue", "maxValue", "none"].forEach((entity) => {
           const answer = {
             id: "a1",
@@ -1125,7 +1125,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should not validate if one of the two is a previous answer", () => {
+      it("should validate if one of the two is a previous answer", () => {
         ["minValue", "maxValue", "none"].forEach((entity) => {
           const answer = {
             id: "a1",
@@ -1178,7 +1178,7 @@ describe("schema validation", () => {
           expect(pageErrors).toHaveLength(0);
         });
       });
-      it("should not validate if a number is not entered for decimals", () => {
+      it("should validate if a number is not entered for decimals", () => {
         [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
           const answer = {
             id: "a1",

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1072,7 +1072,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should validate if one of the two is disabled", () => {
+      it("should not validate if one of the two is disabled", () => {
         ["minValue", "maxValue", "none"].forEach((entity) => {
           const answer = {
             id: "a1",
@@ -1125,7 +1125,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should validate if one of the two is a previous answer", () => {
+      it("should not validate if one of the two is a previous answer", () => {
         ["minValue", "maxValue", "none"].forEach((entity) => {
           const answer = {
             id: "a1",
@@ -1178,6 +1178,7 @@ describe("schema validation", () => {
           expect(pageErrors).toHaveLength(0);
         });
       });
+
       it("should validate if a number is not entered for decimals", () => {
         [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
           const answer = {
@@ -1243,7 +1244,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should not validate if a number greater than 6 is entered for decimals", () => {
+      it("should validate if a number greater than 6 is entered for decimals", () => {
         [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
           const answer = {
             id: "a1",
@@ -1309,7 +1310,7 @@ describe("schema validation", () => {
         });
       });
 
-      it("should not validate if a number less than 0 is entered for decimals", () => {
+      it("should validate if a number less than 0 is entered for decimals", () => {
         [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
           const answer = {
             id: "a1",

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1230,7 +1230,7 @@ describe("schema validation", () => {
           expect(errors[0]).toMatchObject({
             id: uuidRejex,
             field: "decimals",
-            errorCode: "ERR_INVALID_DECIMAL",
+            errorCode: "ERR_VALID_REQUIRED",
             sectionId: "s1",
             type: "answer",
             pageId: "p1",

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1121,7 +1121,6 @@ describe("schema validation", () => {
             ],
           };
           const pageErrors = validation(questionnaire);
-
           expect(pageErrors).toHaveLength(0);
         });
       });
@@ -1177,6 +1176,136 @@ describe("schema validation", () => {
           const pageErrors = validation(questionnaire);
 
           expect(pageErrors).toHaveLength(0);
+        });
+      });
+      it("should not validate if a number is not entered for decimals", () => {
+        [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
+          const answer = {
+            id: "a1",
+            type,
+            label: "some answer",
+            qCode: "qCode1",
+            secondaryQCode: "secQCode1",
+            repeatingLabelAndInput: false,
+            repeatingLabelAndInputListId: "",
+            properties: {
+              required: false,
+              decimals: null,
+            },
+            validation: {
+              minValue: {
+                id: "123",
+                enabled: false,
+                validationType: "minValue",
+              },
+              maxValue: {
+                id: "321",
+                enabled: false,
+                validationType: "maxValue",
+              },
+            },
+          };
+
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                folders: [
+                  {
+                    pages: [
+                      {
+                        id: "p1",
+                        answers: [answer],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+          const errors = validation(questionnaire);
+
+          expect(errors).toHaveLength(1);
+          expect(errors[0]).toMatchObject({
+            id: uuidRejex,
+            field: "decimals",
+            errorCode: "ERR_INVALID_DECIMAL",
+            sectionId: "s1",
+            type: "answer",
+            pageId: "p1",
+            answerId: "a1",
+          });
+
+          answer.properties.decimals = 5;
+          const errors2 = validation(questionnaire);
+          expect(errors2).toHaveLength(0);
+        });
+      });
+
+      it("should not validate if a number greater than 6 is entered for decimals", () => {
+        [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
+          const answer = {
+            id: "a1",
+            type,
+            label: "some answer",
+            qCode: "qCode1",
+            secondaryQCode: "secQCode1",
+            repeatingLabelAndInput: false,
+            repeatingLabelAndInputListId: "",
+            properties: {
+              required: false,
+              decimals: 8,
+            },
+            validation: {
+              minValue: {
+                id: "123",
+                enabled: false,
+                validationType: "minValue",
+              },
+              maxValue: {
+                id: "321",
+                enabled: false,
+                validationType: "maxValue",
+              },
+            },
+          };
+
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                folders: [
+                  {
+                    pages: [
+                      {
+                        id: "p1",
+                        answers: [answer],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+          const errors = validation(questionnaire);
+
+          expect(errors).toHaveLength(1);
+          expect(errors[0]).toMatchObject({
+            id: uuidRejex,
+            field: "decimals",
+            errorCode: "ERR_INVALID_DECIMAL",
+            sectionId: "s1",
+            type: "answer",
+            pageId: "p1",
+            answerId: "a1",
+          });
+
+          answer.properties.decimals = 5;
+
+          const errors2 = validation(questionnaire);
+          expect(errors2).toHaveLength(0);
         });
       });
     });

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -1308,6 +1308,72 @@ describe("schema validation", () => {
           expect(errors2).toHaveLength(0);
         });
       });
+
+      it("should not validate if a number less than 0 is entered for decimals", () => {
+        [CURRENCY, NUMBER, UNIT, PERCENTAGE].forEach((type) => {
+          const answer = {
+            id: "a1",
+            type,
+            label: "some answer",
+            qCode: "qCode1",
+            secondaryQCode: "secQCode1",
+            repeatingLabelAndInput: false,
+            repeatingLabelAndInputListId: "",
+            properties: {
+              required: false,
+              decimals: -8,
+            },
+            validation: {
+              minValue: {
+                id: "123",
+                enabled: false,
+                validationType: "minValue",
+              },
+              maxValue: {
+                id: "321",
+                enabled: false,
+                validationType: "maxValue",
+              },
+            },
+          };
+
+          const questionnaire = {
+            id: "q1",
+            sections: [
+              {
+                id: "s1",
+                folders: [
+                  {
+                    pages: [
+                      {
+                        id: "p1",
+                        answers: [answer],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+          const errors = validation(questionnaire);
+
+          expect(errors).toHaveLength(1);
+          expect(errors[0]).toMatchObject({
+            id: uuidRejex,
+            field: "decimals",
+            errorCode: "ERR_INVALID_DECIMAL",
+            sectionId: "s1",
+            type: "answer",
+            pageId: "p1",
+            answerId: "a1",
+          });
+
+          answer.properties.decimals = 2;
+
+          const errors2 = validation(questionnaire);
+          expect(errors2).toHaveLength(0);
+        });
+      });
     });
   });
 

--- a/eq-author-api/src/validation/schemas/answer.json
+++ b/eq-author-api/src/validation/schemas/answer.json
@@ -158,9 +158,7 @@
           "type": "object",
           "properties": {
             "decimals": {
-              "not": { "type": "null" },
-              "maximum": 6,
-              "errorMessage": "ERR_INVALID_DECIMAL"
+              "$ref": "validation.json#/definitions/decimalValidations"
             }
           }
         }

--- a/eq-author-api/src/validation/schemas/answer.json
+++ b/eq-author-api/src/validation/schemas/answer.json
@@ -150,7 +150,21 @@
       "required": ["label"],
       "errorMessage": { "required": { "label": "ERR_VALID_REQUIRED" } }
     },
+
     "numericAnswer": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "properties": {
+            "decimals": {
+              "not": { "type": "null" },
+              "maximum": 6,
+              "errorMessage": "ERR_INVALID_DECIMAL"
+            }
+          }
+        }
+      },
       "if": {
         "type": "object",
         "properties": {

--- a/eq-author-api/src/validation/schemas/validation.json
+++ b/eq-author-api/src/validation/schemas/validation.json
@@ -161,6 +161,18 @@
         "maxDuration": { "$ref": "#/definitions/validationEntry" }
       }
     },
+    "decimalValidations": {
+      "allOf": [
+        {
+          "not": { "type": "null" },
+          "errorMessage": "ERR_VALID_REQUIRED"
+        },
+        {
+          "maximum": 6,
+          "errorMessage": "ERR_INVALID_DECIMAL"
+        }
+      ]
+    },
     "validationEntry": {
       "type": "object",
       "allOf": [

--- a/eq-author-api/src/validation/schemas/validation.json
+++ b/eq-author-api/src/validation/schemas/validation.json
@@ -168,6 +168,7 @@
           "errorMessage": "ERR_VALID_REQUIRED"
         },
         {
+          "minimum": 0,
           "maximum": 6,
           "errorMessage": "ERR_INVALID_DECIMAL"
         }

--- a/eq-author/src/components/AnswerContent/AnswerProperties/NumberProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/NumberProperties.js
@@ -1,8 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 import Decimal from "components/AnswerContent/Decimal";
 import Required from "components/AnswerContent/Required";
 import MultiLineField from "components/AnswerContent/Format/MultiLineField";
+
+const Paragraph = styled.p`
+  margin-top: 0em;
+  margin-bottom: 0.35em;
+`;
 
 const NumberProperties = ({
   answer,
@@ -13,7 +19,13 @@ const NumberProperties = ({
 }) => {
   return (
     <>
-      <MultiLineField id={`${answer.id}-decimals`} label="Decimal places">
+      <MultiLineField
+        id={`${answer.id}-decimals`}
+        label="Maximum number of decimal places"
+      >
+        <Paragraph>
+          Must be between 0 and 6. For example, 2 to allow numbers such as 1.11
+        </Paragraph>
         <Decimal
           id={`${answer.id}-decimals`}
           answer={answer}

--- a/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/UnitProperties.js
@@ -11,6 +11,11 @@ import { groupBy } from "lodash/fp";
 import { unitPropertyErrors } from "constants/validationMessages";
 import ValidationError from "components/ValidationError";
 
+const Paragraph = styled.p`
+  margin-top: 0em;
+  margin-bottom: 0.5em;
+`;
+
 const Container = styled.div`
   width: 15em;
 `;
@@ -98,7 +103,13 @@ const UnitProperties = ({
           {unitPropertyErrors[errors[0].errorCode].message}
         </ValidationError>
       )}
-      <MultiLineField id="decimals" label="Decimal places">
+      <MultiLineField
+        id={`${answer.id}-decimals`}
+        label="Maximum number of decimal places"
+      >
+        <Paragraph>
+          Must be between 0 and 6. For example, 2 to allow numbers such as 1.11
+        </Paragraph>
         <Decimal
           id="decimals"
           answer={answer}

--- a/eq-author/src/components/AnswerContent/Decimal/index.js
+++ b/eq-author/src/components/AnswerContent/Decimal/index.js
@@ -47,7 +47,6 @@ const Decimal = ({ answer, value, updateAnswerOfType, id, page }) => {
         onBlur={() => onUpdateDecimal(decimal)}
         value={decimal}
         invalid={errors.length !== 0}
-        max={999999999}
       />
       {errors.length !== 0 && (
         <ValidationError>

--- a/eq-author/src/components/AnswerContent/Decimal/index.js
+++ b/eq-author/src/components/AnswerContent/Decimal/index.js
@@ -26,6 +26,7 @@ const Decimal = ({ answer, value, updateAnswerOfType, id, page }) => {
   const errors = filter(answer.validationErrorInfo.errors, {
     field: "decimals",
   });
+
   const onUpdateDecimal = (value) => {
     updateAnswerOfType({
       variables: {
@@ -46,7 +47,7 @@ const Decimal = ({ answer, value, updateAnswerOfType, id, page }) => {
         onBlur={() => onUpdateDecimal(decimal)}
         value={decimal}
         invalid={errors.length !== 0}
-        max={6} //System limit enforced by eq-runner
+        max={999999999}
       />
       {errors.length !== 0 && (
         <ValidationError>

--- a/eq-author/src/components/AnswerContent/Decimal/index.test.js
+++ b/eq-author/src/components/AnswerContent/Decimal/index.test.js
@@ -35,6 +35,17 @@ describe("Decimal Property", () => {
     `);
   });
 
+  it("should render with an empty decimal error", () => {
+    props.answer.validationErrorInfo.errors[0] = {
+      errorCode: "ERR_VALID_REQUIRED",
+      field: "decimals",
+    };
+    const { getByTestId } = render(<Decimal {...props} />);
+    expect(getByTestId("number-input")).toHaveStyle(`
+      border-color: ${colors.errorPrimary};
+    `);
+  });
+
   it("should render with an invalid decimal error", () => {
     props.answer.validationErrorInfo.errors[0] = {
       errorCode: "ERR_INVALID_DECIMAL",

--- a/eq-author/src/components/AnswerContent/Decimal/index.test.js
+++ b/eq-author/src/components/AnswerContent/Decimal/index.test.js
@@ -24,9 +24,20 @@ describe("Decimal Property", () => {
     expect(getByTestId("number-input")).toBeTruthy();
   });
 
-  it("should render with Error", () => {
+  it("should render with a decimal inconsistency error", () => {
     props.answer.validationErrorInfo.errors[0] = {
       errorCode: "ERR_REFERENCED_ANSWER_DECIMAL_INCONSISTENCY",
+      field: "decimals",
+    };
+    const { getByTestId } = render(<Decimal {...props} />);
+    expect(getByTestId("number-input")).toHaveStyle(`
+      border-color: ${colors.errorPrimary};
+    `);
+  });
+
+  it("should render with an invalid decimal error", () => {
+    props.answer.validationErrorInfo.errors[0] = {
+      errorCode: "ERR_INVALID_DECIMAL",
       field: "decimals",
     };
     const { getByTestId } = render(<Decimal {...props} />);

--- a/eq-author/src/components/AnswerContent/Decimal/index.test.js
+++ b/eq-author/src/components/AnswerContent/Decimal/index.test.js
@@ -29,10 +29,15 @@ describe("Decimal Property", () => {
       errorCode: "ERR_REFERENCED_ANSWER_DECIMAL_INCONSISTENCY",
       field: "decimals",
     };
-    const { getByTestId } = render(<Decimal {...props} />);
+    const { getByTestId, getByText } = render(<Decimal {...props} />);
     expect(getByTestId("number-input")).toHaveStyle(`
       border-color: ${colors.errorPrimary};
     `);
+    expect(
+      getByText(
+        "Enter a decimal that is the same as the associated question page"
+      )
+    ).toBeTruthy();
   });
 
   it("should render with an empty decimal error", () => {
@@ -40,10 +45,13 @@ describe("Decimal Property", () => {
       errorCode: "ERR_VALID_REQUIRED",
       field: "decimals",
     };
-    const { getByTestId } = render(<Decimal {...props} />);
+    const { getByTestId, getByText } = render(<Decimal {...props} />);
     expect(getByTestId("number-input")).toHaveStyle(`
       border-color: ${colors.errorPrimary};
     `);
+    expect(
+      getByText("Enter the maximum number of decimal points allowed")
+    ).toBeTruthy();
   });
 
   it("should render with an invalid decimal error", () => {
@@ -51,10 +59,13 @@ describe("Decimal Property", () => {
       errorCode: "ERR_INVALID_DECIMAL",
       field: "decimals",
     };
-    const { getByTestId } = render(<Decimal {...props} />);
+    const { getByTestId, getByText } = render(<Decimal {...props} />);
     expect(getByTestId("number-input")).toHaveStyle(`
       border-color: ${colors.errorPrimary};
     `);
+    expect(
+      getByText("Maximum number of decimal places must be between 0 and 6")
+    ).toBeTruthy();
   });
 
   it("should call onChange and onBlur correctly", async () => {

--- a/eq-author/src/components/Forms/Number/index.js
+++ b/eq-author/src/components/Forms/Number/index.js
@@ -66,7 +66,8 @@ const Number = (props) => {
       return;
     }
 
-    const enteredValue = clamp(parseInt(value, 10), min, max);
+    const enteredValue =
+      min || max ? clamp(parseInt(value, 10), min, max) : parseInt(value, 10);
     const newValue =
       isNaN(enteredValue) || Object.is(enteredValue, -0)
         ? props.default

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -361,6 +361,10 @@ export const decimalErrors = {
     errorCode: "ERR_INVALID_DECIMAL",
     message: "Maximum number of decimal places must be between 0 and 6",
   },
+  ERR_VALID_REQUIRED: {
+    errorCode: "ERR_VALID_REQUIRED",
+    message: "Enter the maximum number of decimal points allowed",
+  },
 };
 
 export const unitPropertyErrors = {

--- a/eq-author/src/constants/validationMessages.js
+++ b/eq-author/src/constants/validationMessages.js
@@ -357,6 +357,10 @@ export const decimalErrors = {
     errorCode: "ERR_REFERENCED_ANSWER_DECIMAL_INCONSISTENCY",
     message: "Enter a decimal that is the same as the associated question page",
   },
+  ERR_INVALID_DECIMAL: {
+    errorCode: "ERR_INVALID_DECIMAL",
+    message: "Maximum number of decimal places must be between 0 and 6",
+  },
 };
 
 export const unitPropertyErrors = {


### PR DESCRIPTION
Ticket: https://jira.ons.gov.uk/browse/EAR-2125

### What is the context of this PR?

> Prevent questionnaires from including empty decimal place value. Validation has now been added to ensure an error appears if the decimals field is left empty or the input number is over 6

### How to review
(Test for each type of numeric answer - unit, currency, number, percentage)
1. Add a numeric answer
2. Remove the '0' from the decimals box

- [ ] Check if the correct validation message appears for empty decimal


3. Add a number between 0 and 6 back in to the box

- [ ] Check  if the validation message disappears


1.  Add a different numeric answer
2. Replace the '0' in the decimals box to a number above 6

- [ ] Check  if the correct validation message appears for numbers above the maximum

3. Add a number between 0 and 6 back in to the box

- [ ] Check  if the validation message disappears


1.  Add a different numeric answer
2. Replace the '0' in the decimals box to a number below 0

- [ ] Check  if the correct validation message appears for numbers below the minimum

3. Add a number between 0 and 6 back in to the box

- [ ] Check  if the validation message disappears

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
3. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
4. - [ ] Click the **Merge** button on this pull request
5. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
6. - [ ] Move the Jira ticket for this task into the next stage of the process
