### PR TITLE
EAR 2291 update content for calculated summary questions

### DIFF
--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -4,6 +4,7 @@ import { propType } from "graphql-anywhere";
 import { get, flowRight, some } from "lodash";
 import styled from "styled-components";
 import gql from "graphql-tag";
+import DescribedText from "components/DescribedText";
 
 import { richTextEditorErrors } from "constants/validationMessages";
 import { colors } from "constants/theme";
@@ -202,7 +203,11 @@ export const CalculatedSummaryPageEditor = (props) => {
         <RichTextEditor
           id="summary-title"
           name="title"
-          label="Calculated summary title"
+          label={
+            <DescribedText description='The question "Is this correct?" will be added to the end of the calculated summary title '>
+              Calculated summary title
+            </DescribedText>
+          }
           placeholder=""
           value={page.title}
           onUpdate={onChangeUpdate}
@@ -217,6 +222,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           autoFocus={!page.title}
           pageType={page.pageType}
         />
+
         <HorizontalRule />
         <PageTitleContainer
           pageDescription={page.pageDescription}

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -204,7 +204,7 @@ export const CalculatedSummaryPageEditor = (props) => {
           id="summary-title"
           name="title"
           label={
-            <DescribedText description='The question "Is this correct?" will be added to the end of the calculated summary title '>
+            <DescribedText description='The question "Is this correct?" will be added to the end of the calculated summary title.'>
               Calculated summary title
             </DescribedText>
           }

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -57,7 +57,9 @@ const Summary = styled.div`
 `;
 
 const SummaryItem = styled.div`
-  border-top: 1px solid #999;
+  &:not(:first-of-type) {
+    border-top: 1px solid #999;
+  }
   border-radius: 0;
   position: relative;
   padding: 1rem 0;

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -116,7 +116,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     >
       <Panel data-test="calSum test page">
         <Container>
-          <PageTitle title={page.title} />
+          <PageTitle title={`${page.title} Is this correct?`} />
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -102,9 +102,15 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     section: page?.section,
   });
 
-  const endsWithFullStop = (string) => {
-    const stringWithoutClosingParagraphTag = string.replace(/<\/p>$/, "");
-    return stringWithoutClosingParagraphTag.endsWith(".");
+  const addConfirmationToTitle = () => {
+    if (page.title) {
+      const titleWithoutClosingParagraphTag = page.title.replace(/<\/p>$/, "");
+      if (titleWithoutClosingParagraphTag.endsWith(".")) {
+        return `${page.title} Is this correct?`;
+      } else {
+        return `${page.title}. Is this correct?`;
+      }
+    }
   };
 
   return (
@@ -120,13 +126,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     >
       <Panel data-test="calSum test page">
         <Container>
-          <PageTitle
-            title={
-              endsWithFullStop(page.title)
-                ? `${page.title} Is this correct?`
-                : `${page.title}. Is this correct?`
-            }
-          />
+          <PageTitle title={addConfirmationToTitle()} />
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -127,7 +127,6 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                 : `${page.title}. Is this correct?`
             }
           />
-
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-danger */
 import React from "react";
 import { propType } from "graphql-anywhere";
+import { darken } from "polished";
 
 import styled from "styled-components";
 import Error from "components/preview/Error";
@@ -22,11 +23,12 @@ const Button = styled.div`
   padding: 0.75rem 1rem;
   margin: 0;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: bold;
   border-radius: 3px;
   display: inline-block;
   text-rendering: optimizeLegibility;
   margin-bottom: 2em;
+  box-shadow: 0 3px ${({ theme }) => darken(0.15, theme.colors.primary)};
 `;
 
 const Container = styled.div`

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -124,7 +124,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
             title={
               endsWithFullStop(page.title)
                 ? `${page.title} Is this correct?`
-                : `${page.title}. Is this correct`
+                : `${page.title}. Is this correct?`
             }
           />
           {/* {`${page.title} Is this correct?`} */}

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-danger */
 import React from "react";
 import { propType } from "graphql-anywhere";
-import { darken } from "polished";
 
 import styled from "styled-components";
 import Error from "components/preview/Error";
@@ -23,12 +22,11 @@ const Button = styled.div`
   padding: 0.75rem 1rem;
   margin: 0;
   font-size: 1rem;
-  font-weight: bold;
+  font-weight: 600;
   border-radius: 3px;
   display: inline-block;
   text-rendering: optimizeLegibility;
   margin-bottom: 2em;
-  box-shadow: 0 3px ${({ theme }) => darken(0.15, theme.colors.primary)};
 `;
 
 const Container = styled.div`

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -127,7 +127,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                 : `${page.title}. Is this correct?`
             }
           />
-          {/* {`${page.title} Is this correct?`} */}
+
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -16,6 +16,20 @@ import { colors } from "constants/theme";
 import CalculatedSummaryPageEditor from "../Design/CalculatedSummaryPageEditor";
 import { useSetNavigationCallbacksForPage } from "components/NavigationCallbacks";
 
+const Button = styled.div`
+  color: white;
+  background-color: ${colors.positive};
+  border: 2px solid ${colors.positive};
+  padding: 0.75rem 1rem;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 3px;
+  display: inline-block;
+  text-rendering: optimizeLegibility;
+  margin-bottom: 2em;
+`;
+
 const Container = styled.div`
   padding: 2em;
   font-size: 1.1em;
@@ -103,8 +117,6 @@ const CalculatedSummaryPagePreview = ({ page }) => {
       <Panel data-test="calSum test page">
         <Container>
           <PageTitle title={page.title} />
-          <Info>Please review your answers and confirm these are correct.</Info>
-
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (
@@ -151,6 +163,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
               No answers selected
             </Error>
           )}
+          <Button>Yes, I confirm this is correct</Button>
         </Container>
       </Panel>
     </EditorLayout>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -5,7 +5,6 @@ import { propType } from "graphql-anywhere";
 import styled from "styled-components";
 import Error from "components/preview/Error";
 import PageTitle from "components/preview/elements/PageTitle";
-import Info from "components/preview/elements/Info";
 
 import EditorLayout from "components/EditorLayout";
 import Panel from "components/Panel";
@@ -103,6 +102,11 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     section: page?.section,
   });
 
+  const endsWithFullStop = (string) => {
+    const stringWithoutClosingParagraphTag = string.replace(/<\/p>$/, "");
+    return stringWithoutClosingParagraphTag.endsWith(".");
+  };
+
   return (
     <EditorLayout
       title={page.displayName}
@@ -116,7 +120,14 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     >
       <Panel data-test="calSum test page">
         <Container>
-          <PageTitle title={`${page.title} Is this correct?`} />
+          <PageTitle
+            title={
+              endsWithFullStop(page.title)
+                ? `${page.title} Is this correct?`
+                : `${page.title}. Is this correct`
+            }
+          />
+          {/* {`${page.title} Is this correct?`} */}
           {page.summaryAnswers.length > 0 ? (
             <Summary>
               {page.summaryAnswers.map((answer) => (


### PR DESCRIPTION
### What is the context of this PR?
To update the preview and EQ of the calculated summary page by adding a button and the text "Is this correct" of the title
ticket: https://jira.ons.gov.uk/browse/EAR-2291
EQ-publisher-v3: https://github.com/ONSdigital/eq-publisher-v3/pull/208

### How to review
- [ ] Create a questionnaire with a calculated summary page 
- [ ] Ensure 2 questions are created within the calculated summary page
- [ ] In the calculated summary title add a title without a full-spot
- [ ] View in preview and check if there is a full spot after a title and the text "Is this correct"?
- [ ] Check if the button text is "Yes, I confirm this is correct"
- [ ] Go back to the calculated summary title and add a full spot in the title
- [ ] Then view in preview again and check that the full spot is not repeated after the title and check the text "Is this correct"?

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
