### PR TITLE
EAR 2291 update content for calculated summary questions

### DIFF
--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -5,7 +5,6 @@ import { propType } from "graphql-anywhere";
 import styled from "styled-components";
 import Error from "components/preview/Error";
 import PageTitle from "components/preview/elements/PageTitle";
-import Info from "components/preview/elements/Info";
 
 import EditorLayout from "components/EditorLayout";
 import Panel from "components/Panel";
@@ -15,6 +14,9 @@ import CommentsPanel from "App/Comments";
 import { colors } from "constants/theme";
 import CalculatedSummaryPageEditor from "../Design/CalculatedSummaryPageEditor";
 import { useSetNavigationCallbacksForPage } from "components/NavigationCallbacks";
+import { getPageByAnswerId } from "utils/questionnaireUtils";
+import { useQuestionnaire } from "components/QuestionnaireContext";
+import Answers from "../Design/CalculatedSummaryPageEditor/AnswerSelector/Answers";
 
 const Container = styled.div`
   padding: 2em;
@@ -97,6 +99,21 @@ const CalculatedSummaryPagePreview = ({ page }) => {
     section: page?.section,
   });
 
+  const { questionnaire } = useQuestionnaire();
+  const uniqueTitles = new Set();
+
+  const titles = page.summaryAnswers.map((answer) => {
+    const pages = getPageByAnswerId(questionnaire, answer.id);
+    if (pages) {
+      const title = pages.title.replace(/<[^>]*>/g, "");
+      if (!uniqueTitles.has(title)) {
+        uniqueTitles.add(title);
+        return title;
+      }
+    }
+    return null;
+  });
+
   return (
     <EditorLayout
       title={page.displayName}
@@ -114,6 +131,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
 
           {page.summaryAnswers.length > 0 ? (
             <Summary>
+              <div>{titles}</div>
               {page.summaryAnswers.map((answer) => (
                 <SummaryItem key={answer.id}>
                   <Grid>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -218,7 +218,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
 
                     <Grid>
                       <Column cols={7}>
-                        <SummaryLabel data-test="answer-item">
+                        <SummaryLabel data-test={`answer-item-${answer.id}`}>
                           {answer.displayName}
                         </SummaryLabel>
                       </Column>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -48,15 +48,19 @@ const Button = styled.div`
 `;
 
 const Summary = styled.div`
-  border-bottom: 1px solid #999;
   margin-bottom: 2rem;
 `;
 
 const SummaryItem = styled.div`
-  border-top: 1px solid #999;
   border-radius: 0;
   position: relative;
   padding: 1rem 0;
+`;
+
+const TitleQuestion = styled.div`
+  &:not(:first-of-type) {
+    border-top: ${(props) => (props.questionTitle ? "1px solid #999" : "none")};
+  }
 `;
 
 const SummaryLabel = styled.div`
@@ -187,12 +191,18 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                 }
 
                 const duplicatedPageIds = getDuplicatedPageIds();
+                const questionTitle =
+                  !hasAnswerPageIdBeenUsed &&
+                  duplicatedPageIds.includes(answerPage?.id) &&
+                  answerPage?.title.replace(/<p>|<\/p>/g, "");
+
+                console.log("questionpage", questionTitle);
 
                 return (
                   <>
-                    {!hasAnswerPageIdBeenUsed &&
-                      duplicatedPageIds.includes(answerPage?.id) &&
-                      answerPage?.title.replace(/<p>|<\/p>/g, "")}
+                    <TitleQuestion questionTitle={questionTitle}>
+                      {questionTitle}
+                    </TitleQuestion>
                     <SummaryItem key={answer.id}>
                       <Grid>
                         <Column cols={7}>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -55,12 +55,13 @@ const SummaryItem = styled.div`
   border-radius: 0;
   position: relative;
   padding: 1rem 0;
+  border-bottom: ${(props) =>
+    props.isLastSummaryAnswerFromPage ? "1px solid #999" : "none"};
 `;
 
-const TitleQuestion = styled.div`
-  &:not(:first-of-type) {
-    border-top: ${(props) => (props.questionTitle ? "1px solid #999" : "none")};
-  }
+const QuestionPageTitle = styled.div`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 `;
 
 const SummaryLabel = styled.div`
@@ -207,10 +208,13 @@ const CalculatedSummaryPagePreview = ({ page }) => {
 
                 return (
                   <>
-                    <TitleQuestion questionTitle={questionTitle}>
+                    <QuestionPageTitle questionTitle={questionTitle}>
                       {questionTitle}
-                    </TitleQuestion>
-                    <SummaryItem key={answer.id}>
+                    </QuestionPageTitle>
+                    <SummaryItem
+                      key={answer.id}
+                      isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
+                    >
                       <Grid>
                         <Column cols={7}>
                           <SummaryLabel data-test="answer-item">

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -186,15 +186,16 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                 const hasAnswerPageIdBeenUsed = usedPageIds.includes(
                   answerPage?.id
                 );
+
                 if (!hasAnswerPageIdBeenUsed) {
                   usedPageIds.push(answerPage?.id);
                 }
 
                 const duplicatedPageIds = getDuplicatedPageIds();
-                const questionTitle =
-                  !hasAnswerPageIdBeenUsed &&
-                  duplicatedPageIds.includes(answerPage?.id) &&
-                  answerPage?.title.replace(/<p>|<\/p>/g, "");
+                const questionTitle = answerPage?.title.replace(
+                  /<p>|<\/p>/g,
+                  ""
+                );
 
                 const summaryAnswersOnSamePage = sortedSummaryAnswers.filter(
                   (summaryAnswer) =>
@@ -212,12 +213,17 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                     key={answer.id}
                     isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
                   >
-                    <QuestionPageTitle
-                      data-test={`question-title-${index}`}
-                      questionTitle={questionTitle}
-                    >
-                      {questionTitle}
-                    </QuestionPageTitle>
+                    {!hasAnswerPageIdBeenUsed &&
+                      duplicatedPageIds.includes(answerPage?.id) && (
+                        <QuestionPageTitle
+                          data-test={`question-title-${duplicatedPageIds?.findIndex(
+                            (pageId) => pageId === answerPage?.id
+                          )}`}
+                          questionTitle={questionTitle}
+                        >
+                          {questionTitle}
+                        </QuestionPageTitle>
+                      )}
 
                     <Grid>
                       <Column cols={7}>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -213,7 +213,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                     isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
                   >
                     <QuestionPageTitle
-                      data-test="question-page-title"
+                      data-test={`question-title-${index}`}
                       questionTitle={questionTitle}
                     >
                       {questionTitle}

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -101,10 +101,53 @@ const CalculatedSummaryPagePreview = ({ page }) => {
 
   const usedPageIds = [];
 
+  const getAnswerIndexInPage = (answer) => {
+    const page = getPageByAnswerId(questionnaire, answer.id);
+
+    // Finds the index of the answer argument within its page
+    return page?.answers?.findIndex(
+      (pageAnswer) => pageAnswer.id === answer.id
+    );
+  };
+
+  /* 
+  Sorts summaryAnswers by page and answers (keeps pages in the order they appear in summaryAnswers, and sorts answers by their order in their page)
+  Ensures answers are always displayed underneath their page, and in the order they appear in the page
+  .slice() creates a copy of page.summaryAnswers to prevent mutating the original page.summaryAnswers array
+  */
+  const sortedSummaryAnswers = page.summaryAnswers.slice().sort((a, b) => {
+    const pageContainingAnswerA = getPageByAnswerId(questionnaire, a.id);
+    const pageContainingAnswerB = getPageByAnswerId(questionnaire, b.id);
+
+    // If the answers are on the same page, sort the answers in the order they appear in the page
+    if (pageContainingAnswerA?.id === pageContainingAnswerB?.id) {
+      return getAnswerIndexInPage(a) - getAnswerIndexInPage(b);
+    }
+
+    // Gets the first answer from page A that appears in summaryAnswers
+    const firstAnswerFromPageA = page.summaryAnswers.find(
+      (answer) =>
+        getPageByAnswerId(questionnaire, answer.id)?.id ===
+        pageContainingAnswerA?.id
+    );
+    // Gets the first answer from page B that appears in summaryAnswers
+    const firstAnswerFromPageB = page.summaryAnswers.find(
+      (answer) =>
+        getPageByAnswerId(questionnaire, answer.id)?.id ===
+        pageContainingAnswerB?.id
+    );
+
+    // Sorts answers based on the order of their pages in summaryAnswers (keeps pages in the order they appear in summaryAnswers)
+    return (
+      page.summaryAnswers.indexOf(firstAnswerFromPageA) -
+      page.summaryAnswers.indexOf(firstAnswerFromPageB)
+    );
+  });
+
   const getDuplicatedPageIds = () => {
     const allPageIds = [];
 
-    page.summaryAnswers.forEach((summaryAnswer) => {
+    sortedSummaryAnswers.forEach((summaryAnswer) => {
       const summaryAnswerPage = getPageByAnswerId(
         questionnaire,
         summaryAnswer.id
@@ -132,9 +175,9 @@ const CalculatedSummaryPagePreview = ({ page }) => {
         <Container>
           <PageTitle title={page.title} />
 
-          {page.summaryAnswers.length > 0 ? (
+          {sortedSummaryAnswers.length > 0 ? (
             <Summary>
-              {page.summaryAnswers.map((answer) => {
+              {sortedSummaryAnswers.map((answer) => {
                 const answerPage = getPageByAnswerId(questionnaire, answer.id);
                 const hasAnswerPageIdBeenUsed = usedPageIds.includes(
                   answerPage?.id

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -60,7 +60,6 @@ const SummaryItem = styled.div`
 `;
 
 const QuestionPageTitle = styled.div`
-  margin-top: 1rem;
   margin-bottom: 1rem;
 `;
 
@@ -207,29 +206,28 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                   answer.id === lastSummaryAnswerFromPage.id;
 
                 return (
-                  <>
+                  <SummaryItem
+                    key={answer.id}
+                    isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
+                  >
                     <QuestionPageTitle questionTitle={questionTitle}>
                       {questionTitle}
                     </QuestionPageTitle>
-                    <SummaryItem
-                      key={answer.id}
-                      isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
-                    >
-                      <Grid>
-                        <Column cols={7}>
-                          <SummaryLabel data-test="answer-item">
-                            {answer.displayName}
-                          </SummaryLabel>
-                        </Column>
-                        <Column cols={3}>
-                          <SummaryValue>Value</SummaryValue>
-                        </Column>
-                        <Column cols={2}>
-                          <SummaryLink>Change</SummaryLink>
-                        </Column>
-                      </Grid>
-                    </SummaryItem>
-                  </>
+
+                    <Grid>
+                      <Column cols={7}>
+                        <SummaryLabel data-test="answer-item">
+                          {answer.displayName}
+                        </SummaryLabel>
+                      </Column>
+                      <Column cols={3}>
+                        <SummaryValue>Value</SummaryValue>
+                      </Column>
+                      <Column cols={2}>
+                        <SummaryLink>Change</SummaryLink>
+                      </Column>
+                    </Grid>
+                  </SummaryItem>
                 );
               })}
 

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -196,11 +196,13 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                   duplicatedPageIds.includes(answerPage?.id) &&
                   answerPage?.title.replace(/<p>|<\/p>/g, "");
 
-                const lastSummaryAnswerFromPage = sortedSummaryAnswers.findLast(
+                const summaryAnswersOnSamePage = sortedSummaryAnswers.filter(
                   (summaryAnswer) =>
                     getPageByAnswerId(questionnaire, summaryAnswer.id)?.id ===
                     answerPage?.id
                 );
+                const lastSummaryAnswerFromPage =
+                  summaryAnswersOnSamePage[summaryAnswersOnSamePage.length - 1];
 
                 const isLastSummaryAnswerFromPage =
                   answer.id === lastSummaryAnswerFromPage.id;

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -32,6 +32,19 @@ const Container = styled.div`
     white-space: pre-wrap;
   }
 `;
+const Button = styled.div`
+  color: white;
+  background-color: ${colors.green};
+  border: 2px solid ${colors.green};
+  padding: 0.75rem 1rem;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 3px;
+  display: inline-block;
+  text-rendering: optimizeLegibility;
+  margin-bottom: 2em;
+`;
 
 const Summary = styled.div`
   border-bottom: 1px solid #999;
@@ -98,7 +111,6 @@ const CalculatedSummaryPagePreview = ({ page }) => {
       <Panel data-test="calSum test page">
         <Container>
           <PageTitle title={page.title} />
-          <Info>Please review your answers and confirm these are correct.</Info>
 
           {page.summaryAnswers.length > 0 ? (
             <Summary>
@@ -148,6 +160,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
               No answers selected
             </Error>
           )}
+          <Button>Yes, I confirm this is correct</Button>
         </Container>
       </Panel>
     </EditorLayout>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -181,7 +181,7 @@ const CalculatedSummaryPagePreview = ({ page }) => {
 
           {sortedSummaryAnswers.length > 0 ? (
             <Summary>
-              {sortedSummaryAnswers.map((answer) => {
+              {sortedSummaryAnswers.map((answer, index) => {
                 const answerPage = getPageByAnswerId(questionnaire, answer.id);
                 const hasAnswerPageIdBeenUsed = usedPageIds.includes(
                   answerPage?.id
@@ -212,13 +212,16 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                     key={answer.id}
                     isLastSummaryAnswerFromPage={isLastSummaryAnswerFromPage}
                   >
-                    <QuestionPageTitle questionTitle={questionTitle}>
+                    <QuestionPageTitle
+                      data-test="question-page-title"
+                      questionTitle={questionTitle}
+                    >
                       {questionTitle}
                     </QuestionPageTitle>
 
                     <Grid>
                       <Column cols={7}>
-                        <SummaryLabel data-test={`answer-item-${answer.id}`}>
+                        <SummaryLabel data-test={`answer-item-${index}`}>
                           {answer.displayName}
                         </SummaryLabel>
                       </Column>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.js
@@ -196,7 +196,14 @@ const CalculatedSummaryPagePreview = ({ page }) => {
                   duplicatedPageIds.includes(answerPage?.id) &&
                   answerPage?.title.replace(/<p>|<\/p>/g, "");
 
-                console.log("questionpage", questionTitle);
+                const lastSummaryAnswerFromPage = sortedSummaryAnswers.findLast(
+                  (summaryAnswer) =>
+                    getPageByAnswerId(questionnaire, summaryAnswer.id)?.id ===
+                    answerPage?.id
+                );
+
+                const isLastSummaryAnswerFromPage =
+                  answer.id === lastSummaryAnswerFromPage.id;
 
                 return (
                   <>

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -25,9 +25,9 @@ const questionnaire = {
               pageType: "QuestionPage",
               title: "Page 1",
               answers: [
-                { id: "4", label: "answer 1", questionPageId: "123" },
+                { id: "answer-1", label: "answer 1", questionPageId: "123" },
                 {
-                  id: "5",
+                  id: "answer-2",
                   label: "answer 2",
                   questionPageId: "234",
                 },
@@ -39,12 +39,12 @@ const questionnaire = {
               title: "Page 2",
               answer: [
                 {
-                  id: "7",
+                  id: "answer-3",
                   label: "answer 3",
                   questionPageId: "345",
                 },
                 {
-                  id: "8",
+                  id: "answer-4",
                   label: "answer 4",
                   questionPageId: "456",
                 },
@@ -54,11 +54,13 @@ const questionnaire = {
               id: "9",
               title: "calculated summary page 1",
               pageType: "CalculatedSummaryPage",
+              pageDescription: "Hello",
+              alias: "Who am I?",
               summaryAnswers: [
-                { id: "8", displayName: "Answer 8" },
-                { id: "5", displayName: "Answer 5" },
-                { id: "7", displayName: "Answer 7" },
-                { id: "4", displayName: "Answer 4" },
+                { id: "answer-4", displayName: "Answer 4" },
+                { id: "answer-2", displayName: "Answer 2" },
+                { id: "answer-3", displayName: "Answer 3" },
+                { id: "answer-1", displayName: "Answer 1" },
               ],
             },
           ],
@@ -197,8 +199,9 @@ describe("CalculatedSummaryPreview", () => {
   // change the code where it test based on the data-test id(data-test id need to be unique for each answer) no functions need to be mock at all.
   // check the text of answer found from the data test id is equal to the answer.displayName
   // check if the question page title appear in the correct order with the answer display name
+  // index for each loop
 
-  it("should order the summary answers correctly ", () => {
+  it.only("should order the summary answers correctly ", () => {
     const { getByTestId } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
@@ -215,18 +218,9 @@ describe("CalculatedSummaryPreview", () => {
       }
     );
 
-    const answer = questionnaire.sections[0].folders[0].pages[2].summaryAnswers;
-    expect(getByTestId(`answer-item-${answer[0].id}`)).toHaveTextContent(
-      "Answer 8"
-    );
-    expect(getByTestId(`answer-item-${answer[1].id}`)).toHaveTextContent(
-      "Answer 5"
-    );
-    expect(getByTestId(`answer-item-${answer[2].id}`)).toHaveTextContent(
-      "Answer 7"
-    );
-    expect(getByTestId(`answer-item-${answer[3].id}`)).toHaveTextContent(
-      "Answer 4"
-    );
+    expect(getByTestId("answer-item-0")).toHaveTextContent("Answer 4");
+    expect(getByTestId("answer-item-1")).toHaveTextContent("Answer 3");
+    expect(getByTestId("answer-item-2")).toHaveTextContent("Answer 1");
+    expect(getByTestId("answer-item-3")).toHaveTextContent("Answer 2");
   });
 });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -54,7 +54,12 @@ const questionnaire = {
               id: "9",
               title: "calculated summary page 1",
               pageType: "CalculatedSummaryPage",
-              summaryAnswers: ["8", "5", "7", "4"],
+              summaryAnswers: [
+                { id: "8", displayName: "Answer 8" },
+                { id: "5", displayName: "Answer 5" },
+                { id: "7", displayName: "Answer 7" },
+                { id: "4", displayName: "Answer 4" },
+              ],
             },
           ],
         },
@@ -188,9 +193,12 @@ describe("CalculatedSummaryPreview", () => {
     expect(wrapper.find(byTestAttr("no-answers-selected"))).toBeTruthy();
   });
 
+  // test the answer.display name is rendered in the page.
+  // change the code where it test based on the data-test id(data-test id need to be unique for each answer) no functions need to be mock at all.
+  // check the text of answer found from the data test id is equal to the answer.displayName
+
   it("should order the summary answers correctly ", () => {
-    const sortedSummaryAnswers = jest.fn();
-    const { getByTestId, getByText, getAllByTestId } = render(
+    const { getByTestId, getByText } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
           <CalculatedSummaryPreview page={page} />
@@ -202,7 +210,11 @@ describe("CalculatedSummaryPreview", () => {
         mocks,
       }
     );
-
-    expect(sortedSummaryAnswers).toHaveBeenCalled();
+    questionnaire.sections[0].folders[0].pages[2].summaryAnswers.forEach(
+      (answer) => {
+        const renderDisplayName = getByText(answer.displayName);
+        expect(renderDisplayName).toBeInTheDocument();
+      }
+    );
   });
 });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -4,24 +4,21 @@ import { render, flushPromises, act } from "tests/utils/rtl";
 
 import commentsSubscription from "graphql/subscriptions/commentSubscription.graphql";
 import { MeContext } from "App/MeContext";
+
 import { byTestAttr } from "tests/utils/selectors";
 
 import CalculatedSummaryPreview from "./CalculatedSummaryPreview";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
-import useQuestionnaire from "components/QuestionnaireContext";
-
-jest.mock("components/QuestionnaireContext", () => ({
-  useQuestionnaire: jest.fn(),
-}));
+import QuestionnaireContext from "components/QuestionnaireContext";
 
 const questionnaire = {
   id: "questionnaire-1",
   sections: [
     {
-      id: "1",
+      id: "section-1",
       folders: [
         {
-          id: "2",
+          id: "folder-1",
           pages: [
             {
               id: "3",
@@ -57,7 +54,7 @@ const questionnaire = {
               id: "9",
               title: "calculated summary page 1",
               pageType: "CalculatedSummaryPage",
-              summaryAnswers: ["4", "5", "7", "8"],
+              summaryAnswers: ["8", "5", "7", "4"],
             },
           ],
         },
@@ -65,10 +62,6 @@ const questionnaire = {
     },
   ],
 };
-
-// useQuestionnaire.mockImplementation(() => ({
-//   questionnaire:
-// }));
 
 describe("CalculatedSummaryPreview", () => {
   let page, me, mocks, questionnaireId;
@@ -195,5 +188,21 @@ describe("CalculatedSummaryPreview", () => {
     expect(wrapper.find(byTestAttr("no-answers-selected"))).toBeTruthy();
   });
 
-  it("should order the summary answers correctly ", () => {});
+  it("should order the summary answers correctly ", () => {
+    const sortedSummaryAnswers = jest.fn();
+    const { getByTestId, getByText, getAllByTestId } = render(
+      <QuestionnaireContext.Provider value={{ questionnaire }}>
+        <MeContext.Provider value={{ me }}>
+          <CalculatedSummaryPreview page={page} />
+        </MeContext.Provider>
+      </QuestionnaireContext.Provider>,
+      {
+        route: `/q/${questionnaireId}/page/9/preview`,
+        urlParamMatcher: "/q/:questionnaireId/page/:pageId",
+        mocks,
+      }
+    );
+
+    expect(sortedSummaryAnswers).toHaveBeenCalled();
+  });
 });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -58,10 +58,15 @@ const questionnaire = {
             },
             {
               id: "9",
-              title: "calculated summary page 1",
-              pageType: "CalculatedSummaryPage",
-              pageDescription: "Hello",
+              displayName: "Cal Sum",
+              position: 1,
+              title: "Calculated summary page 1",
+              totalTitle: "Total bills:",
+              pageDescription: "This page calculates the total bills",
               alias: "Who am I?",
+              type: "Number",
+              answers: [],
+              comments: [],
 
               summaryAnswers: [
                 { id: "answer-4", displayName: "Answer 4" },
@@ -69,6 +74,24 @@ const questionnaire = {
                 { id: "answer-3", displayName: "Answer 3" },
                 { id: "answer-1", displayName: "Answer 1" },
               ],
+              pageType: "CalculatedSummaryPage",
+              section: {
+                id: "1",
+                position: 0,
+                questionnaire: {
+                  id: "1",
+                  metadata: [],
+                },
+              },
+              validationErrorInfo: {
+                id: "test",
+                totalCount: 0,
+                errors: [],
+              },
+              folder: {
+                id: "folder-1",
+                position: 0,
+              },
             },
           ],
         },
@@ -202,13 +225,8 @@ describe("CalculatedSummaryPreview", () => {
     expect(wrapper.find(byTestAttr("no-answers-selected"))).toBeTruthy();
   });
 
-  // test the answer.display name is rendered in the page.
-  // change the code where it test based on the data-test id(data-test id need to be unique for each answer) no functions need to be mock at all.
-  // check the text of answer found from the data test id is equal to the answer.displayName
-  // check if the question page title appear in the correct order with the answer display name
-
-  it.only("should order the summary answers correctly ", () => {
-    const { getByTestId, getByText } = render(
+  it("should sort the summary answers based on the first selection and ensure that the display names and question titles match this order ", () => {
+    const { getByTestId } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
           <CalculatedSummaryPreview

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -8,7 +8,7 @@ import { byTestAttr } from "tests/utils/selectors";
 
 import CalculatedSummaryPreview from "./CalculatedSummaryPreview";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
-import { useQuestionnaire } from "components/QuestionnaireContext";
+import useQuestionnaire from "components/QuestionnaireContext";
 
 jest.mock("components/QuestionnaireContext", () => ({
   useQuestionnaire: jest.fn(),
@@ -52,6 +52,12 @@ const questionnaire = {
                   questionPageId: "456",
                 },
               ],
+            },
+            {
+              id: "9",
+              title: "calculated summary page 1",
+              pageType: "CalculatedSummaryPage",
+              summaryAnswers: ["4", "5", "7", "8"],
             },
           ],
         },

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -8,6 +8,61 @@ import { byTestAttr } from "tests/utils/selectors";
 
 import CalculatedSummaryPreview from "./CalculatedSummaryPreview";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
+import { useQuestionnaire } from "components/QuestionnaireContext";
+
+jest.mock("components/QuestionnaireContext", () => ({
+  useQuestionnaire: jest.fn(),
+}));
+
+const questionnaire = {
+  id: "questionnaire-1",
+  sections: [
+    {
+      id: "1",
+      folders: [
+        {
+          id: "2",
+          pages: [
+            {
+              id: "3",
+              pageType: "QuestionPage",
+              title: "Page 1",
+              answers: [
+                { id: "4", label: "answer 1", questionPageId: "123" },
+                {
+                  id: "5",
+                  label: "answer 2",
+                  questionPageId: "234",
+                },
+              ],
+            },
+            {
+              id: "6",
+              pageType: "QuestionPage",
+              title: "Page 2",
+              answers: [
+                {
+                  id: "7",
+                  label: "answer 3",
+                  questionPageId: "345",
+                },
+                {
+                  id: "8",
+                  label: "answer 4",
+                  questionPageId: "456",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// useQuestionnaire.mockImplementation(() => ({
+//   questionnaire:
+// }));
 
 describe("CalculatedSummaryPreview", () => {
   let page, me, mocks, questionnaireId;
@@ -133,4 +188,6 @@ describe("CalculatedSummaryPreview", () => {
     );
     expect(wrapper.find(byTestAttr("no-answers-selected"))).toBeTruthy();
   });
+
+  it("should order the summary answers correctly ", () => {});
 });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -206,10 +206,9 @@ describe("CalculatedSummaryPreview", () => {
   // change the code where it test based on the data-test id(data-test id need to be unique for each answer) no functions need to be mock at all.
   // check the text of answer found from the data test id is equal to the answer.displayName
   // check if the question page title appear in the correct order with the answer display name
-  // index for each loop
 
   it.only("should order the summary answers correctly ", () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByText } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
           <CalculatedSummaryPreview
@@ -224,9 +223,13 @@ describe("CalculatedSummaryPreview", () => {
         mocks,
       }
     );
+    expect(getByTestId("question-title-0")).toHaveTextContent("Page 2");
 
     expect(getByTestId("answer-item-0")).toHaveTextContent("Answer 3");
     expect(getByTestId("answer-item-1")).toHaveTextContent("Answer 4");
+
+    expect(getByTestId("question-title-2")).toHaveTextContent("Page 1");
+
     expect(getByTestId("answer-item-2")).toHaveTextContent("Answer 1");
     expect(getByTestId("answer-item-3")).toHaveTextContent("Answer 2");
   });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -11,6 +11,12 @@ import CalculatedSummaryPreview from "./CalculatedSummaryPreview";
 import { publishStatusSubscription } from "components/EditorLayout/Header";
 import QuestionnaireContext from "components/QuestionnaireContext";
 
+jest.mock("@apollo/react-hooks", () => ({
+  ...jest.requireActual("@apollo/react-hooks"),
+  useQuery: jest.fn(),
+  useMutation: jest.fn(() => [() => null]),
+}));
+
 const questionnaire = {
   id: "questionnaire-1",
   sections: [
@@ -25,11 +31,13 @@ const questionnaire = {
               pageType: "QuestionPage",
               title: "Page 1",
               answers: [
-                { id: "answer-1", label: "answer 1", questionPageId: "123" },
+                {
+                  id: "answer-1",
+                  label: "answer 1",
+                },
                 {
                   id: "answer-2",
                   label: "answer 2",
-                  questionPageId: "234",
                 },
               ],
             },
@@ -37,16 +45,14 @@ const questionnaire = {
               id: "6",
               pageType: "QuestionPage",
               title: "Page 2",
-              answer: [
+              answers: [
                 {
                   id: "answer-3",
                   label: "answer 3",
-                  questionPageId: "345",
                 },
                 {
                   id: "answer-4",
                   label: "answer 4",
-                  questionPageId: "456",
                 },
               ],
             },
@@ -56,6 +62,7 @@ const questionnaire = {
               pageType: "CalculatedSummaryPage",
               pageDescription: "Hello",
               alias: "Who am I?",
+
               summaryAnswers: [
                 { id: "answer-4", displayName: "Answer 4" },
                 { id: "answer-2", displayName: "Answer 2" },
@@ -218,8 +225,8 @@ describe("CalculatedSummaryPreview", () => {
       }
     );
 
-    expect(getByTestId("answer-item-0")).toHaveTextContent("Answer 4");
-    expect(getByTestId("answer-item-1")).toHaveTextContent("Answer 3");
+    expect(getByTestId("answer-item-0")).toHaveTextContent("Answer 3");
+    expect(getByTestId("answer-item-1")).toHaveTextContent("Answer 4");
     expect(getByTestId("answer-item-2")).toHaveTextContent("Answer 1");
     expect(getByTestId("answer-item-3")).toHaveTextContent("Answer 2");
   });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -37,7 +37,7 @@ const questionnaire = {
               id: "6",
               pageType: "QuestionPage",
               title: "Page 2",
-              answers: [
+              answer: [
                 {
                   id: "7",
                   label: "answer 3",
@@ -196,13 +196,17 @@ describe("CalculatedSummaryPreview", () => {
   // test the answer.display name is rendered in the page.
   // change the code where it test based on the data-test id(data-test id need to be unique for each answer) no functions need to be mock at all.
   // check the text of answer found from the data test id is equal to the answer.displayName
+  // check if the question page title appear in the correct order with the answer display name
 
   it("should order the summary answers correctly ", () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
-          <CalculatedSummaryPreview page={page} />
+          <CalculatedSummaryPreview
+            page={questionnaire.sections[0].folders[0].pages[2]}
+          />
         </MeContext.Provider>
+        ,
       </QuestionnaireContext.Provider>,
       {
         route: `/q/${questionnaireId}/page/9/preview`,
@@ -210,11 +214,19 @@ describe("CalculatedSummaryPreview", () => {
         mocks,
       }
     );
-    questionnaire.sections[0].folders[0].pages[2].summaryAnswers.forEach(
-      (answer) => {
-        const renderDisplayName = getByText(answer.displayName);
-        expect(renderDisplayName).toBeInTheDocument();
-      }
+
+    const answer = questionnaire.sections[0].folders[0].pages[2].summaryAnswers;
+    expect(getByTestId(`answer-item-${answer[0].id}`)).toHaveTextContent(
+      "Answer 8"
+    );
+    expect(getByTestId(`answer-item-${answer[1].id}`)).toHaveTextContent(
+      "Answer 5"
+    );
+    expect(getByTestId(`answer-item-${answer[2].id}`)).toHaveTextContent(
+      "Answer 7"
+    );
+    expect(getByTestId(`answer-item-${answer[3].id}`)).toHaveTextContent(
+      "Answer 4"
     );
   });
 });

--- a/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
+++ b/eq-author/src/App/page/Preview/CalculatedSummaryPreview.test.js
@@ -225,7 +225,7 @@ describe("CalculatedSummaryPreview", () => {
     expect(wrapper.find(byTestAttr("no-answers-selected"))).toBeTruthy();
   });
 
-  it("should sort the summary answers based on the first selection and ensure that the display names and question titles match this order ", () => {
+  it("should sort the summary answers based on the first selection and ensure that the display names and question titles match this order", () => {
     const { getByTestId } = render(
       <QuestionnaireContext.Provider value={{ questionnaire }}>
         <MeContext.Provider value={{ me }}>
@@ -246,7 +246,7 @@ describe("CalculatedSummaryPreview", () => {
     expect(getByTestId("answer-item-0")).toHaveTextContent("Answer 3");
     expect(getByTestId("answer-item-1")).toHaveTextContent("Answer 4");
 
-    expect(getByTestId("question-title-2")).toHaveTextContent("Page 1");
+    expect(getByTestId("question-title-1")).toHaveTextContent("Page 1");
 
     expect(getByTestId("answer-item-2")).toHaveTextContent("Answer 1");
     expect(getByTestId("answer-item-3")).toHaveTextContent("Answer 2");


### PR DESCRIPTION
### What is the context of this PR?
To match the calculated summary preview page to what is shown in EQ for the users. 

Ticket: https://jira.ons.gov.uk/browse/EAR-2291

### How to review


1. - [ ] Create a two questions page question page 1 and question page 2. Both of the question pages should have 2 currency answers
2.  - [ ] Create a calculated summary Page. and select one answer from question page 1 and another answer from question page 2. 
3.  - [ ] Check in the preview page that the question page titles are not shown, and the border separates both of the answers
4.  - [ ] Repeat step 2 but this time select 2 answers from question page 1 and question page 2.
5.  - [ ]  Check that the answers are grouped together based on the question page title they belong to and has a border that separates each group. Also ensure that it groups the answers based on the answer that is selected first. e.g if an answer is selected from question page 1, it should group all answers from question page 1 first.  this should matches the order that is shown in the EQ 
6.  - [ ] Check in the preview page that the button ‘Yes, I confirm this is correct’ matches the one in EQ 

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
7. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
8. - [ ] Click the **Merge** button on this pull request
9. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
10. - [ ] Move the Jira ticket for this task into the next stage of the process
