### PR TITLE
EAR-2280 dynamically update SDS schema

### DIFF
--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -323,6 +323,30 @@ const Resolvers = {
         };
       }
     },
+    supplementaryDataSurveyIdList: async () => {
+      const url = `${process.env.SUPPLEMENTARY_DATA_GATEWAY}survey_list`;
+
+      try {
+        const response = await authorisedRequest(
+          url,
+          process.env.SUPPLEMENTARY_DATA_GATEWAY_AUDIENCE,
+          {
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+        if (response.status !== 200) {
+          throw new Error(`enable to get versions. status(${response.status})`);
+        }
+        return {
+          surveyIdList: response.data,
+        };
+      } catch (err) {
+        logger.error(err.message);
+        return {
+          surveyIdList: [],
+        };
+      }
+    },
     supplementaryData: (_, args, ctx) => ctx.questionnaire.supplementaryData,
     listNames: (_, args, ctx) => {
       const listNames = [];

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -335,7 +335,9 @@ const Resolvers = {
           }
         );
         if (response.status !== 200) {
-          throw new Error(`enable to get versions. status(${response.status})`);
+          throw new Error(
+            `unable to get survey list. status(${response.status})`
+          );
         }
         return {
           surveyIdList: response.data,

--- a/eq-author-api/schema/tests/SupplementaryDataSurveyIdList.test.js
+++ b/eq-author-api/schema/tests/SupplementaryDataSurveyIdList.test.js
@@ -1,0 +1,34 @@
+/* eslint-disable camelcase */
+const executeQuery = require("../../tests/utils/executeQuery");
+
+jest.mock("node-fetch");
+
+const fetch = require("node-fetch");
+const query = `
+query GetSupplementaryDataSurveyIdList {
+    supplementaryDataSurveyIdList {
+        surveyIdList
+    }
+ }`;
+
+fetch.mockImplementation(() =>
+  Promise.resolve({
+    status: 200,
+    json: () => ["121", "122", "123"],
+  })
+);
+
+describe("SupplementaryDataSurveyIdList", () => {
+  it("should query supplementary data survey id list schema", async () => {
+    const expectedResponse = {
+      data: {
+        supplementaryDataSurveyIdList: {
+          surveyIdList: ["121", "122", "123"],
+        },
+      },
+    };
+
+    const response = await executeQuery(query);
+    expect(response).toMatchObject(expectedResponse);
+  });
+});

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -850,7 +850,7 @@ type SupplementaryDataVersions {
 }
 
 type SupplementaryDataSurveyIdList {
-  surveyIdList: [String]
+  surveyIdList: [String]!
 }
 
 type SupplementaryDataField {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -849,6 +849,10 @@ type SupplementaryDataVersions {
   versions: [Version!]!
 }
 
+type SupplementaryDataSurveyIdList {
+  surveyIdList: [String]
+}
+
 type SupplementaryDataField {
   id: ID,
   type: String,
@@ -908,6 +912,7 @@ type Query {
   collectionLists: CollectionLists
   list(input: QueryInput!): List
   supplementaryDataVersions(id: ID!): SupplementaryDataVersions
+  supplementaryDataSurveyIdList: SupplementaryDataSurveyIdList
   supplementaryData: SupplementaryData
   publishHistory: [PublishHistoryEvent]
   listNames: [ListName]

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { useQuery, useMutation } from "@apollo/react-hooks";
 import { withRouter, useParams } from "react-router-dom";
 
+import GET_SUPPLEMENTARY_DATA_SURVEY_ID_LIST from "graphql/getSupplementaryDataSurveyIdList.graphql";
 import UPDATE_SUPPLEMENTARY_DATA from "graphql/updateSupplementaryData.graphql";
 import GET_SUPPLEMENTARY_DATA from "graphql/getSupplementaryData.graphql";
 import UNLINK_SUPPLEMENTARY_DATA from "graphql/unlinkSupplementaryData.graphql";
@@ -19,7 +20,6 @@ import Loading from "components/Loading";
 import Error from "components/Error";
 
 import Theme from "contexts/themeContext";
-import { SURVEY_IDS } from "constants/surveyIDs";
 import { colors, radius } from "constants/theme";
 import Icon from "assets/icon-select.svg";
 import {
@@ -143,6 +143,13 @@ const SupplementaryDataPage = () => {
     fetchPolicy: "cache-and-network",
   });
 
+  const { data: supplementaryDataSurveyIdList } = useQuery(
+    GET_SUPPLEMENTARY_DATA_SURVEY_ID_LIST,
+    {
+      fetchPolicy: "network-only",
+    }
+  );
+
   const buildData = () => {
     let schemaData;
     if (supplementaryData?.supplementaryData?.data) {
@@ -153,12 +160,16 @@ const SupplementaryDataPage = () => {
     if (schemaData) {
       schemaData.surveyId = supplementaryData.supplementaryData?.surveyId;
     }
+
     return schemaData;
   };
 
   const tableData = buildData();
 
   const schemaData = tableData?.data;
+
+  const surveyIdList =
+    supplementaryDataSurveyIdList?.supplementaryDataSurveyIdList?.surveyIdList;
 
   const handleUnlinkClick = () => {
     setShowUnlinkModal(true);
@@ -233,7 +244,7 @@ const SupplementaryDataPage = () => {
                               >
                                 Survey ID
                               </Option>
-                              {SURVEY_IDS.map((surveyID) => (
+                              {surveyIdList?.map((surveyID) => (
                                 <Option key={surveyID} value={surveyID}>
                                   {surveyID}
                                 </Option>

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
@@ -18,46 +18,6 @@ jest.mock("@apollo/react-hooks", () => ({
   useMutation: jest.fn(() => [() => null]),
 }));
 
-const dataver = {
-  loading: false,
-  error: false,
-  data: {
-    supplementaryDataVersions: {
-      surveyId: "121",
-      versions: [
-        {
-          guid: "123-111-789",
-          // eslint-disable-next-line camelcase
-          sds_schema_version: "1",
-          // eslint-disable-next-line camelcase
-          sds_published_at: "2023-01-12T13:37:27+00:00",
-        },
-        {
-          guid: "123-222-789",
-          // eslint-disable-next-line camelcase
-          sds_schema_version: "2",
-          // eslint-disable-next-line camelcase
-          sds_published_at: "2023-02-08T12:37:27+00:00",
-        },
-        {
-          guid: "123-333-789",
-          // eslint-disable-next-line camelcase
-          sds_schema_version: "3",
-          // eslint-disable-next-line camelcase
-          sds_published_at: "2023-03-23T08:37:27+00:00",
-        },
-      ],
-    },
-  },
-};
-const sur = {
-  data: {
-    supplementaryDataSurveyIdList: {
-      surveyIdList: ["121"],
-    },
-  },
-};
-
 const renderSupplementaryDatasetPage = (questionnaire, props, user, mocks) => {
   return render(
     <MeContext.Provider value={{ me: user, signOut: jest.fn(), props }}>
@@ -117,9 +77,46 @@ describe("Supplementary dataset page", () => {
     ];
     useQuery.mockImplementation((key) => {
       if (key === GET_SUPPLEMENTARY_DATA_VERSIONS_QUERY) {
-        return dataver;
+        return {
+          loading: false,
+          error: false,
+          data: {
+            supplementaryDataVersions: {
+              surveyId: "121",
+              versions: [
+                {
+                  guid: "123-111-789",
+                  // eslint-disable-next-line camelcase
+                  sds_schema_version: "1",
+                  // eslint-disable-next-line camelcase
+                  sds_published_at: "2023-01-12T13:37:27+00:00",
+                },
+                {
+                  guid: "123-222-789",
+                  // eslint-disable-next-line camelcase
+                  sds_schema_version: "2",
+                  // eslint-disable-next-line camelcase
+                  sds_published_at: "2023-02-08T12:37:27+00:00",
+                },
+                {
+                  guid: "123-333-789",
+                  // eslint-disable-next-line camelcase
+                  sds_schema_version: "3",
+                  // eslint-disable-next-line camelcase
+                  sds_published_at: "2023-03-23T08:37:27+00:00",
+                },
+              ],
+            },
+          },
+        };
       } else if (key === GET_SUPPLEMENTARY_DATA_SURVEY_ID_LIST) {
-        return sur;
+        return {
+          data: {
+            supplementaryDataSurveyIdList: {
+              surveyIdList: ["121"],
+            },
+          },
+        };
       } else {
         return {
           loading: false,

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
@@ -113,7 +113,7 @@ describe("Supplementary dataset page", () => {
         return {
           data: {
             supplementaryDataSurveyIdList: {
-              surveyIdList: ["121"],
+              surveyIdList: ["121", "122"],
             },
           },
         };
@@ -155,6 +155,7 @@ describe("Supplementary dataset page", () => {
       expect(getByText("Select a survey ID")).toBeTruthy();
       expect(getByTestId("list-select")).toBeTruthy();
       expect(getByText(/121/)).toBeTruthy();
+      expect(getByText(/122/)).toBeTruthy();
     });
 
     it("should select a survey id", async () => {

--- a/eq-author/src/constants/surveyIDs.js
+++ b/eq-author/src/constants/surveyIDs.js
@@ -1,1 +1,0 @@
-export const SURVEY_IDS = ["068"];

--- a/eq-author/src/graphql/getSupplementaryDataSurveyIdList.graphql
+++ b/eq-author/src/graphql/getSupplementaryDataSurveyIdList.graphql
@@ -1,5 +1,5 @@
-query GetSupplementaryDataSurveyIdList{
-    supplementaryDataSurveyIdList {
+query GetSupplementaryDataSurveyIdList {
+  supplementaryDataSurveyIdList {
     surveyIdList
   }
 }

--- a/eq-author/src/graphql/getSupplementaryDataSurveyIdList.graphql
+++ b/eq-author/src/graphql/getSupplementaryDataSurveyIdList.graphql
@@ -1,0 +1,5 @@
+query GetSupplementaryDataSurveyIdList{
+    supplementaryDataSurveyIdList {
+    surveyIdList
+  }
+}


### PR DESCRIPTION

### What is the context of this PR?

> Adds the ability to dynamically update the list of available SDS schema so that it displays an up-to-date list of available survey IDs in the drop-down menu


### How to review

1. Create a questionnaire
2. Go to the data section 
3. Click on the supplementary data tab
4. Click the dropdown list under 'Select a Survey ID'

- [ ] Check it displays the list of mock survey IDs which are 121,122,123
- [ ] Check the schema versions table is displayed when selecting one of the survey IDs
- [ ] Check the selected survey ID is displayed in the title after linking a schema version

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
6. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
7. - [ ] Click the **Merge** button on this pull request
8. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
9. - [ ] Move the Jira ticket for this task into the next stage of the process
