### PR TITLE
set dataversion for supplementary

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1088,8 +1088,7 @@ const Resolvers = {
         { qid: ctx.questionnaire.id },
         `List removed with ID - ${input.id}`
       );
-      ctx.questionnaire.dataVersion =
-        ctx.questionnaire.collectionLists.lists.length > 0 ? "3" : "1";
+      setDataVersion(ctx);
 
       const answers = getAnswers(ctx);
 
@@ -1629,7 +1628,7 @@ const Resolvers = {
               supplementaryDataVersion
             );
           }
-
+          setDataVersion(ctx);
           return ctx.questionnaire.supplementaryData;
         } else {
           logger.info(`Schema version data not found - ${id}`);
@@ -1646,6 +1645,7 @@ const Resolvers = {
       const oldSupplementaryData = ctx.questionnaire?.supplementaryData?.data;
       onUnlinkSupplementaryData(ctx, ctx.questionnaire, oldSupplementaryData);
       ctx.questionnaire.supplementaryData = undefined;
+      setDataVersion(ctx);
       return ctx.questionnaire;
     }),
   },

--- a/eq-author-api/schema/resolvers/utils/setDataVersion.js
+++ b/eq-author-api/schema/resolvers/utils/setDataVersion.js
@@ -8,6 +8,11 @@ const setDataVersion = ({ questionnaire }) => {
     return;
   }
 
+  if (questionnaire.supplementaryData) {
+    questionnaire.dataVersion = "3";
+    return;
+  }
+
   const allAnswers = getAnswers({ questionnaire });
   allAnswers.some((answer) => {
     return answer.options?.some((option) => {


### PR DESCRIPTION
Updated to set the correct dataversion for runner when linked to a supplementary data schema
