### PR TITLE
updale launch claim to v2

### DIFF
--- a/eq-author-api/middleware/launch.js
+++ b/eq-author-api/middleware/launch.js
@@ -1,6 +1,6 @@
 const { generateToken } = require("../utils/jwtHelper");
 const { assign, isNil, isEmpty } = require("lodash");
-const { sanitiseMetadata } = require("../utils/sanitiseMetadata");
+const { sanitiseMetadata } = require("../utils/sanitiseMetadataV2");
 const { getQuestionnaire } = require("../db/datastore");
 const { defaultTypeValueNames } = require("../utils/defaultMetadata");
 

--- a/eq-author-api/utils/sanitiseMetadataV2.js
+++ b/eq-author-api/utils/sanitiseMetadataV2.js
@@ -1,0 +1,58 @@
+/* eslint-disable camelcase*/
+const { omit, assign } = require("lodash/fp");
+const { v1: uuidv1 } = require("uuid");
+const EXPIRY_OFFSET_SECONDS = 100;
+
+const filterUnacceptableMeta = omit([
+  "survey_url",
+  "tx_id",
+  "iat",
+  "exp",
+  "eq_id",
+  "form_type",
+  "account_service_url",
+]);
+
+const today = new Date();
+const nextMonth = new Date(today.setMonth(today.getMonth() + 1));
+
+const defaultMetadata = (questionnaireId, tokenIssueTime, schemaUrl) => ({
+  version: "v2",
+  iat: tokenIssueTime,
+  exp: tokenIssueTime + EXPIRY_OFFSET_SECONDS,
+  jti: uuidv1(),
+  account_service_url: "https://www.ons.gov.uk/",
+  case_id: uuidv1(),
+  collection_exercise_sid: uuidv1(),
+  response_id: uuidv1(),
+  tx_id: uuidv1(),
+  response_expires_at: nextMonth,
+  schema_url: `${schemaUrl}${questionnaireId}?r${tokenIssueTime}`,
+  language_code: "en",
+  survey_metadata: {
+    data: {
+      user_id: "UNKNOWN",
+      ru_ref: "12346789012A",
+      ru_name: "ESSENTIAL ENTERPRISE LTD",
+      trad_as: "ESSENTIAL ENTERPRISE LTD",
+      period_id: "201605",
+      form_type: "H",
+    },
+  },
+});
+
+module.exports.sanitiseMetadata = (metadata, questionnaireId) => {
+  const schemaUrl = process.env.PUBLISHER_URL;
+  const refinedMetadata = filterUnacceptableMeta(metadata);
+  const tokenIssueTime = Math.round(new Date().getTime() / 1000);
+  const sanitisedMetadata = defaultMetadata(
+    questionnaireId,
+    tokenIssueTime,
+    schemaUrl
+  );
+  sanitisedMetadata.survey_metadata.data = assign(
+    sanitisedMetadata.survey_metadata.data,
+    refinedMetadata
+  );
+  return sanitisedMetadata;
+};

--- a/eq-author-api/utils/sanitiseMetadataV2.test.js
+++ b/eq-author-api/utils/sanitiseMetadataV2.test.js
@@ -1,0 +1,61 @@
+/* eslint-disable camelcase*/
+const { sanitiseMetadata } = require("./sanitiseMetadataV2");
+jest.mock("uuid", () => ({
+  v1: () => 123,
+}));
+describe("sanitise Metadata", () => {
+  let defaultMetadata;
+
+  describe("GCP", () => {
+    beforeEach(() => {
+      defaultMetadata = {
+        tx_id: 123,
+        jti: 123,
+        iat: expect.any(Number),
+        exp: expect.any(Number),
+        case_id: 123,
+        collection_exercise_sid: 123,
+        schema_url: expect.any(String),
+        survey_metadata: {
+          data: {
+            user_id: "UNKNOWN",
+            ru_ref: "12346789012A",
+            ru_name: "ESSENTIAL ENTERPRISE LTD",
+            trad_as: "ESSENTIAL ENTERPRISE LTD",
+            period_id: "201605",
+          },
+        },
+      };
+    });
+
+    it("should add the correct defaults when no metadata is defined", () => {
+      const sanitisedMetadata = sanitiseMetadata({}, 1);
+      expect(sanitisedMetadata).toMatchObject(defaultMetadata);
+    });
+
+    it("should overwrite user defined metadata when it uses reserved keys", () => {
+      const sanitisedMetadata = sanitiseMetadata(
+        {
+          iat: "foo",
+          exp: "bar",
+        },
+        1
+      );
+      expect(sanitisedMetadata).toMatchObject(defaultMetadata);
+    });
+
+    it("should allow user defined metadata to overwrite the defaults where not reserved", () => {
+      defaultMetadata.survey_metadata.data.ru_name = "foo";
+      defaultMetadata.survey_metadata.data.trad_as = "bar";
+      const sanitisedMetadata = sanitiseMetadata(
+        {
+          ru_name: "foo",
+          trad_as: "bar",
+        },
+        1
+      );
+      console.log(sanitisedMetadata);
+      expect(sanitisedMetadata).toMatchObject(defaultMetadata);
+    });
+  });
+});

--- a/eq-author-api/utils/sanitiseMetadataV2.test.js
+++ b/eq-author-api/utils/sanitiseMetadataV2.test.js
@@ -54,7 +54,6 @@ describe("sanitise Metadata", () => {
         },
         1
       );
-      console.log(sanitisedMetadata);
       expect(sanitisedMetadata).toMatchObject(defaultMetadata);
     });
   });


### PR DESCRIPTION
To support prepop we need to use the launch pattern v2. This PR Updates the Author API to use the v2 pattern.
[Launch pattern v2 spec](https://github.com/ONSdigital/ons-schema-definitions/blob/main/docs/rm_to_eq_runner_payload_v2.md)

To test:

- Spin up everything
- Launch Runner successfully
- Pick apart code
