### PR TITLE
EAR-2311 - Moving page from repeating section into list collector folder

### DIFF
--- a/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
+++ b/eq-author/src/App/QuestionnaireDesignPage/NavigationSidebar/index.js
@@ -110,7 +110,9 @@ const NavigationSidebar = ({ questionnaire }) => {
   const [openSections, toggleSections] = useState(true);
   const [entity, setEntity] = useState({}); // Allows data for entity being dragged by user to be used in other droppables
 
-  const [movePage] = useMutation(MOVE_PAGE_MUTATION);
+  const [movePage] = useMutation(MOVE_PAGE_MUTATION, {
+    refetchQueries: ["GetPage"],
+  });
   const [moveFolder] = useMutation(MOVE_FOLDER_MUTATION);
   const [moveSection] = useMutation(MOVE_SECTION_MUTATION);
 

--- a/eq-author/src/App/page/Design/ListCollectorPageEditor/index.js
+++ b/eq-author/src/App/page/Design/ListCollectorPageEditor/index.js
@@ -782,6 +782,9 @@ UnwrappedListCollectorPageEditor.fragments = {
       folder {
         id
         position
+        ... on ListCollectorFolder {
+          listId
+        }
       }
       section {
         id

--- a/eq-author/src/App/page/Design/QuestionPageEditor/index.js
+++ b/eq-author/src/App/page/Design/QuestionPageEditor/index.js
@@ -239,6 +239,9 @@ UnwrappedQuestionPageEditor.fragments = {
       folder {
         id
         position
+        ... on ListCollectorFolder {
+          listId
+        }
       }
       section {
         id

--- a/eq-author/src/App/page/Design/index.js
+++ b/eq-author/src/App/page/Design/index.js
@@ -63,6 +63,10 @@ export const PAGE_QUERY = gql`
           listId
         }
       }
+      section {
+        id
+        repeatingSectionListId
+      }
     }
   }
   ${CalculatedSummaryPageEditor.fragments.CalculatedSummaryPage}

--- a/eq-author/src/graphql/movePage.graphql
+++ b/eq-author/src/graphql/movePage.graphql
@@ -49,6 +49,10 @@ mutation MovePage($input: MovePageInput!) {
               listId
             }
           }
+          section {
+            id
+            repeatingSectionListId
+          }
           ... on QuestionPage {
             answers {
               ...Answer


### PR DESCRIPTION
### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-2311

### How to review

- Create a questionnaire, open the "Collection Lists" page, and create two collection lists - 'Collect1' and 'Collect2' - each with an answer.
- Create a section with a list collector folder and link it to the first collection list called 'Collect1'.
- Create a new repeating section and link it to the second collection list called 'Collect2'.
- Create a question page called 'Q123' inside the repeating section.
- In the question title, click 'Pipe Answer', select 'Answer from linked collection list' - this must show 'Collect2' which is the collection list the repeating section is linked to.
- Move the question page 'Q123' from the repeating section into the list collector folder created above.
- In the question title, click 'Pipe Answer', select 'Answer from linked collection list' - this must show 'Collect1' which is the collection list the list collector folder is linked to.
- Move the page 'Q123' back into the repeating section and repeat the above checks.