### PR TITLE
Replace health theme with ukhsa-ons

### DIFF
--- a/eq-author-api/constants/themes.js
+++ b/eq-author-api/constants/themes.js
@@ -10,7 +10,7 @@ const THEME_SHORT_NAMES = [
   "dbt-dsit",
   "dbt-dsit-ni",
   "social",
-  "health",
+  "ukhsa-ons",
   "desnz",
   "desnz-ni",
 ];

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -52,6 +52,7 @@ const migrations = [
   require("./addValidationToListCollectorAnswers"),
   require("./addFieldsToListCollectorFolderContents"),
   require("./addAdditonalContentsToAddItemPage"),
+  require("./updateHealthThemeToPandemicMonitoring"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/updateHealthThemeToPandemicMonitoring.js
+++ b/eq-author-api/migrations/updateHealthThemeToPandemicMonitoring.js
@@ -1,0 +1,6 @@
+module.exports = (questionnaire) => {
+  if (questionnaire.theme === "health") {
+    questionnaire.theme = "ukhsa-ons";
+  }
+  return questionnaire;
+};

--- a/eq-author-api/migrations/updateHealthThemeToPandemicMonitoring.test.js
+++ b/eq-author-api/migrations/updateHealthThemeToPandemicMonitoring.test.js
@@ -1,0 +1,13 @@
+const updateHealthThemeToPandemicMonitoring = require("./updateHealthThemeToPandemicMonitoring");
+
+describe("updateHealthTheme", () => {
+  it("should update health theme", () => {
+    const questionnaire = {
+      theme: "health",
+    };
+
+    const updatedQuestionnaire =
+      updateHealthThemeToPandemicMonitoring(questionnaire);
+    expect(updatedQuestionnaire.theme).toBe("ukhsa-ons");
+  });
+});

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1135,7 +1135,7 @@ const Resolvers = {
         "Northern Ireland": "northernireland",
         Business: "business",
         Social: "social",
-        Health: "health",
+        "Pandemic monitoring": "ukhsa-ons",
         "UKIS Northern Ireland": "ukis_ni",
         "UKIS ONS": "ukis",
       };

--- a/eq-author/src/constants/themes.js
+++ b/eq-author/src/constants/themes.js
@@ -11,10 +11,10 @@ const THEMES = [
       "Header includes the Office for National Statistics logo but does not include the links for 'Help', 'My account' or 'Sign out'",
   },
   {
-    id: "health",
-    title: "Health",
+    id: "ukhsa-ons",
+    title: "Pandemic monitoring",
     description:
-      "Header includes the Office for National Statistics logo but does not include the links for 'Help', 'My account' or 'Sign out'",
+      "Header includes the logos for Office for National Statistics and UK Health and Security Agency but does not include the links for ‘Help’, ‘My account’ or ‘Sign out’",
   },
   {
     id: "dbt",


### PR DESCRIPTION
### What is the context of this PR?

Change, in conjunction with a matching Publisher change, replaces the 'health' theme with a new theme of 'Pandemic monitoring'

### How to review

Confirm that the theme option for 'Health' on the Settings page has been replaced with 'Pandemic monitoring'
Confirm that when selected a theme value of 'ukhsa-ons' is output when the new value is selected
When run with the publisher update, and having pulled the latest EQ runner release, ensure when set and viewing the questionnaire in EQ via the Author View > Open in Electronic Questionnaire link EQ shows the UKHSA and ONS logos in the page header

Requires matching change in eq-publisher-v3
https://github.com/ONSdigital/eq-publisher-v3/pull/189

https://jira.ons.gov.uk/browse/EAR-2288
