### PR TITLE
EAR-2354-Display-validation-error-border-in-TextField-character-limit-Input

### DIFF
--- a/eq-author/src/components/AnswerContent/AnswerProperties/TextFieldProperties.js
+++ b/eq-author/src/components/AnswerContent/AnswerProperties/TextFieldProperties.js
@@ -75,6 +75,7 @@ const TextFieldProperties = ({
             value={maxLength}
             onBlur={() => onUpdateMaxLength(maxLength)}
             onChange={({ value }) => setMaxLength(value)}
+            invalid={errors.length > 0}
             data-test="limitCharacterInput"
           />
         </InlineField>


### PR DESCRIPTION
### What is the context of this PR?

To display the validation error border in TextField character limit input
Ticket: https://jira.ons.gov.uk/browse/EAR-2354


### How to review
1. - [ ] Create a Questionnaire with a TextField answer
2. - [ ] Have character limit toggle switch on
3.  - [ ] Input values that are less than 8 
4. - [ ] Check for an orange border around the Character limit input box
5. - [ ] Input values that are above than 100
6. - [ ] Check for an orange border around the Character limit input box

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
7. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
8. - [ ] Click the **Merge** button on this pull request
9. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
10. - [ ] Move the Jira ticket for this task into the next stage of the process
