### PR TITLE
EAR 2367 Add piping for answer labels in list additional pages

### DIFF
--- a/eq-author-api/schema/resolvers/utils/folderGetters.js
+++ b/eq-author-api/schema/resolvers/utils/folderGetters.js
@@ -10,9 +10,17 @@ const getFolderById = (ctx, id) => find(getFolders(ctx), { id });
 const getFolderByPageId = (ctx, id) =>
   find(getFolders(ctx), ({ pages }) => pages && some(pages, { id }));
 
+const getFolderByAnswerId = (ctx, id) =>
+  find(
+    getFolders(ctx),
+    ({ pages }) =>
+      pages && some(pages, ({ answers }) => answers && some(answers, { id }))
+  );
+
 module.exports = {
   getFolders,
   getFoldersBySectionId,
   getFolderById,
   getFolderByPageId,
+  getFolderByAnswerId,
 };

--- a/eq-author-api/src/validation/customKeywords/validatePipingAnswerInLabel.js
+++ b/eq-author-api/src/validation/customKeywords/validatePipingAnswerInLabel.js
@@ -9,6 +9,7 @@ const {
   idExists,
   getListByAnswerId,
   getSupplementaryDataAsCollectionListbyFieldId,
+  getFolderByAnswerId,
 } = require("../../../schema/resolvers/utils");
 
 const pipedAnswerIdRegex =
@@ -31,6 +32,7 @@ module.exports = (ajv) =>
         rootData: questionnaire,
       }
     ) {
+      const folder = getFolderByAnswerId({ questionnaire }, parentData.id);
       isValid.errors = [];
       const pipedIdList = [];
 
@@ -78,8 +80,9 @@ module.exports = (ajv) =>
         if (list) {
           if (!(dataPiped === "supplementary" && list.listName === "")) {
             if (
-              list.id !== parentData.repeatingLabelAndInputListId ||
-              !parentData.repeatingLabelAndInput
+              !folder.listId &&
+              (list.id !== parentData.repeatingLabelAndInputListId ||
+                !parentData.repeatingLabelAndInput)
             ) {
               return hasError(PIPING_TITLE_DELETED);
             }

--- a/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
+++ b/eq-author/src/App/page/Design/answers/BasicAnswer/index.js
@@ -124,7 +124,12 @@ export const StatelessBasicAnswer = ({
           controls={pipingControls}
           size="large"
           allowableTypes={[ANSWER, METADATA]}
-          listId={answer.repeatingLabelAndInputListId ?? null}
+          listId={
+            (answer.repeatingLabelAndInputListId ||
+              page.section?.repeatingSectionListId ||
+              page.folder?.listId) ??
+            null
+          }
           hasLabelErrors={hasLabelErrors(answer.validationErrorInfo?.errors)}
           autoFocus={!answer.label}
         />


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Enable piping answers into answer labels inside list collector folders' additional pages. This will allow respondents to see which answer from a list collector's responses each value in a calculated summary page refers to.

https://jira.ons.gov.uk/browse/EAR-2367

### How to review
**Check:**
- [ ] Answers can be piped into answer labels in list collectors' additional pages, including answers from the linked collection list
- [ ] When an answer piped into an additional page's answer label is deleted, a validation error is displayed
- [ ] When viewing a questionnaire in eQ, calculated summary pages based on list collector additional pages' answers display the piped answer in each label in the summary

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
