### PR TITLE
Fix for list collector answer max character limit

### DIFF
--- a/eq-author/src/graphql/lists/listAnswer.graphql
+++ b/eq-author/src/graphql/lists/listAnswer.graphql
@@ -20,6 +20,7 @@ fragment ListAnswer on Answer {
   advancedProperties
   ... on BasicAnswer {
     secondaryQCode
+    limitCharacter
     options {
       id
       mutuallyExclusive


### PR DESCRIPTION
Fix for list collector answer max character limit

- Add a list and a text answer
- Check you can now set the limit