### PR TITLE
EAR-2404 Pasting of rich text content

### DIFF
--- a/eq-author-api/utils/createQuestionnaireIntroduction.js
+++ b/eq-author-api/utils/createQuestionnaireIntroduction.js
@@ -23,7 +23,7 @@ module.exports = (metadata) => {
     additionalGuidancePanelSwitch: false,
     additionalGuidancePanel: "",
     description:
-      "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. </li><li>You can provide info estimates if actual figures are not available.</li><li>We will treat your data securely and confidentially.</li></ul>",
+      "<ul><li>Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.</li><li>You can provide info estimates if actual figures are not available.</li><li>We will treat your data securely and confidentially.</li></ul>",
     legalBasis: NOTICE_1,
     // TODO: previewQuestions
     previewQuestions: false,

--- a/eq-author/package.json
+++ b/eq-author/package.json
@@ -107,6 +107,7 @@
     "draft-js-block-breakout-plugin": "latest",
     "draft-js-plugins-editor": "latest",
     "draft-js-raw-content-state": "latest",
+    "draft-js-import-html": "latest",
     "draftjs-filters": "^2.5.0",
     "firebase": "latest",
     "firebaseui": "latest",

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -458,9 +458,10 @@ class RichTextEditor extends React.Component {
         false
       );
       while (walker.nextNode()) {
-        walker.currentNode.nodeValue = walker.currentNode.nodeValue
-          .replace(/\s{2,}/g, " ")
-          .replace(/  /g, " ");
+        walker.currentNode.nodeValue = walker.currentNode.nodeValue.replace(
+          /\s+/g,
+          " "
+        );
       }
       processedText = div.innerHTML;
 
@@ -483,10 +484,9 @@ class RichTextEditor extends React.Component {
       );
     } else {
       // For single line pastes, replace multiple spaces with a single space
-      processedText = sanitizedHtml
+      processedText = processedText
         .replace(/\n/g, " ")
         .replace(/\s+/g, " ")
-        .replace(/  /g, " ")
         .trim();
       const contentState = stateFromHTML(processedText);
       const fragment = contentState.getBlockMap();

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -458,10 +458,9 @@ class RichTextEditor extends React.Component {
         false
       );
       while (walker.nextNode()) {
-        walker.currentNode.nodeValue = walker.currentNode.nodeValue.replace(
-          /\s{2,}/g,
-          " "
-        );
+        walker.currentNode.nodeValue = walker.currentNode.nodeValue
+          .replace(/\s{2,}/g, " ")
+          .replace(/  /g, " ");
       }
       processedText = div.innerHTML;
 
@@ -484,9 +483,10 @@ class RichTextEditor extends React.Component {
       );
     } else {
       // For single line pastes, replace multiple spaces with a single space
-      processedText = processedText
+      processedText = sanitizedHtml
         .replace(/\n/g, " ")
         .replace(/\s+/g, " ")
+        .replace(/  /g, " ")
         .trim();
       const contentState = stateFromHTML(processedText);
       const fragment = contentState.getBlockMap();

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -2,13 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import Editor from "draft-js-plugins-editor";
-import {
-  EditorState,
-  RichUtils,
-  Modifier,
-  CompositeDecorator,
-  ContentState,
-} from "draft-js";
+import { EditorState, RichUtils, Modifier, CompositeDecorator } from "draft-js";
 import { stateFromHTML } from "draft-js-import-html";
 import "draft-js/dist/Draft.css";
 import createBlockBreakoutPlugin from "draft-js-block-breakout-plugin";
@@ -34,9 +28,7 @@ import { sharedStyles } from "components/Forms/css";
 import { Field, Label } from "components/Forms";
 import ValidationError from "components/ValidationError";
 
-import PasteModal, {
-  preserveRichFormatting,
-} from "components/modals/PasteModal";
+import PasteModal from "components/modals/PasteModal";
 
 import { colors } from "../../constants/theme";
 

--- a/eq-author/src/components/RichTextEditor/index.js
+++ b/eq-author/src/components/RichTextEditor/index.js
@@ -438,9 +438,33 @@ class RichTextEditor extends React.Component {
     let newEditorState;
     let processedText = text;
 
+    // Simple HTML sanitization function
+    const sanitizeHtml = (html) => {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      return doc.body.innerHTML;
+    };
+
+    // Sanitize the input HTML
+    const sanitizedHtml = sanitizeHtml(processedText);
+
     if (multiline) {
       // Process the text to remove multiple spaces
-      processedText = processedText.replace(/\s{2,}/g, " ").trim();
+      const div = document.createElement("div");
+      div.innerHTML = sanitizedHtml;
+      const walker = document.createTreeWalker(
+        div,
+        NodeFilter.SHOW_TEXT,
+        null,
+        false
+      );
+      while (walker.nextNode()) {
+        walker.currentNode.nodeValue = walker.currentNode.nodeValue.replace(
+          /\s{2,}/g,
+          " "
+        );
+      }
+      processedText = div.innerHTML;
+
       // Convert processed text from HTML to ContentState
       const contentState = stateFromHTML(processedText);
       const fragment = contentState.getBlockMap();

--- a/eq-author/src/components/modals/PasteModal/index.js
+++ b/eq-author/src/components/modals/PasteModal/index.js
@@ -5,19 +5,6 @@ import PropTypes from "prop-types";
 
 const Message = styled.div``;
 
-export const preserveRichFormatting = (text) => {
-  // Replace multiple spaces and tabs with a single space
-  let formattedText = text.replace(/[ \t]+/g, " ");
-
-  // Split the text into lines
-  let lines = formattedText.split(/\r?\n/);
-
-  // Remove leading and trailing spaces from each line and join them back with newline characters
-  formattedText = lines.map((line) => line.trim()).join("\n");
-
-  return formattedText;
-};
-
 const ModalWrapper = styled.div`
   .modal-button-container {
     margin-top: 1em;

--- a/eq-author/src/components/modals/PasteModal/index.test.js
+++ b/eq-author/src/components/modals/PasteModal/index.test.js
@@ -1,26 +1,10 @@
 import React from "react";
 import { render, fireEvent } from "tests/utils/rtl";
-import PasteModal, { preserveRichFormatting } from ".";
+import PasteModal from ".";
 
 import { keyCodes } from "constants/keyCodes";
 
 const { Escape } = keyCodes;
-
-describe("preserveRichFormatting function", () => {
-  it("should replace multiple spaces and tabs with a single space", () => {
-    const inputText = "   Hello \t\t World    ";
-    const expectedOutput = "Hello World";
-    const result = preserveRichFormatting(inputText);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it("should remove leading and trailing spaces from each line", () => {
-    const inputText = "   Line 1   \n   Line 2   \n   Line 3   ";
-    const expectedOutput = "Line 1\nLine 2\nLine 3";
-    const result = preserveRichFormatting(inputText);
-    expect(result).toBe(expectedOutput);
-  });
-});
 
 describe("PasteModal", () => {
   let onConfirm, onCancel;

--- a/eq-author/yarn.lock
+++ b/eq-author/yarn.lock
@@ -7331,6 +7331,21 @@ draft-js-block-breakout-plugin@latest:
   dependencies:
     immutable "~3.7.4"
 
+draft-js-import-element@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz#8760acbfeb60ed824a1c8319ec049f702681df66"
+  integrity sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==
+  dependencies:
+    draft-js-utils "^1.4.0"
+    synthetic-dom "^1.4.0"
+
+draft-js-import-html@latest:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-import-html/-/draft-js-import-html-1.4.1.tgz#c222a3a40ab27dee5874fcf78526b64734fe6ea4"
+  integrity sha512-KOZmtgxZriCDgg5Smr3Y09TjubvXe7rHPy/2fuLSsL+aSzwUDwH/aHDA/k47U+WfpmL4qgyg4oZhqx9TYJV0tg==
+  dependencies:
+    draft-js-import-element "^1.4.0"
+
 draft-js-plugins-editor@latest:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/draft-js-plugins-editor/-/draft-js-plugins-editor-3.0.0.tgz#196d1e065e2c29faebaab4ec081b734fdef294a2"
@@ -7345,6 +7360,11 @@ draft-js-raw-content-state@latest:
   integrity sha512-1EVlN3AW0RwpoJSsnlU4uU+XXQSADCkRhUnYukKFvlnnqmLgatw2uKtZ8qcclOJ0tqAFCr+2xDXMxLLpns3KdQ==
   dependencies:
     draft-js "^0.10.5"
+
+draft-js-utils@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-utils/-/draft-js-utils-1.4.1.tgz#a59c792ad621f7050292031a237d524708a6d509"
+  integrity sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==
 
 draft-js@^0.10.5:
   version "0.10.5"
@@ -16752,6 +16772,11 @@ synchronous-promise@latest:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
+
+synthetic-dom@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/synthetic-dom/-/synthetic-dom-1.4.0.tgz#d988d7a4652458e2fc8706a875417af913e4dd34"
+  integrity sha512-mHv51ZsmZ+ShT/4s5kg+MGUIhY7Ltq4v03xpN1c8T1Krb5pScsh/lzEjyhrVD0soVDbThbd2e+4dD9vnDG4rhg==
 
 tabbable@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
### What is the context of this PR?

An issue with the new spaces paste modal confirmation pasting has been identified, in that when pasting HTML content (list items etc) into RT fields where the pasted content contains multiple spaces the formatting is lost. Change fixes this issue. 

### How to review

- Changes include a new package, so a yarn update is needed to be done when running the branch.
- Test that rich formatted text (list, bold, links etc) with additional spaces in are maintained when pasted into a RT field, confirming that the confirm paste modal is triggered. 
- Confirm that pasting rich formatted text without spaces does not trigger the paste modal, but maintains the formatting
- Confirm that single line pastes (non-rich text) behave as before, both with and without spaces
- Changes have also been deployed to prototype-one for on-Network testing

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
