### PR TITLE
EAR 2482 supplementary data text change

### DIFF
--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
@@ -183,11 +183,13 @@ const SupplementaryDataPage = () => {
   };
 
   if (surveyLoading) {
-    return <Loading height="100%">Dataset page is loading...</Loading>;
+    return (
+      <Loading height="100%"> Supplementary data page is loading...</Loading>
+    );
   }
 
   if (surveyError) {
-    return <Error>Dataset page error</Error>;
+    return <Error>Supplementary data page error</Error>;
   }
 
   return (

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
@@ -193,9 +193,9 @@ const SupplementaryDataPage = () => {
   return (
     <>
       <Modal
-        title="Unlink dataset"
+        title="Unlink dataset schema"
         positiveButtonText="Unlink"
-        warningMessage="The dataset will be unlinked from the questionnaire. You will not be able to pipe data fields from this dataset. Any piped answers or example values will be deleted."
+        warningMessage="The dataset schema will be unlinked from the questionnaire. You will not be able to pipe data fields from this dataset schema. Any piped answers or example values will be deleted."
         isOpen={showUnlinkModal}
         onConfirm={() => unlinkDataset()}
         onClose={() => setShowUnlinkModal(false)}

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
@@ -267,7 +267,8 @@ const SupplementaryDataPage = () => {
                             <Grid>
                               <Column gutters={false} cols={8}>
                                 <Common.TabTitle>
-                                  Dataset for survey ID {tableData.surveyId}
+                                  Dataset schema for survey ID{" "}
+                                  {tableData.surveyId}
                                 </Common.TabTitle>
                               </Column>
                               <Column gutters={false} cols={4}>
@@ -276,7 +277,7 @@ const SupplementaryDataPage = () => {
                                     data-test="btn-unlink-dataset"
                                     onClick={handleUnlinkClick}
                                   >
-                                    Unlink dataset
+                                    Unlink dataset schema
                                   </UnlinkButton>
                                 </UnlinkButtonWrapper>
                               </Column>
@@ -311,7 +312,7 @@ const SupplementaryDataPage = () => {
                               </StyledTitle>
                               <Common.TabContent>
                                 A respondent&apos;s answers to previous
-                                questions are stored in supplementary datasets
+                                questions are stored in supplementary dataset
                                 schemas as data fields. Data fields can be piped
                                 into question and section pages using the
                                 toolbar.

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.js
@@ -312,8 +312,9 @@ const SupplementaryDataPage = () => {
                               <Common.TabContent>
                                 A respondent&apos;s answers to previous
                                 questions are stored in supplementary datasets
-                                as data fields. Data fields can be piped into
-                                question and section pages using the toolbar.
+                                schemas as data fields. Data fields can be piped
+                                into question and section pages using the
+                                toolbar.
                               </Common.TabContent>
                               <Common.TabContent>
                                 Data fields are defined as either:

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
@@ -246,7 +246,7 @@ describe("Supplementary dataset page", () => {
   });
 
   describe("Unlink dataset", () => {
-    it("should display the Unlink dataset modal", async () => {
+    it("should display the Unlink dataset schema modal", async () => {
       useQuery.mockImplementation(() => ({
         loading: false,
         error: false,
@@ -315,7 +315,7 @@ describe("Supplementary dataset page", () => {
       expect(queryByTestId("modal")).not.toBeInTheDocument();
     });
 
-    it("should close the Unlink dataset modal", async () => {
+    it("should close the Unlink dataset schema modal", async () => {
       useQuery.mockImplementationOnce(() => ({
         loading: false,
         error: false,

--- a/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
+++ b/eq-author/src/App/dataSettings/SupplementaryDataPage/index.test.js
@@ -236,7 +236,7 @@ describe("Supplementary dataset page", () => {
         user,
         mocks
       );
-      expect(getByText("Dataset for survey ID 068")).toBeTruthy();
+      expect(getByText("Dataset schema for survey ID 068")).toBeTruthy();
       expect(getByText("ID:")).toBeTruthy();
       expect(getByText("Version:")).toBeTruthy();
       expect(getByText("Date created:")).toBeTruthy();

--- a/eq-author/src/components/buttons/UnlinkButton/index.js
+++ b/eq-author/src/components/buttons/UnlinkButton/index.js
@@ -34,7 +34,11 @@ const StyledUnlinkButton = styled(Button).attrs({
 `;
 
 const UnlinkTooltip = ({ children }) => (
-  <Tooltip content="Unlink dataset" place="top" offset={{ top: 0, bottom: 10 }}>
+  <Tooltip
+    content="Unlink dataset schema"
+    place="top"
+    offset={{ top: 0, bottom: 10 }}
+  >
     {children}
   </Tooltip>
 );

--- a/eq-author/src/components/buttons/UnlinkButton/index.js
+++ b/eq-author/src/components/buttons/UnlinkButton/index.js
@@ -41,7 +41,7 @@ const UnlinkTooltip = ({ children }) => (
 
 const UnlinkButton = ({
   hideText,
-  iconText = "Unlink dataset",
+  iconText = "Unlink dataset schema",
   ...otherProps
 }) => {
   const Wrapper = hideText ? UnlinkTooltip : React.Fragment;
@@ -68,7 +68,7 @@ UnlinkButton.propTypes = {
 
 UnlinkButton.defaultProps = {
   hideText: false,
-  iconText: "Unlink dataset",
+  iconText: "Unlink dataset schema",
   disabledIcon: false,
 };
 

--- a/eq-author/src/components/buttons/UnlinkButton/index.js
+++ b/eq-author/src/components/buttons/UnlinkButton/index.js
@@ -18,7 +18,7 @@ const StyledUnlinkButton = styled(Button).attrs({
     fill: ${colors.blue};
   }
 
-  width: 11em;
+  width: 14em;
   height: 2.5em;
   align-items: center;
   margin: 0 0 0 auto;


### PR DESCRIPTION
### What is the context of this PR?
The term "dataset" on the supplementary page needs to be updated to "dataset schema."
ticket: https://jira.ons.gov.uk/browse/EAR-2482

### How to review
On the supplementary data page, when linking to a dataset schema, ensure the following:
1) The unlink button is labeled as "unlink dataset schema."
2) After clicking the unlink button, verify that the modal refers to "dataset schema" instead of "dataset."


### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
