### PR TITLE
EAR 2470 questionnaire picker

### DIFF
--- a/eq-author-api/db/datastore/datastore-mongodb.js
+++ b/eq-author-api/db/datastore/datastore-mongodb.js
@@ -299,6 +299,7 @@ const getMatchQuery = async (input = {}, ctx) => {
       createdOnOrBefore,
       access,
       myQuestionnaires,
+      questionnairesToExclude,
     } = input;
 
     const { id: userId } = ctx.user;
@@ -393,6 +394,12 @@ const getMatchQuery = async (input = {}, ctx) => {
       matchQuery.$and.push({
         $or: [{ editors: { $in: [userId] } }, { createdBy: userId }],
       });
+    }
+
+    // Excludes questionnaires with IDs in `questionnairesToExclude` array
+    if (questionnairesToExclude?.length) {
+      matchQuery.$and = matchQuery.$and || [];
+      matchQuery.$and.push({ id: { $nin: questionnairesToExclude } });
     }
 
     return matchQuery;

--- a/eq-author-api/db/datastore/datastore-mongodb.test.js
+++ b/eq-author-api/db/datastore/datastore-mongodb.test.js
@@ -414,64 +414,85 @@ describe("MongoDB Datastore", () => {
         });
 
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 1",
-            ownerId: "user-1",
-            shortTitle: "Alias 1",
-            createdAt: new Date(2021, 2, 5, 5, 0, 0, 0),
-          }),
+          {
+            id: "test-questionnaire-1",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 1",
+              ownerId: "user-1",
+              shortTitle: "Alias 1",
+              createdAt: new Date(2021, 2, 5, 5, 0, 0, 0),
+            }),
+          },
           ctx
         );
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 2",
-            ownerId: "user-1",
-            createdAt: new Date(2021, 2, 10, 5, 0, 0, 0),
-          }),
+          {
+            id: "test-questionnaire-2",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 2",
+              ownerId: "user-1",
+              createdAt: new Date(2021, 2, 10, 5, 0, 0, 0),
+            }),
+          },
           ctx
         );
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 3",
-            ownerId: "user-2",
-            editors: ["user-1"],
-            createdAt: new Date(2021, 2, 15, 5, 0, 0, 0),
-          }),
+          {
+            id: "test-questionnaire-3",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 3",
+              ownerId: "user-2",
+              editors: ["user-1"],
+              createdAt: new Date(2021, 2, 15, 5, 0, 0, 0),
+            }),
+          },
           ctx
         );
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 4",
-            ownerId: "user-2",
-            createdAt: new Date(2021, 2, 20, 5, 0, 0, 0),
-          }),
+          {
+            id: "test-questionnaire-4",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 4",
+              ownerId: "user-2",
+              createdAt: new Date(2021, 2, 20, 5, 0, 0, 0),
+            }),
+          },
           ctx
         );
         // ** "Test questionnaire 5" is not included in several test assertions as it is not public and `ctx.user` is not owner/editor
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 5",
-            ownerId: "user-2",
-            createdAt: new Date(2021, 2, 25, 5, 0, 0, 0),
-            isPublic: false,
-          }),
+          {
+            id: "test-questionnaire-5",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 5",
+              ownerId: "user-2",
+              createdAt: new Date(2021, 2, 25, 5, 0, 0, 0),
+              isPublic: false,
+            }),
+          },
           ctx
         );
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 6",
-            ownerId: "user-1",
-            createdAt: new Date(2021, 2, 30, 5, 0, 0, 0),
-            isPublic: false,
-          }),
+          {
+            id: "test-questionnaire-6",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 6",
+              ownerId: "user-1",
+              createdAt: new Date(2021, 2, 30, 5, 0, 0, 0),
+              isPublic: false,
+            }),
+          },
           ctx
         );
         await mongoDB.createQuestionnaire(
-          mockQuestionnaire({
-            title: "Test questionnaire 7",
-            ownerId: "user-4",
-            createdAt: new Date(2021, 4, 10, 5, 0, 0, 0),
-          }),
+          {
+            id: "test-questionnaire-7",
+            ...mockQuestionnaire({
+              title: "Test questionnaire 7",
+              ownerId: "user-4",
+              createdAt: new Date(2021, 4, 10, 5, 0, 0, 0),
+            }),
+          },
           ctx
         );
       });
@@ -726,6 +747,41 @@ describe("MongoDB Datastore", () => {
         expect(listOfQuestionnaires[1].title).toEqual("Test questionnaire 3");
         expect(listOfQuestionnaires[2].title).toEqual("Test questionnaire 2");
         expect(listOfQuestionnaires[3].title).toEqual("Test questionnaire 1");
+      });
+
+      it("should not return questionnaires in `questionnairesToExclude` array", async () => {
+        const listOfQuestionnaires = await mongoDB.listFilteredQuestionnaires(
+          {
+            searchByTitleOrShortCode: "",
+            owner: "",
+            access: "All",
+            resultsPerPage: 10,
+            questionnairesToExclude: [
+              "test-questionnaire-1",
+              "test-questionnaire-2",
+            ],
+          },
+          ctx
+        );
+
+        expect(listOfQuestionnaires.length).toBe(7);
+        /* 
+          Questionnaires with titles "Default questionnaire title" are created in previous tests.
+          These appear first when sorted by newest to oldest as their `createdAt` dates are most recent.
+        */
+        expect(listOfQuestionnaires[0].title).toEqual(
+          "Default questionnaire title"
+        );
+        expect(listOfQuestionnaires[1].title).toEqual(
+          "Default questionnaire title"
+        );
+        expect(listOfQuestionnaires[2].title).toEqual(
+          "Default questionnaire title"
+        );
+        expect(listOfQuestionnaires[3].title).toEqual("Test questionnaire 7");
+        expect(listOfQuestionnaires[4].title).toEqual("Test questionnaire 6");
+        expect(listOfQuestionnaires[5].title).toEqual("Test questionnaire 4");
+        expect(listOfQuestionnaires[6].title).toEqual("Test questionnaire 3");
       });
 
       it("should return questionnaires on previous page when `firstQuestionnaireIdOnPage` is provided without `lastQuestionnaireIdOnPage`", async () => {

--- a/eq-author-api/db/datastore/datastore-mongodb.test.js
+++ b/eq-author-api/db/datastore/datastore-mongodb.test.js
@@ -1057,6 +1057,24 @@ describe("MongoDB Datastore", () => {
 
         expect(totalFilteredQuestionnaires).toBe(2);
       });
+
+      it("should get the total number of questionnaires when `questionnairesToExclude` filter is applied", async () => {
+        const totalFilteredQuestionnaires =
+          await mongoDB.getTotalFilteredQuestionnaires(
+            {
+              searchByTitleOrShortCode: "",
+              owner: "",
+              access: "All",
+              questionnairesToExclude: [
+                "test-questionnaire-3",
+                "test-questionnaire-4",
+              ],
+            },
+            ctx
+          );
+
+        expect(totalFilteredQuestionnaires).toBe(7);
+      });
     });
 
     describe("Getting total page count", () => {

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -956,6 +956,7 @@ input FilteredQuestionnairesInput {
   access: Access!
   myQuestionnaires: Boolean
   sortBy: String
+  questionnairesToExclude: [ID!]
 }
 
 input TotalFilteredQuestionnairesInput {
@@ -965,6 +966,7 @@ input TotalFilteredQuestionnairesInput {
     createdOnOrBefore: DateTime
     access: Access!
     myQuestionnaires: Boolean
+    questionnairesToExclude: [ID!]
 }
 
 input TotalPagesInput {
@@ -975,6 +977,7 @@ input TotalPagesInput {
   createdOnOrBefore: DateTime
   access: Access!
   myQuestionnaires: Boolean
+  questionnairesToExclude: [ID!]
 }
 
 input QueryInput {


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Updates Author's API to enable questionnaires to be excluded from the questionnaires search page - this enables the currently opened questionnaire to be excluded when selecting a questionnaire to import from, and prevents importing content from the currently opened questionnaire into the same questionnaire.

### How to review
**Check:**
- [ ] The "All questionnaires" and "My questionnaires" pages do not exclude any questionnaires by default
- [ ] The import process' questionnaire picker page excludes the currently opened questionnaire
- [ ] The total number of questionnaires and total page count on the import process' questionnaire picker page exclude the currently opened questionnaire

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
