### PR TITLE
fix for destination picker with LC

### DIFF
--- a/eq-author/README.md
+++ b/eq-author/README.md
@@ -112,3 +112,4 @@ theme colours and action names.
 `yarn storybook` Start the local server.
 
 `yarn build-storybook -o ../docs` deploy updates to static site (run from eq-author folder).
+

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/RoutingDestinationContentPicker.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
-import { takeRightWhile } from "lodash";
+import { takeRightWhile, reject } from "lodash";
 
 import {
   ContentSelectButton,
@@ -42,11 +42,18 @@ export const generateAvailableRoutingDestinations = (
   const currentSectionPages = currentSection.folders.flatMap(
     ({ pages }) => pages
   );
-  const routablePages = takeRightWhile(
+  let routablePages = takeRightWhile(
     currentSectionPages,
     ({ id }) => id !== pageId
   );
   routablePages.forEach((page) => (page.section = currentSection));
+
+  routablePages = reject(routablePages, {
+    pageType: "ListCollectorAddItemPage",
+  });
+  routablePages = reject(routablePages, {
+    pageType: "ListCollectorConfirmationPage",
+  });
 
   return {
     pages: routablePages || [],

--- a/eq-author/src/App/page/Logic/Routing/DestinationSelector/index.js
+++ b/eq-author/src/App/page/Logic/Routing/DestinationSelector/index.js
@@ -16,7 +16,7 @@ const DESTINATION_TYPE = {
   Section: "Section",
   QuestionPage: "QuestionPage",
   CalculatedSummaryPage: "CalculatedSummaryPage",
-  ListCollectorPage: "ListCollectorPage",
+  ListCollectorPage: "ListCollectorQualifierPage",
 };
 
 const RoutingRuleResult = styled.div`


### PR DESCRIPTION
Currently we can not set the routing destination to be a list collector, we get an error.
This PR fixes that and removes the extra pages in the picker from the new list collector format.

To test -

- Add an optional question to skip over
- Add a List collector
- Add routing to the first question to take you to the list collector past the optional question.


