### PR TITLE
Add validation to list collector answers

### DIFF
--- a/eq-author-api/migrations/addValidationToListCollectorAnswers.js
+++ b/eq-author-api/migrations/addValidationToListCollectorAnswers.js
@@ -1,0 +1,22 @@
+module.exports = (questionnaire) => {
+  questionnaire.sections.forEach((section) => {
+    section.folders.forEach((folder) => {
+      if (folder.listId !== undefined) {
+        folder.pages.forEach((page) => {
+          if (
+            page.pageType === "ListCollectorQualifierPage" ||
+            page.pageType === "ListCollectorConfirmationPage"
+          ) {
+            page.answers.forEach((answer) => {
+              if (answer.validation === undefined) {
+                answer.validation = {};
+              }
+            });
+          }
+        });
+      }
+    });
+  });
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/addValidationToListCollectorAnswers.test.js
+++ b/eq-author-api/migrations/addValidationToListCollectorAnswers.test.js
@@ -1,0 +1,179 @@
+const addValidationToListCollectorAnswers = require("./addValidationToListCollectorAnswers");
+
+describe("addValidationToListCollectorAnswers", () => {
+  let questionnaire;
+
+  beforeEach(() => {
+    questionnaire = {
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              listId: "list-1",
+              pages: [
+                {
+                  id: "qualifier-page-1",
+                  pageType: "ListCollectorQualifierPage",
+                  answers: [
+                    {
+                      id: "answer-1",
+                      type: "Radio",
+                      options: [
+                        {
+                          id: "qualifier-option-positive-1",
+                          label: "Qualifier positive",
+                          description: "Qualifier positive description",
+                        },
+                        {
+                          id: "qualifier-option-negative-1",
+                          label: "Qualifier negative",
+                          description: "Qualifier negative description",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: "add-item-page-1",
+                  pageType: "ListCollectorAddItemPage",
+                  title: `Add item question`,
+                  pageDescription: `Add item description`,
+                },
+                {
+                  id: "confirmation-page-1",
+                  pageType: "ListCollectorConfirmationPage",
+                  title: `Confirmation question`,
+                  pageDescription: `Confirmation description`,
+                  answers: [
+                    {
+                      id: "answer-2",
+                      type: "Radio",
+                      options: [
+                        {
+                          id: "confirmation-option-positive-1",
+                          label: "Confirmation positive",
+                          description: "Confirmation positive description",
+                        },
+                        {
+                          id: "confirmation-option-negative-1",
+                          label: "Confirmation negative",
+                          description: "Confirmation negative description",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  it("should add validation to list collector answers", () => {
+    const updatedQuestionnaire =
+      addValidationToListCollectorAnswers(questionnaire);
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).not.toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).toEqual({});
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).not.toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).toEqual({});
+  });
+
+  it("should not change validation on list collector answers if validation is defined", () => {
+    questionnaire.sections[0].folders[0].pages[0].answers[0].validation = {
+      id: "qualifier-answer-validation-1",
+    };
+    questionnaire.sections[0].folders[0].pages[2].answers[0].validation = {
+      id: "confirmation-answer-validation-1",
+    };
+    const updatedQuestionnaire =
+      addValidationToListCollectorAnswers(questionnaire);
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).not.toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).toEqual({ id: "qualifier-answer-validation-1" });
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).not.toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).toEqual({ id: "confirmation-answer-validation-1" });
+  });
+
+  it("should not add validation to non-list-collector answers", () => {
+    questionnaire.sections[0].folders[0].pages[0].pageType = "QuestionPage";
+
+    const updatedQuestionnaire =
+      addValidationToListCollectorAnswers(questionnaire);
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[0].answers[0].validation
+    ).not.toEqual({});
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).not.toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[0].pages[2].answers[0].validation
+    ).toEqual({});
+  });
+
+  it("should not add validation to answers in non-list-collector folders", () => {
+    questionnaire.sections[0].folders[1] = {
+      id: "folder-2",
+      pages: [
+        {
+          id: "page-2",
+          answers: [
+            {
+              id: "answer-3",
+              type: "Radio",
+              options: [
+                {
+                  id: "qualifier-option-positive-1",
+                  label: "Qualifier positive",
+                  description: "Qualifier positive description",
+                },
+                {
+                  id: "qualifier-option-negative-1",
+                  label: "Qualifier negative",
+                  description: "Qualifier negative description",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const updatedQuestionnaire =
+      addValidationToListCollectorAnswers(questionnaire);
+
+    expect(
+      updatedQuestionnaire.sections[0].folders[1].pages[0].answers[0].validation
+    ).toBeUndefined();
+    expect(
+      updatedQuestionnaire.sections[0].folders[1].pages[0].answers[0].validation
+    ).not.toEqual({});
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -49,6 +49,7 @@ const migrations = [
   require("./addCollectionListAnswerRepeatingProperties"),
   require("./updateIntroductionPreviewQuestionsSettings"),
   require("./convertListCollectorPageToFolder"),
+  require("./addValidationToListCollectorAnswers"),
 ];
 
 const currentVersion = migrations.length;


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Adds empty validation object to pre-existing list collector answers to prevent "Page not found" error when opening pre-existing questionnaires with list collector pages.

### How to review

Copy "Demo Repeating Section" questionnaire, created by Martyn Colmer.
**Check:**
- [ ] Questionnaire list collector pages are migrated to list collector folders
- [ ] Questionnaire does not display a "not found" error

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
