### PR TITLE
EAR-2296 and EAR-2299 fix collection lists without introduction page

### DIFF
--- a/eq-author-api/src/businessLogic/createList.js
+++ b/eq-author-api/src/businessLogic/createList.js
@@ -1,8 +1,10 @@
 const { v4: uuidv4 } = require("uuid");
 
 const createList = (ctx) => {
-  ctx.questionnaire.introduction.previewQuestions = false;
-  ctx.questionnaire.introduction.disallowPreviewQuestions = true;
+  if (ctx.questionnaire.introduction) {
+    ctx.questionnaire.introduction.previewQuestions = false;
+    ctx.questionnaire.introduction.disallowPreviewQuestions = true;
+  }
   return {
     id: uuidv4(),
     listName: null,

--- a/eq-author-api/src/businessLogic/createList.test.js
+++ b/eq-author-api/src/businessLogic/createList.test.js
@@ -1,0 +1,38 @@
+const createList = require("./createList");
+
+describe("createList", () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = {
+      questionnaire: {
+        id: "questionnaire-1",
+        introduction: {
+          id: "introduction-1",
+          title: "introduction 1",
+          previewQuestions: true,
+          disallowPreviewQuestions: false,
+        },
+        collectionLists: {
+          id: "collection-list",
+          lists: [
+            {
+              id: "list-1",
+              ListName: "list 1",
+              answers: [],
+            },
+          ],
+        },
+      },
+    };
+  });
+
+  it("Should change the introduction's disallowPreviewQuestion to true when collection list is created", () => {
+    createList(ctx);
+    expect(ctx.questionnaire.introduction.disallowPreviewQuestions).toBe(true);
+  });
+
+  it("Should change the introduction's previewQuestions to false when the collection list is created", () => {
+    createList(ctx);
+    expect(ctx.questionnaire.introduction.previewQuestions).toBe(false);
+  });
+});

--- a/eq-author-api/src/businessLogic/onListDeleted.js
+++ b/eq-author-api/src/businessLogic/onListDeleted.js
@@ -29,8 +29,8 @@ module.exports = (ctx, list) => {
   }
 
   if (
-    ctx.questionnaire.lists === undefined ||
-    ctx.questionnaire.lists.length === 0
+    ctx.questionnaire.introduction &&
+    ctx.questionnaire.collectionLists.lists.length === 0
   ) {
     ctx.questionnaire.introduction.disallowPreviewQuestions = false;
   }

--- a/eq-author-api/src/businessLogic/onListDeleted.js
+++ b/eq-author-api/src/businessLogic/onListDeleted.js
@@ -30,7 +30,8 @@ module.exports = (ctx, list) => {
 
   if (
     ctx.questionnaire.introduction &&
-    ctx.questionnaire.collectionLists.lists.length === 0
+    (ctx.questionnaire.lists === undefined ||
+      ctx.questionnaire.collectionLists.lists.length === 0)
   ) {
     ctx.questionnaire.introduction.disallowPreviewQuestions = false;
   }

--- a/eq-author-api/src/businessLogic/onListDeleted.test.js
+++ b/eq-author-api/src/businessLogic/onListDeleted.test.js
@@ -1,7 +1,14 @@
 const onListDeleted = require("./onListDeleted");
+const onAnswerDeleted = require("./onAnswerDeleted");
+
+jest.mock("./onAnswerDeleted");
 
 describe("onListDeleted", () => {
   let ctx;
+  const list = {
+    id: "id-1",
+    answers: [{ id: "answer-1", type: "TextField" }],
+  };
   beforeEach(() => {
     ctx = {
       questionnaire: {
@@ -13,16 +20,55 @@ describe("onListDeleted", () => {
         },
         collectionLists: {
           id: "collectionList-1",
-          lists: [],
+          lists: [list],
         },
-        sections: [],
+        sections: [
+          {
+            repeatingSectionListId: "id-1",
+            folders: [{ pages: [{}] }],
+          },
+        ],
       },
     };
+  });
+
+  afterEach(() => {
+    onAnswerDeleted.mockClear();
+  });
+
+  it("should change the section's page.listId to null when it is the same as the list's id", () => {
+    ctx.questionnaire.sections[0].folders[0].pages[0] = {
+      id: "page-1",
+      listId: "id-1",
+    };
+    onListDeleted(ctx, list);
+    expect(ctx.questionnaire.sections[0].folders[0].pages[0].listId).toBeNull();
   });
 
   it("should change the introduction's disallowPreviewQuestion to false when there is no collection lists", () => {
     onListDeleted(ctx, {});
 
     expect(ctx.questionnaire.introduction.disallowPreviewQuestions).toBe(false);
+  });
+
+  it("should change the section's repeatingSectionListId to null when it is the same as the list's id", () => {
+    onListDeleted(ctx, list);
+    expect(ctx.questionnaire.sections[0].repeatingSectionListId).toBeNull();
+  });
+
+  it("should call onAnswerDeleted when list with answers is deleted", () => {
+    onListDeleted(ctx, list);
+    expect(ctx.questionnaire.sections[0].repeatingSectionListId).toBeNull();
+  });
+
+  it("should call onAnswerDeleted when list has answers", () => {
+    onListDeleted(ctx, list);
+    expect(onAnswerDeleted).toHaveBeenCalledTimes(1);
+    expect(onAnswerDeleted).toHaveBeenCalledWith(
+      ctx,
+      list,
+      list.answers[0],
+      ctx.questionnaire.sections[0].folders[0].pages
+    );
   });
 });

--- a/eq-author-api/src/businessLogic/onListDeleted.test.js
+++ b/eq-author-api/src/businessLogic/onListDeleted.test.js
@@ -1,0 +1,28 @@
+const onListDeleted = require("./onListDeleted");
+
+describe("onListDeleted", () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = {
+      questionnaire: {
+        id: "questionnaire-1",
+        introduction: {
+          id: "introduction-1",
+          title: "introduction 1",
+          disallowPreviewQuestions: true,
+        },
+        collectionLists: {
+          id: "collectionList-1",
+          lists: [],
+        },
+        sections: [],
+      },
+    };
+  });
+
+  it("should change the introduction's disallowPreviewQuestion to false when there is no collection lists", () => {
+    onListDeleted(ctx, {});
+
+    expect(ctx.questionnaire.introduction.disallowPreviewQuestions).toBe(false);
+  });
+});


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-2296
https://jira.ons.gov.uk/browse/EAR-2299

Fixed a bug preventing collection lists from being created and deleted without an introduction page.

### How to review

- [ ]  Create a collection list on a questionnaire without an introduction page.
- [ ]  Delete the same collection list on a questionnaire without an introduction page.
- [ ]  Check if the collection list is created and deleted without the introduction page.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
