### PR TITLE
Fix questionnaires without introduction pages crashing

### DIFF
--- a/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.js
+++ b/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.js
@@ -16,6 +16,6 @@ module.exports = function updateIntroductionPreviewQuestionsSettings(
       questionnaire.introduction.previewQuestions = false;
       questionnaire.introduction.disallowPreviewQuestions = true;
     }
-    return questionnaire;
   }
+  return questionnaire;
 };

--- a/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.test.js
+++ b/eq-author-api/migrations/updateIntroductionPreviewQuestionsSettings.test.js
@@ -1,11 +1,11 @@
 const updateIntroductionPreviewQuestionsSettings = require("./updateIntroductionPreviewQuestionsSettings");
 
 describe("updateIntroductionPreviewQuestionsSettings", () => {
-  it("should check for introduction", () => {
+  it("should check return questionnaire if introduction is undefined", () => {
     const questionnaire = {};
     expect(
       updateIntroductionPreviewQuestionsSettings(questionnaire)
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 
   it("should add preview questions equal to false if it doesnt exist", () => {


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes crash on questionnaires which do not have introduction pages

### How to review

- On `master` branch, import https://author.eqbs.gcp.onsdigital.uk/#/q/1838a3da-ef2e-4720-a528-84454a3811e8
- Check that this questionnaire crashes when opened locally
- Switch to branch `fix-for-update-introduction-migration` (this branch)
- Check that this questionnaire does not crash when opened locally

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
