### PR TITLE
EAR 2382 and EAR 2383 replace emphasis tags with strong tags

### DIFF
--- a/eq-author-api/migrations/convertEmTagsToStrongTags.js
+++ b/eq-author-api/migrations/convertEmTagsToStrongTags.js
@@ -1,7 +1,13 @@
 const convertEmTagsToStrongTags = (inputData) => {
   if (inputData !== null && inputData !== undefined) {
     if (typeof inputData === "string") {
+      /* 
+        Removes em tags wrapped in strong tags and em tags wrapped around strong tags before converting em tags 
+        Prevents wrapping text in two strong tags when it was previously wrapped in both strong and em tags
+      */
       inputData = inputData
+        .replace(/<strong><em>|<em><strong>/g, "<strong>")
+        .replace(/<\/em><\/strong>|<\/strong><\/em>/g, "</strong>")
         .replace(/<em>/g, "<strong>")
         .replace(/<\/em>/g, "</strong>");
     } else if (Array.isArray(inputData)) {

--- a/eq-author-api/migrations/convertEmTagsToStrongTags.js
+++ b/eq-author-api/migrations/convertEmTagsToStrongTags.js
@@ -1,0 +1,19 @@
+const convertEmTagsToStrongTags = (inputData) => {
+  if (inputData !== null && inputData !== undefined) {
+    if (typeof inputData === "string") {
+      inputData = inputData
+        .replace(/<em>/g, "<strong>")
+        .replace(/<\/em>/g, "</strong>");
+    } else if (Array.isArray(inputData)) {
+      inputData = inputData.map((item) => convertEmTagsToStrongTags(item));
+    } else if (typeof inputData === "object") {
+      Object.keys(inputData).forEach((key) => {
+        inputData[key] = convertEmTagsToStrongTags(inputData[key]);
+      });
+    }
+  }
+
+  return inputData;
+};
+
+module.exports = (questionnaire) => convertEmTagsToStrongTags(questionnaire);

--- a/eq-author-api/migrations/convertEmTagsToStrongTags.test.js
+++ b/eq-author-api/migrations/convertEmTagsToStrongTags.test.js
@@ -1,0 +1,78 @@
+const convertEmTagsToStrongTags = require("./convertEmTagsToStrongTags");
+
+describe("convertEmTagsToStrongTags", () => {
+  it("should replace em tags with strong tags in a string", () => {
+    const emText = "<em>Question 1</em>";
+
+    expect(convertEmTagsToStrongTags(emText)).toEqual(
+      "<strong>Question 1</strong>"
+    );
+  });
+
+  it("should not replace strong tags", () => {
+    const strongText = "<strong>Question 1</strong>";
+
+    expect(convertEmTagsToStrongTags(strongText)).toEqual(strongText);
+  });
+
+  it("should replace em tags with strong tags in an array of strings", () => {
+    const emArray = ["<em>Question 1</em>", "<em>Question 2</em>"];
+
+    expect(convertEmTagsToStrongTags(emArray)).toEqual([
+      "<strong>Question 1</strong>",
+      "<strong>Question 2</strong>",
+    ]);
+  });
+
+  it("should replace em tags with strong tags in an object", () => {
+    const page = {
+      title: "<em>Test title</em>",
+      description: "<em>Test description</em>",
+      answers: [
+        {
+          label: "<em>Answer 1</em>",
+        },
+        {
+          label: "<em>Answer 2</em>",
+        },
+      ],
+    };
+
+    expect(convertEmTagsToStrongTags(page)).toEqual({
+      title: "<strong>Test title</strong>",
+      description: "<strong>Test description</strong>",
+      answers: [
+        {
+          label: "<strong>Answer 1</strong>",
+        },
+        {
+          label: "<strong>Answer 2</strong>",
+        },
+      ],
+    });
+  });
+
+  it("should not wrap text in two strong tags when text is wrapped in strong and em tags", () => {
+    const emTagsWrappedInStrong = "<strong><em>Question 1</em></strong>";
+    const strongTagsWrappedInEm = "<em><strong>Question 2</strong></em>";
+
+    expect(convertEmTagsToStrongTags(emTagsWrappedInStrong)).toEqual(
+      "<strong>Question 1</strong>"
+    );
+    expect(convertEmTagsToStrongTags(strongTagsWrappedInEm)).toEqual(
+      "<strong>Question 2</strong>"
+    );
+  });
+
+  it("should return undefined if inputData is undefined", () => {
+    expect(convertEmTagsToStrongTags(undefined)).toBeUndefined(); // convertEmTagsToStrongTags returns inputData, which is undefined
+  });
+
+  it("should return null if inputData is null", () => {
+    expect(convertEmTagsToStrongTags(null)).toBeNull(); // convertEmTagsToStrongTags returns inputData, which is null
+  });
+
+  it("should return inputData if inputData is not string, array, or object", () => {
+    expect(convertEmTagsToStrongTags(true)).toEqual(true);
+  });
+});

--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -54,6 +54,7 @@ const migrations = [
   require("./addAdditonalContentsToAddItemPage"),
   require("./updateHealthThemeToPandemicMonitoring"),
   require("./addAllowableDataVersions"),
+  require("./convertEmTagsToStrongTags"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author/src/App/Submission/Design/SubmissionEditor/index.js
+++ b/eq-author/src/App/Submission/Design/SubmissionEditor/index.js
@@ -46,7 +46,6 @@ const InlineField = styled(Field)`
 const contentControls = {
   heading: true,
   bold: true,
-  emphasis: true,
   list: true,
   link: true,
 };

--- a/eq-author/src/App/history/HistoryItem.js
+++ b/eq-author/src/App/history/HistoryItem.js
@@ -160,7 +160,6 @@ const HistoryItem = ({
               value={noteState}
               controls={{
                 heading: true,
-                emphasis: true,
                 list: true,
                 bold: true,
               }}

--- a/eq-author/src/App/history/HistoryItem.js
+++ b/eq-author/src/App/history/HistoryItem.js
@@ -69,16 +69,6 @@ const EventText = styled.div`
   p {
     margin: 0 0 1em;
     word-break: break-all;
-    em {
-      background-color: ${colors.highlightGreen};
-      font-style: normal;
-    }
-  }
-  h2 {
-    em {
-      background-color: ${colors.highlightGreen};
-      font-style: normal;
-    }
   }
   ul {
     margin-top: 0;
@@ -88,10 +78,6 @@ const EventText = styled.div`
       margin-left: 1em;
       span {
         font-weight: bold;
-      }
-      em {
-        background-color: ${colors.highlightGreen};
-        font-style: normal;
       }
     }
   }

--- a/eq-author/src/App/history/HistoryPage.js
+++ b/eq-author/src/App/history/HistoryPage.js
@@ -124,7 +124,6 @@ const HistoryPageContent = ({ match }) => {
               value={noteState.value}
               controls={{
                 heading: true,
-                emphasis: true,
                 list: true,
                 bold: true,
               }}

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/__snapshots__/index.test.js.snap
@@ -53,7 +53,6 @@ exports[`CollapsibleEditor should render 1`] = `
     controls={
       Object {
         "bold": true,
-        "emphasis": true,
         "link": true,
         "list": true,
         "piping": true,

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/CollapsiblesEditor/CollapsibleEditor/index.js
@@ -28,7 +28,6 @@ const Detail = styled.div`
   position: relative;
 `;
 
-
 const DetailHeader = styled.div`
   position: absolute;
   top: 0.5em;
@@ -100,7 +99,6 @@ export const CollapsibleEditor = ({
         onUpdate={onChangeUpdate}
         multiline
         controls={{
-          emphasis: true,
           piping: true,
           list: true,
           bold: true,

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/__snapshots__/index.test.js.snap
@@ -22,9 +22,8 @@ exports[`IntroductionEditor should render 1`] = `
         autoFocus={false}
         controls={
           Object {
-            "bold": true,
-            "emphasis": true,
             "heading": true,
+            "highlight": true,
             "link": true,
             "piping": true,
           }
@@ -178,7 +177,6 @@ exports[`IntroductionEditor should render 1`] = `
         controls={
           Object {
             "bold": true,
-            "emphasis": true,
             "link": true,
             "list": true,
             "piping": true,
@@ -281,7 +279,7 @@ exports[`IntroductionEditor should render 1`] = `
         autoFocus={false}
         controls={
           Object {
-            "emphasis": true,
+            "highlight": true,
             "piping": true,
           }
         }
@@ -303,7 +301,6 @@ exports[`IntroductionEditor should render 1`] = `
         controls={
           Object {
             "bold": true,
-            "emphasis": true,
             "link": true,
             "list": true,
             "piping": true,
@@ -348,7 +345,7 @@ exports[`IntroductionEditor should render 1`] = `
         autoFocus={false}
         controls={
           Object {
-            "emphasis": true,
+            "highlight": true,
             "piping": true,
           }
         }
@@ -370,7 +367,6 @@ exports[`IntroductionEditor should render 1`] = `
         controls={
           Object {
             "bold": true,
-            "emphasis": true,
             "link": true,
             "list": true,
             "piping": true,

--- a/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
+++ b/eq-author/src/App/introduction/Design/IntroductionEditor/index.js
@@ -45,13 +45,12 @@ const SectionDescription = styled.p`
 `;
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 
 const descriptionControls = {
   bold: true,
-  emphasis: true,
   piping: true,
   list: true,
   link: true,
@@ -165,9 +164,8 @@ const IntroductionEditor = ({ introduction, history }) => {
             }
             controls={{
               heading: true,
-              bold: true,
               link: true,
-              emphasis: true,
+              highlight: true,
               piping: true,
             }}
             testSelector="txt-intro-title"

--- a/eq-author/src/App/introduction/Preview/IntroductionPreview/index.js
+++ b/eq-author/src/App/introduction/Preview/IntroductionPreview/index.js
@@ -22,11 +22,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: ${colors.highlightGreen};
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #e0e0e0;
     padding: 0 0.125em;

--- a/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
+++ b/eq-author/src/App/page/Design/CalculatedSummaryPageEditor/index.js
@@ -36,7 +36,7 @@ import CommentFragment from "graphql/fragments/comment.graphql";
 import AnswerFragment from "graphql/fragments/answer.graphql";
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 

--- a/eq-author/src/App/page/Design/ListCollectorPageEditors/AddItemPageEditor/index.js
+++ b/eq-author/src/App/page/Design/ListCollectorPageEditors/AddItemPageEditor/index.js
@@ -59,7 +59,7 @@ const StyledCollapsible = styled(Collapsible)`
   margin-top: 1em;
 `;
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 
@@ -148,6 +148,7 @@ const AddItemPageEditor = ({ fetchAnswers, page }) => {
             })
           }
           errorValidationMsg={getErrorMessage("title")}
+          size="large"
           controls={titleControls}
           allowableTypes={[ANSWER, METADATA, VARIABLES]}
           testSelector="add-item-question"

--- a/eq-author/src/App/page/Design/ListCollectorPageEditors/ConfirmationPageEditor/index.js
+++ b/eq-author/src/App/page/Design/ListCollectorPageEditors/ConfirmationPageEditor/index.js
@@ -54,7 +54,7 @@ const HorizontalSeparator = styled.hr`
 `;
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 
@@ -124,6 +124,7 @@ const ConfirmationPageEditor = ({ page, onUpdateOption }) => {
             })
           }
           errorValidationMsg={getErrorMessage("title")}
+          size="large"
           controls={titleControls}
           allowableTypes={[ANSWER, METADATA, VARIABLES]}
           testSelector="confirmation-question"

--- a/eq-author/src/App/page/Design/ListCollectorPageEditors/QualifierPageEditor/index.js
+++ b/eq-author/src/App/page/Design/ListCollectorPageEditors/QualifierPageEditor/index.js
@@ -55,7 +55,7 @@ const HorizontalSeparator = styled.hr`
 `;
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 
@@ -127,6 +127,7 @@ const QualifierPageEditor = ({ page, onUpdateOption }) => {
             })
           }
           errorValidationMsg={getErrorMessage("title")}
+          size="large"
           controls={titleControls}
           allowableTypes={[ANSWER, METADATA, VARIABLES]}
           testSelector="qualifier-question"

--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
@@ -19,7 +19,7 @@ import {
 } from "components/ContentPickerSelectv3/content-types";
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 

--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
@@ -56,6 +56,7 @@ export class StatelessMetaEditor extends React.Component {
           listId={
             (page.section?.repeatingSectionListId || page.folder.listId) ?? null
           }
+          usesHighlightStyle
           errorValidationMsg={this.errorMsg("title")}
         />
       </div>

--- a/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/MetaEditor.js
@@ -56,7 +56,6 @@ export class StatelessMetaEditor extends React.Component {
           listId={
             (page.section?.repeatingSectionListId || page.folder.listId) ?? null
           }
-          usesHighlightStyle
           errorValidationMsg={this.errorMsg("title")}
         />
       </div>

--- a/eq-author/src/App/page/Design/QuestionPageEditor/QuestionProperties/AdditionalContentOptions.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/QuestionProperties/AdditionalContentOptions.js
@@ -26,20 +26,18 @@ import {
 
 const contentControls = {
   bold: true,
-  emphasis: true,
   list: true,
   link: true,
 };
 
 const descriptionControls = {
-  emphasis: true,
+  bold: true,
   piping: true,
   link: true,
 };
 
 const definitionControls = {
   list: true,
-  emphasis: true,
   bold: true,
   link: true,
 };

--- a/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -13,7 +13,7 @@ exports[`MetaEditor should be able to display both deleted metadata and deleted 
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -55,7 +55,7 @@ exports[`MetaEditor should display the correct error message when piping answer 
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -96,7 +96,7 @@ exports[`MetaEditor should display the correct error message when piping answer 
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -137,7 +137,7 @@ exports[`MetaEditor should display the correct error message when the definition
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -174,7 +174,7 @@ exports[`MetaEditor should display the correct error message when the definition
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -211,7 +211,7 @@ exports[`MetaEditor should display the correct error message when the descriptio
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -248,7 +248,7 @@ exports[`MetaEditor should display the correct error message when the includes/e
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -285,7 +285,7 @@ exports[`MetaEditor should display the correct error message when the title is m
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -326,7 +326,7 @@ exports[`MetaEditor should render 1`] = `
     autoFocus={false}
     controls={
       Object {
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -25,11 +25,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: #dce5b0;
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #e0e0e0;
     padding: 0 0.125em;
@@ -130,7 +125,10 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                   <Grid>
                     <Column cols={7}>
                       <SummaryTotalLabel data-test="total-title">
-                        {page.totalTitle.replace(/<\/?p>/g, "")}
+                        {
+                          /* Removes all HTML tags */
+                          page.totalTitle.replace(/<[^>]*>/g, "")
+                        }
                       </SummaryTotalLabel>
                     </Column>
                     <Column cols={3}>

--- a/eq-author/src/App/page/Preview/ListCollectorPagePreview.js
+++ b/eq-author/src/App/page/Preview/ListCollectorPagePreview.js
@@ -33,11 +33,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: #dce5b0;
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #e0e0e0;
     padding: 0 0.125em;

--- a/eq-author/src/App/page/Preview/ListCollectorPagePreviews/AddItemPagePreview/index.js
+++ b/eq-author/src/App/page/Preview/ListCollectorPagePreviews/AddItemPagePreview/index.js
@@ -32,11 +32,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: ${colors.highlightGreen};
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: ${colors.pipingGrey};
     padding: 0 0.125em;

--- a/eq-author/src/App/page/Preview/ListCollectorPagePreviews/ConfirmationPagePreview/index.js
+++ b/eq-author/src/App/page/Preview/ListCollectorPagePreviews/ConfirmationPagePreview/index.js
@@ -20,11 +20,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: ${colors.highlightGreen};
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: ${colors.pipingGrey};
     padding: 0 0.125em;

--- a/eq-author/src/App/page/Preview/ListCollectorPagePreviews/QualifierPagePreview/index.js
+++ b/eq-author/src/App/page/Preview/ListCollectorPagePreviews/QualifierPagePreview/index.js
@@ -20,11 +20,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: ${colors.highlightGreen};
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: ${colors.pipingGrey};
     padding: 0 0.125em;

--- a/eq-author/src/App/page/Preview/QuestionPagePreview.js
+++ b/eq-author/src/App/page/Preview/QuestionPagePreview.js
@@ -29,11 +29,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: #dce5b0;
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #e0e0e0;
     padding: 0 0.125em;

--- a/eq-author/src/App/questionConfirmation/Design/Editor.js
+++ b/eq-author/src/App/questionConfirmation/Design/Editor.js
@@ -65,7 +65,7 @@ export class UnwrappedEditor extends React.Component {
           label="Confirmation question"
           value={title}
           onUpdate={this.handleRichTextUpdate}
-          controls={{ bold: true, emphasis: true, piping: true }}
+          controls={{ highlight: true, piping: true }}
           size="large"
           testSelector="txt-confirmation-title"
           data-test="title-input"

--- a/eq-author/src/App/questionConfirmation/Design/__snapshots__/Editor.test.js.snap
+++ b/eq-author/src/App/questionConfirmation/Design/__snapshots__/Editor.test.js.snap
@@ -6,8 +6,7 @@ exports[`Editor Editor Component should autoFocus the title when there is not on
     autoFocus={true}
     controls={
       Object {
-        "bold": true,
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }
@@ -88,8 +87,7 @@ exports[`Editor Editor Component should render 1`] = `
     autoFocus={false}
     controls={
       Object {
-        "bold": true,
-        "emphasis": true,
+        "highlight": true,
         "piping": true,
       }
     }

--- a/eq-author/src/App/questionConfirmation/Preview/index.js
+++ b/eq-author/src/App/questionConfirmation/Preview/index.js
@@ -32,11 +32,6 @@ const Container = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: #dce5b0;
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #5f7682;
     border-radius: 4px;

--- a/eq-author/src/App/section/Design/SectionEditor/SectionIntroduction/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/SectionIntroduction/index.js
@@ -57,7 +57,7 @@ const SectionIntroduction = ({
           size="large"
           testSelector="txt-introduction-title"
           value={section?.introductionTitle}
-          controls={{ piping: true }}
+          controls={{ highlight: true, piping: true }}
           listId={section?.repeatingSectionListId ?? null}
           errorValidationMsg={introductionTitleErrorMessage}
         />
@@ -74,7 +74,6 @@ const SectionIntroduction = ({
             bold: true,
             list: true,
             piping: true,
-            emphasis: true,
             link: true,
           }}
           listId={section?.repeatingSectionListId ?? null}

--- a/eq-author/src/App/section/Design/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/eq-author/src/App/section/Design/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -24,7 +24,7 @@ exports[`SectionEditor should render 1`] = `
       autoFocus={false}
       controls={
         Object {
-          "emphasis": true,
+          "highlight": true,
           "piping": true,
         }
       }
@@ -152,7 +152,7 @@ exports[`SectionEditor should render 2`] = `
       autoFocus={false}
       controls={
         Object {
-          "emphasis": true,
+          "highlight": true,
           "piping": true,
         }
       }

--- a/eq-author/src/App/section/Design/SectionEditor/index.js
+++ b/eq-author/src/App/section/Design/SectionEditor/index.js
@@ -32,7 +32,7 @@ import {
 } from "constants/modal-content";
 
 const titleControls = {
-  emphasis: true,
+  highlight: true,
   piping: true,
 };
 

--- a/eq-author/src/App/section/Preview/SectionIntroPreview.js
+++ b/eq-author/src/App/section/Preview/SectionIntroPreview.js
@@ -15,11 +15,6 @@ const Wrapper = styled.div`
   p:last-of-type {
     margin-bottom: 0;
   }
-  em {
-    background-color: #dce5b0;
-    padding: 0 0.125em;
-    font-style: normal;
-  }
   span[data-piped] {
     background-color: #e0e0e0;
     padding: 0 0.125em;

--- a/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/eq-author/src/components/RichTextEditor/RichTextEditor.test.js
@@ -31,7 +31,7 @@ const content = `
   <ul>
     <li>Regular</li>
     <li><strong>Bold</strong></li>
-    <li><em>Emphasis</em></li>
+    <li><strong>Highlight</strong></li>
   </ul>
 `;
 
@@ -43,6 +43,10 @@ describe("components/RichTextEditor", function () {
       id: "test",
       name: "test-name",
       testSelector: "test-selector-foo",
+      controls: {
+        bold: true,
+        highlight: false,
+      },
     };
     editorFocus = jest.fn();
     editorInstance = {

--- a/eq-author/src/components/RichTextEditor/Toolbar.js
+++ b/eq-author/src/components/RichTextEditor/Toolbar.js
@@ -35,7 +35,7 @@ export const styleButtons = [
     title: "Highlight",
     icon: iconEmphasis,
     type: STYLE_INLINE,
-    style: "BOLD",
+    style: "BOLD", // BOLD style wraps text in strong tags - used for highlighting
   },
 ];
 

--- a/eq-author/src/components/RichTextEditor/Toolbar.js
+++ b/eq-author/src/components/RichTextEditor/Toolbar.js
@@ -31,11 +31,11 @@ export const styleButtons = [
     style: "BOLD",
   },
   {
-    id: "emphasis",
+    id: "highlight",
     title: "Highlight",
     icon: iconEmphasis,
     type: STYLE_INLINE,
-    style: "ITALIC",
+    style: "HIGHLIGHT",
   },
 ];
 

--- a/eq-author/src/components/RichTextEditor/Toolbar.js
+++ b/eq-author/src/components/RichTextEditor/Toolbar.js
@@ -31,7 +31,7 @@ export const styleButtons = [
     style: "BOLD",
   },
   {
-    id: "emphasis",
+    id: "highlight",
     title: "Highlight",
     icon: iconEmphasis,
     type: STYLE_INLINE,
@@ -86,7 +86,7 @@ class ToolBar extends React.Component {
     selectionIsCollapsed: PropTypes.bool.isRequired,
     controls: PropTypes.shape({
       bold: PropTypes.bool,
-      emphasis: PropTypes.bool,
+      highlight: PropTypes.bool,
       heading: PropTypes.bool,
       list: PropTypes.bool,
       piping: PropTypes.bool,

--- a/eq-author/src/components/RichTextEditor/Toolbar.js
+++ b/eq-author/src/components/RichTextEditor/Toolbar.js
@@ -31,11 +31,11 @@ export const styleButtons = [
     style: "BOLD",
   },
   {
-    id: "highlight",
+    id: "emphasis",
     title: "Highlight",
     icon: iconEmphasis,
     type: STYLE_INLINE,
-    style: "HIGHLIGHT",
+    style: "BOLD",
   },
 ];
 

--- a/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -31,7 +31,12 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
       >
         <ToolBar
           autoFocus={false}
-          controls={Object {}}
+          controls={
+            Object {
+              "bold": true,
+              "highlight": false,
+            }
+          }
           editorState={
             EditorState {
               "_immutable": Immutable.Record {
@@ -160,8 +165,9 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "HIGHLIGHT": Object {
-                "backgroundColor": "#cbe2c8",
+              "BOLD": Object {
+                "backgroundColor": false,
+                "fontWeight": "bold",
               },
             }
           }
@@ -368,7 +374,12 @@ exports[`components/RichTextEditor should render 1`] = `
       >
         <ToolBar
           autoFocus={false}
-          controls={Object {}}
+          controls={
+            Object {
+              "bold": true,
+              "highlight": false,
+            }
+          }
           editorState={
             EditorState {
               "_immutable": Immutable.Record {
@@ -497,8 +508,9 @@ exports[`components/RichTextEditor should render 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "HIGHLIGHT": Object {
-                "backgroundColor": "#cbe2c8",
+              "BOLD": Object {
+                "backgroundColor": false,
+                "fontWeight": "bold",
               },
             }
           }
@@ -706,7 +718,12 @@ exports[`components/RichTextEditor should render existing content 1`] = `
       >
         <ToolBar
           autoFocus={false}
-          controls={Object {}}
+          controls={
+            Object {
+              "bold": true,
+              "highlight": false,
+            }
+          }
           editorState={
             EditorState {
               "_immutable": Immutable.Record {
@@ -732,53 +749,59 @@ exports[`components/RichTextEditor should render existing content 1`] = `
                     "123": Immutable.Record {
                       "key": "123",
                       "type": "unordered-list-item",
-                      "text": "Emphasis",
+                      "text": "Highlight",
                       "characterList": Immutable.List [
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
+                          ],
+                          "entity": null,
+                        },
+                        Immutable.Record {
+                          "style": Immutable.OrderedSet [
+                            "BOLD",
                           ],
                           "entity": null,
                         },
@@ -853,12 +876,12 @@ exports[`components/RichTextEditor should render existing content 1`] = `
                   "123": Immutable.List [
                     Immutable.Record {
                       "start": 0,
-                      "end": 8,
+                      "end": 9,
                       "decoratorKey": null,
                       "leaves": Immutable.List [
                         Immutable.Record {
                           "start": 0,
-                          "end": 8,
+                          "end": 9,
                         },
                       ],
                     },
@@ -881,7 +904,7 @@ exports[`components/RichTextEditor should render existing content 1`] = `
   <ul>
     <li>Regular</li>
     <li><strong>Bold</strong></li>
-    <li><em>Emphasis</em></li>
+    <li><strong>Highlight</strong></li>
   </ul>
 "
           visible={false}
@@ -892,8 +915,9 @@ exports[`components/RichTextEditor should render existing content 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "HIGHLIGHT": Object {
-                "backgroundColor": "#cbe2c8",
+              "BOLD": Object {
+                "backgroundColor": false,
+                "fontWeight": "bold",
               },
             }
           }
@@ -953,53 +977,59 @@ exports[`components/RichTextEditor should render existing content 1`] = `
                     "123": Immutable.Record {
                       "key": "123",
                       "type": "unordered-list-item",
-                      "text": "Emphasis",
+                      "text": "Highlight",
                       "characterList": Immutable.List [
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
                           ],
                           "entity": null,
                         },
                         Immutable.Record {
                           "style": Immutable.OrderedSet [
-                            "ITALIC",
+                            "BOLD",
+                          ],
+                          "entity": null,
+                        },
+                        Immutable.Record {
+                          "style": Immutable.OrderedSet [
+                            "BOLD",
                           ],
                           "entity": null,
                         },
@@ -1074,12 +1104,12 @@ exports[`components/RichTextEditor should render existing content 1`] = `
                   "123": Immutable.List [
                     Immutable.Record {
                       "start": 0,
-                      "end": 8,
+                      "end": 9,
                       "decoratorKey": null,
                       "leaves": Immutable.List [
                         Immutable.Record {
                           "start": 0,
-                          "end": 8,
+                          "end": 9,
                         },
                       ],
                     },
@@ -1150,7 +1180,12 @@ exports[`components/RichTextEditor should show as disabled and readonly when dis
       >
         <ToolBar
           autoFocus={false}
-          controls={Object {}}
+          controls={
+            Object {
+              "bold": true,
+              "highlight": false,
+            }
+          }
           editorState={
             EditorState {
               "_immutable": Immutable.Record {
@@ -1279,8 +1314,9 @@ exports[`components/RichTextEditor should show as disabled and readonly when dis
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "HIGHLIGHT": Object {
-                "backgroundColor": "#cbe2c8",
+              "BOLD": Object {
+                "backgroundColor": false,
+                "fontWeight": "bold",
               },
             }
           }

--- a/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/eq-author/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -160,7 +160,7 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "ITALIC": Object {
+              "HIGHLIGHT": Object {
                 "backgroundColor": "#cbe2c8",
               },
             }
@@ -497,7 +497,7 @@ exports[`components/RichTextEditor should render 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "ITALIC": Object {
+              "HIGHLIGHT": Object {
                 "backgroundColor": "#cbe2c8",
               },
             }
@@ -892,7 +892,7 @@ exports[`components/RichTextEditor should render existing content 1`] = `
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "ITALIC": Object {
+              "HIGHLIGHT": Object {
                 "backgroundColor": "#cbe2c8",
               },
             }
@@ -1279,7 +1279,7 @@ exports[`components/RichTextEditor should show as disabled and readonly when dis
           blockStyleFn={[Function]}
           customStyleMap={
             Object {
-              "ITALIC": Object {
+              "HIGHLIGHT": Object {
                 "backgroundColor": "#cbe2c8",
               },
             }

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -31,10 +31,13 @@ import PasteModal, {
   preserveRichFormatting,
 } from "components/modals/PasteModal";
 
-const styleMap = {
-  HIGHLIGHT: {
-    backgroundColor: "#cbe2c8",
-  },
+const styleMap = (usesHighlightStyle) => {
+  return {
+    BOLD: {
+      backgroundColor: usesHighlightStyle && "#cbe2c8",
+      fontWeight: !usesHighlightStyle && "bold",
+    },
+  };
 };
 
 const heading = css`
@@ -178,6 +181,7 @@ class RichTextEditor extends React.Component {
     linkLimit: PropTypes.number,
     withoutMargin: PropTypes.bool,
     isRepeatingSection: PropTypes.bool,
+    usesHighlightStyle: PropTypes.bool,
     allCalculatedSummaryPages: PropTypes.array, //eslint-disable-line
   };
 
@@ -371,8 +375,17 @@ class RichTextEditor extends React.Component {
   hasInlineStyle = (editorState, style) =>
     editorState.getCurrentInlineStyle().has(style);
 
-  isActiveControl = ({ style, type }) => {
+  isActiveControl = ({ id, style, type }) => {
     const { editorState } = this.state;
+    const { usesHighlightStyle } = this.props;
+
+    // Displays bold button as inactive when highlight style is used, and emphasis button as inactive when highlight style is not used
+    if (
+      (usesHighlightStyle && id === "bold") ||
+      (!usesHighlightStyle && id === "emphasis")
+    ) {
+      return false;
+    }
 
     return type === STYLE_BLOCK
       ? this.hasBlockStyle(editorState, style)
@@ -485,6 +498,7 @@ class RichTextEditor extends React.Component {
       withoutMargin,
       allCalculatedSummaryPages,
       isRepeatingSection,
+      usesHighlightStyle, // Uses highlight style instead of bold for strong tags when true
       ...otherProps
     } = this.props;
 
@@ -530,6 +544,7 @@ class RichTextEditor extends React.Component {
                 linkLimit={linkLimit}
                 allCalculatedSummaryPages={allCalculatedSummaryPages}
                 isRepeatingSection={isRepeatingSection}
+                usesHighlightStyle={usesHighlightStyle}
                 {...otherProps}
               />
 
@@ -539,7 +554,7 @@ class RichTextEditor extends React.Component {
                 editorState={editorState}
                 onChange={this.handleChange}
                 ref={this.setEditorInstance}
-                customStyleMap={styleMap}
+                customStyleMap={styleMap(usesHighlightStyle)}
                 blockStyleFn={getBlockStyle}
                 handleReturn={multiline ? undefined : this.handleReturn}
                 handlePastedText={

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -32,7 +32,7 @@ import PasteModal, {
 } from "components/modals/PasteModal";
 
 const styleMap = {
-  ITALIC: {
+  HIGHLIGHT: {
     backgroundColor: "#cbe2c8",
   },
 };

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -31,11 +31,11 @@ import PasteModal, {
   preserveRichFormatting,
 } from "components/modals/PasteModal";
 
-const styleMap = (usesHighlightStyle) => {
+const styleMap = (controls) => {
   return {
     BOLD: {
-      backgroundColor: usesHighlightStyle && "#cbe2c8",
-      fontWeight: !usesHighlightStyle && "bold",
+      backgroundColor: controls.highlight && "#cbe2c8",
+      fontWeight: controls.bold && "bold",
     },
   };
 };
@@ -161,7 +161,7 @@ class RichTextEditor extends React.Component {
       piping: PropTypes.bool,
       link: PropTypes.bool,
       bold: PropTypes.bool,
-      emphasis: PropTypes.bool,
+      highlight: PropTypes.bool,
       list: PropTypes.bool,
       heading: PropTypes.bool,
     }),
@@ -181,7 +181,6 @@ class RichTextEditor extends React.Component {
     linkLimit: PropTypes.number,
     withoutMargin: PropTypes.bool,
     isRepeatingSection: PropTypes.bool,
-    usesHighlightStyle: PropTypes.bool,
     allCalculatedSummaryPages: PropTypes.array, //eslint-disable-line
   };
 
@@ -377,12 +376,12 @@ class RichTextEditor extends React.Component {
 
   isActiveControl = ({ id, style, type }) => {
     const { editorState } = this.state;
-    const { usesHighlightStyle } = this.props;
+    const { controls } = this.props;
 
-    // Displays bold button as inactive when highlight style is used, and emphasis button as inactive when highlight style is not used
+    // Displays bold and highlight buttons as inactive when the control is not enabled
     if (
-      (usesHighlightStyle && id === "bold") ||
-      (!usesHighlightStyle && id === "emphasis")
+      (id === "bold" && !controls.bold) ||
+      (id === "highlight" && !controls.highlight)
     ) {
       return false;
     }
@@ -498,7 +497,6 @@ class RichTextEditor extends React.Component {
       withoutMargin,
       allCalculatedSummaryPages,
       isRepeatingSection,
-      usesHighlightStyle, // Uses highlight style instead of bold for strong tags when true
       ...otherProps
     } = this.props;
 
@@ -544,7 +542,6 @@ class RichTextEditor extends React.Component {
                 linkLimit={linkLimit}
                 allCalculatedSummaryPages={allCalculatedSummaryPages}
                 isRepeatingSection={isRepeatingSection}
-                usesHighlightStyle={usesHighlightStyle}
                 {...otherProps}
               />
 
@@ -554,7 +551,7 @@ class RichTextEditor extends React.Component {
                 editorState={editorState}
                 onChange={this.handleChange}
                 ref={this.setEditorInstance}
-                customStyleMap={styleMap(usesHighlightStyle)}
+                customStyleMap={styleMap(this.props.controls)}
                 blockStyleFn={getBlockStyle}
                 handleReturn={multiline ? undefined : this.handleReturn}
                 handlePastedText={

--- a/eq-author/src/components/RichTextEditor/utils/convert.js
+++ b/eq-author/src/components/RichTextEditor/utils/convert.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { convertToHTML, convertFromHTML } from "draft-convert";
 
 export const toHTML = (entityMap) => {
@@ -7,18 +6,7 @@ export const toHTML = (entityMap) => {
     return mapper ? mapper(entity) : originalText;
   };
 
-  // Adds strong tags with class names to text based on the text's style
-  const styleToHTML = (style) => {
-    if (style === "BOLD") {
-      return <strong className="bold" />;
-    }
-
-    if (style === "HIGHLIGHT") {
-      return <strong className="highlight" />;
-    }
-  };
-
-  const convert = convertToHTML({ styleToHTML, entityToHTML });
+  const convert = convertToHTML({ entityToHTML });
 
   return (editorState) => convert(editorState.getCurrentContent());
 };
@@ -33,16 +21,5 @@ export const fromHTML = (nodeToFn) => {
     return entity || null;
   };
 
-  // Applies specific styles based on tags and class names - buttons in the toolbar are activated based on these styles
-  const htmlToStyle = (nodeName, node, currentStyle) => {
-    if (nodeName === "strong" && node.className === "highlight") {
-      return currentStyle.add("HIGHLIGHT").remove("BOLD");
-    }
-    if (nodeName === "strong" && node.className === "bold") {
-      return currentStyle.add("BOLD");
-    }
-    return currentStyle;
-  };
-
-  return convertFromHTML({ htmlToStyle, htmlToEntity });
+  return convertFromHTML({ htmlToEntity });
 };

--- a/eq-author/src/components/RichTextEditor/utils/convert.js
+++ b/eq-author/src/components/RichTextEditor/utils/convert.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { convertToHTML, convertFromHTML } from "draft-convert";
 
 export const toHTML = (entityMap) => {
@@ -6,7 +7,18 @@ export const toHTML = (entityMap) => {
     return mapper ? mapper(entity) : originalText;
   };
 
-  const convert = convertToHTML({ entityToHTML });
+  // Adds strong tags with class names to text based on the text's style
+  const styleToHTML = (style) => {
+    if (style === "BOLD") {
+      return <strong className="bold" />;
+    }
+
+    if (style === "HIGHLIGHT") {
+      return <strong className="highlight" />;
+    }
+  };
+
+  const convert = convertToHTML({ styleToHTML, entityToHTML });
 
   return (editorState) => convert(editorState.getCurrentContent());
 };
@@ -21,5 +33,16 @@ export const fromHTML = (nodeToFn) => {
     return entity || null;
   };
 
-  return convertFromHTML({ htmlToEntity });
+  // Applies specific styles based on tags and class names - buttons in the toolbar are activated based on these styles
+  const htmlToStyle = (nodeName, node, currentStyle) => {
+    if (nodeName === "strong" && node.className === "highlight") {
+      return currentStyle.add("HIGHLIGHT").remove("BOLD");
+    }
+    if (nodeName === "strong" && node.className === "bold") {
+      return currentStyle.add("BOLD");
+    }
+    return currentStyle;
+  };
+
+  return convertFromHTML({ htmlToStyle, htmlToEntity });
 };

--- a/eq-author/src/components/RichTextEditor/utils/convert.test.js
+++ b/eq-author/src/components/RichTextEditor/utils/convert.test.js
@@ -33,30 +33,6 @@ describe("convert", () => {
 
       expect(html).toEqual(htmlEntity);
     });
-
-    it("should convert BOLD style to HTML", () => {
-      const rawBoldText = new Raw()
-        .addBlock("Test text")
-        .addInlineStyle("BOLD", 0, 4); // Applies BOLD style to first four characters in "Test text"
-      const expectedHtmlBold = `<p><strong class="bold">Test</strong> text</p>`;
-
-      const convert = toHTML({});
-      const convertedHtml = convert(rawBoldText.toEditorState());
-
-      expect(convertedHtml).toEqual(expectedHtmlBold);
-    });
-
-    it("should convert HIGHLIGHT style to HTML", () => {
-      const rawHighlightText = new Raw()
-        .addBlock("Test text")
-        .addInlineStyle("HIGHLIGHT", 0, 4); // Applies HIGHLIGHT style to first four characters in "Test text"
-      const expectedHtmlHighlight = `<p><strong class="highlight">Test</strong> text</p>`;
-
-      const convert = toHTML({});
-      const convertedHtml = convert(rawHighlightText.toEditorState());
-
-      expect(convertedHtml).toEqual(expectedHtmlHighlight);
-    });
   });
 
   describe("fromHTML", () => {
@@ -77,32 +53,6 @@ describe("convert", () => {
       const editorState = EditorState.createWithContent(convert(htmlEntity));
 
       expect(stateToRaw(editorState)).toEqual(rawEntity.toRawContentState());
-    });
-
-    it("should convert BOLD from HTML", () => {
-      const htmlBold = `<p><strong class="bold">Test</strong> text</p>`;
-      const rawBoldText = new Raw()
-        .addBlock("Test text")
-        .addInlineStyle("BOLD", 0, 4); // Applies BOLD style to first four characters in "Test text"
-
-      const convert = fromHTML({});
-      const editorState = EditorState.createWithContent(convert(htmlBold));
-
-      expect(stateToRaw(editorState)).toEqual(rawBoldText.toRawContentState());
-    });
-
-    it("should convert HIGHLIGHT from HTML", () => {
-      const htmlHighlight = `<p><strong class="highlight">Test</strong> text</p>`;
-      const rawHighlightText = new Raw()
-        .addBlock("Test text")
-        .addInlineStyle("HIGHLIGHT", 0, 4); // Applies HIGHLIGHT style to first four characters in "Test text"
-
-      const convert = fromHTML({});
-      const editorState = EditorState.createWithContent(convert(htmlHighlight));
-
-      expect(stateToRaw(editorState)).toEqual(
-        rawHighlightText.toRawContentState()
-      );
     });
   });
 });

--- a/eq-author/src/components/RichTextEditor/utils/convert.test.js
+++ b/eq-author/src/components/RichTextEditor/utils/convert.test.js
@@ -33,6 +33,30 @@ describe("convert", () => {
 
       expect(html).toEqual(htmlEntity);
     });
+
+    it("should convert BOLD style to HTML", () => {
+      const rawBoldText = new Raw()
+        .addBlock("Test text")
+        .addInlineStyle("BOLD", 0, 4); // Applies BOLD style to first four characters in "Test text"
+      const expectedHtmlBold = `<p><strong class="bold">Test</strong> text</p>`;
+
+      const convert = toHTML({});
+      const convertedHtml = convert(rawBoldText.toEditorState());
+
+      expect(convertedHtml).toEqual(expectedHtmlBold);
+    });
+
+    it("should convert HIGHLIGHT style to HTML", () => {
+      const rawHighlightText = new Raw()
+        .addBlock("Test text")
+        .addInlineStyle("HIGHLIGHT", 0, 4); // Applies HIGHLIGHT style to first four characters in "Test text"
+      const expectedHtmlHighlight = `<p><strong class="highlight">Test</strong> text</p>`;
+
+      const convert = toHTML({});
+      const convertedHtml = convert(rawHighlightText.toEditorState());
+
+      expect(convertedHtml).toEqual(expectedHtmlHighlight);
+    });
   });
 
   describe("fromHTML", () => {
@@ -53,6 +77,32 @@ describe("convert", () => {
       const editorState = EditorState.createWithContent(convert(htmlEntity));
 
       expect(stateToRaw(editorState)).toEqual(rawEntity.toRawContentState());
+    });
+
+    it("should convert BOLD from HTML", () => {
+      const htmlBold = `<p><strong class="bold">Test</strong> text</p>`;
+      const rawBoldText = new Raw()
+        .addBlock("Test text")
+        .addInlineStyle("BOLD", 0, 4); // Applies BOLD style to first four characters in "Test text"
+
+      const convert = fromHTML({});
+      const editorState = EditorState.createWithContent(convert(htmlBold));
+
+      expect(stateToRaw(editorState)).toEqual(rawBoldText.toRawContentState());
+    });
+
+    it("should convert HIGHLIGHT from HTML", () => {
+      const htmlHighlight = `<p><strong class="highlight">Test</strong> text</p>`;
+      const rawHighlightText = new Raw()
+        .addBlock("Test text")
+        .addInlineStyle("HIGHLIGHT", 0, 4); // Applies HIGHLIGHT style to first four characters in "Test text"
+
+      const convert = fromHTML({});
+      const editorState = EditorState.createWithContent(convert(htmlHighlight));
+
+      expect(stateToRaw(editorState)).toEqual(
+        rawHighlightText.toRawContentState()
+      );
     });
   });
 });

--- a/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
+++ b/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
@@ -4,10 +4,10 @@ import { filterConfig as pipedFilterConfig } from "components/RichTextEditor/ent
 import { filterConfig as linkFilterConfig } from "components/RichTextEditor/LinkPlugin";
 
 const mapper = {
-  bold: { format: "BOLD", type: "styles" },
-  highlight: { format: "HIGHLIGHT", type: "styles" },
-  list: { format: "unordered-list-item", type: "blocks" },
-  heading: { format: "header-two", type: "blocks" },
+  bold: { id: "bold", format: "BOLD", type: "styles" },
+  emphasis: { id: "emphasis", format: "BOLD", type: "styles" },
+  list: { id: "list", format: "unordered-list-item", type: "blocks" },
+  heading: { id: "heading", format: "header-two", type: "blocks" },
 };
 
 export default function createFormatStripper(controls) {

--- a/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
+++ b/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
@@ -5,7 +5,7 @@ import { filterConfig as linkFilterConfig } from "components/RichTextEditor/Link
 
 const mapper = {
   bold: { format: "BOLD", type: "styles" },
-  emphasis: { format: "ITALIC", type: "styles" },
+  highlight: { format: "HIGHLIGHT", type: "styles" },
   list: { format: "unordered-list-item", type: "blocks" },
   heading: { format: "header-two", type: "blocks" },
 };

--- a/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
+++ b/eq-author/src/components/RichTextEditor/utils/createFormatStripper.js
@@ -5,7 +5,7 @@ import { filterConfig as linkFilterConfig } from "components/RichTextEditor/Link
 
 const mapper = {
   bold: { id: "bold", format: "BOLD", type: "styles" },
-  emphasis: { id: "emphasis", format: "BOLD", type: "styles" },
+  highlight: { id: "highlight", format: "BOLD", type: "styles" },
   list: { id: "list", format: "unordered-list-item", type: "blocks" },
   heading: { id: "heading", format: "header-two", type: "blocks" },
 };

--- a/eq-author/src/components/preview/elements/PageTitle.js
+++ b/eq-author/src/components/preview/elements/PageTitle.js
@@ -8,6 +8,11 @@ const Title = styled.h1`
   font-size: 1.4em;
   margin: 0 0 1em;
   word-wrap: break-word;
+  strong {
+    background-color: #dce5b0;
+    padding: 0 0.125em;
+    font-style: normal;
+  }
 `;
 
 const PageTitle = ({ title, missingText = "Missing Page Title" }) => {


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Replaces all emphasis tags in Author with strong tags. 

Content wrapped heading tags and strong tags in eQ uses highlight styling. Content wrapped in strong tags and not heading tags in eQ uses bold styling. These changes reflect this in Author.

**Ticket:** https://jira.ons.gov.uk/browse/EAR-2382

### How to review

**Check:**
- [ ] Rich text editors that use bold text by default (e.g. question title) disable the bold button and enable the highlight button - these rich text editors represent content in eQ wrapped in any heading tag
- [ ] Rich text editors that do not use bold text by default (e.g. submission page additional content) disable the highlight button and enable the bold button - these rich text editors represent content in eQ not wrapped in heading tags
- [ ] Migration converts pre-existing em tags into strong tags

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
