### PR TITLE
EAR-2494 Survey Id returning two errors when supplementary data schema is linked

### DIFF
--- a/eq-author-api/src/validation/customKeywords/validateSurveyId.js
+++ b/eq-author-api/src/validation/customKeywords/validateSurveyId.js
@@ -1,6 +1,8 @@
 const createValidationError = require("../createValidationError");
 const {
   ERR_SURVEY_ID_MISMATCH,
+  ERR_INVALID,
+  ERR_VALID_REQUIRED,
 } = require("../../../constants/validationErrorCodes");
 
 module.exports = (ajv) =>
@@ -35,8 +37,40 @@ module.exports = (ajv) =>
           ),
         ];
         return false;
-      }
+      } else {
+        if (
+          typeof questionnaire.surveyId === "string" &&
+          questionnaire.surveyId.length > 0 &&
+          !questionnaire.surveyId.match(/^\d{3}$/)
+        ) {
+          isValid.errors = [
+            createValidationError(
+              instancePath,
+              fieldName,
+              ERR_INVALID,
+              questionnaire,
+              ERR_INVALID
+            ),
+          ];
+          return false;
+        } else if (
+          typeof questionnaire.surveyId === "string" &&
+          questionnaire.surveyId.length === 0
+        ) {
+          isValid.errors = [
+            createValidationError(
+              instancePath,
+              fieldName,
+              ERR_VALID_REQUIRED,
+              questionnaire,
+              ERR_VALID_REQUIRED
+            ),
+          ];
 
-      return true;
+          return false;
+        }
+
+        return true;
+      }
     },
   });

--- a/eq-author-api/src/validation/customKeywords/validateSurveyId.js
+++ b/eq-author-api/src/validation/customKeywords/validateSurveyId.js
@@ -35,41 +35,39 @@ module.exports = (ajv) =>
           ),
         ];
         return false;
+      } else if (
+        typeof questionnaire.surveyId === "string" &&
+        questionnaire.surveyId.length > 0 &&
+        !questionnaire.surveyId.match(/^\d{3}$/)
+      ) {
+        isValid.errors = [
+          createValidationError(
+            instancePath,
+            fieldName,
+            ERR_INVALID,
+            questionnaire,
+            ERR_INVALID
+          ),
+        ];
+        return false;
+        // If supplementaryData exists and contains a surveyId, and supplementaryData's surveyId doesn't match the questionnaire's surveyId, throw a validation error
+      } else if (
+        supplementaryData &&
+        supplementaryData.surveyId &&
+        questionnaireSurveyId !== supplementaryData.surveyId
+      ) {
+        isValid.errors = [
+          createValidationError(
+            instancePath,
+            fieldName,
+            ERR_SURVEY_ID_MISMATCH,
+            questionnaire,
+            ERR_SURVEY_ID_MISMATCH
+          ),
+        ];
+
+        return false;
       } else {
-        if (
-          typeof questionnaire.surveyId === "string" &&
-          questionnaire.surveyId.length > 0 &&
-          !questionnaire.surveyId.match(/^\d{3}$/)
-        ) {
-          isValid.errors = [
-            createValidationError(
-              instancePath,
-              fieldName,
-              ERR_INVALID,
-              questionnaire,
-              ERR_INVALID
-            ),
-          ];
-          return false;
-          // If supplementaryData exists and contains a surveyId, and supplementaryData's surveyId doesn't match the questionnaire's surveyId, throw a validation error
-        } else if (
-          supplementaryData &&
-          supplementaryData.surveyId &&
-          questionnaireSurveyId !== supplementaryData.surveyId
-        ) {
-          isValid.errors = [
-            createValidationError(
-              instancePath,
-              fieldName,
-              ERR_SURVEY_ID_MISMATCH,
-              questionnaire,
-              ERR_SURVEY_ID_MISMATCH
-            ),
-          ];
-
-          return false;
-        }
-
         return true;
       }
     },

--- a/eq-author-api/src/validation/customKeywords/validateSurveyId.js
+++ b/eq-author-api/src/validation/customKeywords/validateSurveyId.js
@@ -21,19 +21,17 @@ module.exports = (ajv) =>
       // Get the supplementary data from the questionnaire object
       const supplementaryData = questionnaire.supplementaryData;
 
-      // If supplementaryData exists and contains a surveyId, and supplementaryData's surveyId doesn't match the questionnaire's surveyId, throw a validation error
       if (
-        supplementaryData &&
-        supplementaryData.surveyId &&
-        questionnaireSurveyId !== supplementaryData.surveyId
+        typeof questionnaire.surveyId === "string" &&
+        questionnaire.surveyId.length === 0
       ) {
         isValid.errors = [
           createValidationError(
             instancePath,
             fieldName,
-            ERR_SURVEY_ID_MISMATCH,
+            ERR_VALID_REQUIRED,
             questionnaire,
-            ERR_SURVEY_ID_MISMATCH
+            ERR_VALID_REQUIRED
           ),
         ];
         return false;
@@ -53,17 +51,19 @@ module.exports = (ajv) =>
             ),
           ];
           return false;
+          // If supplementaryData exists and contains a surveyId, and supplementaryData's surveyId doesn't match the questionnaire's surveyId, throw a validation error
         } else if (
-          typeof questionnaire.surveyId === "string" &&
-          questionnaire.surveyId.length === 0
+          supplementaryData &&
+          supplementaryData.surveyId &&
+          questionnaireSurveyId !== supplementaryData.surveyId
         ) {
           isValid.errors = [
             createValidationError(
               instancePath,
               fieldName,
-              ERR_VALID_REQUIRED,
+              ERR_SURVEY_ID_MISMATCH,
               questionnaire,
-              ERR_VALID_REQUIRED
+              ERR_SURVEY_ID_MISMATCH
             ),
           ];
 

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -38,6 +38,7 @@ const {
   CALCSUM_MOVED,
   ERR_SEC_CONDITION_NOT_SELECTED,
   ERR_COUNT_OF_GREATER_THAN_AVAILABLE_OPTIONS,
+  ERR_SURVEY_ID_MISMATCH,
 } = require("../../constants/validationErrorCodes");
 
 const validation = require(".");
@@ -151,6 +152,10 @@ describe("schema validation", () => {
           ],
         },
       ],
+      supplementaryData: {
+        id: "supplementary_dataset_schema",
+        surveyId: "123",
+      },
       metadata: [
         {
           id: "87c64b20-9662-408b-b674-e2403e90dad3",
@@ -214,6 +219,11 @@ describe("schema validation", () => {
       questionnaire.type = "Social";
       const errors = validation(questionnaire);
       expect(errors[0].errorCode).toBe(ERR_VALID_REQUIRED);
+    });
+    it("should return an error if survey ID does not match with supplementary dataset schema’s survey ID", () => {
+      questionnaire.surveyId = "111";
+      const errors = validation(questionnaire);
+      expect(errors[0].errorCode).toBe(ERR_SURVEY_ID_MISMATCH);
     });
   });
 

--- a/eq-author-api/src/validation/index.test.js
+++ b/eq-author-api/src/validation/index.test.js
@@ -198,7 +198,7 @@ describe("schema validation", () => {
 
   describe("Themes validation", () => {
     it("should return an error if survey ID missing", () => {
-      questionnaire.surveyId = null;
+      questionnaire.surveyId = "";
       const errors = validation(questionnaire);
       expect(errors[0].errorCode).toBe(ERR_VALID_REQUIRED);
     });
@@ -210,7 +210,7 @@ describe("schema validation", () => {
     });
 
     it("should return an error if survey ID is missing on a social survey", () => {
-      questionnaire.surveyId = null;
+      questionnaire.surveyId = "";
       questionnaire.type = "Social";
       const errors = validation(questionnaire);
       expect(errors[0].errorCode).toBe(ERR_VALID_REQUIRED);

--- a/eq-author-api/src/validation/schemas/questionnaire.json
+++ b/eq-author-api/src/validation/schemas/questionnaire.json
@@ -26,25 +26,7 @@
       "$ref": "submission.json"
     },
     "surveyId": {
-      "allOf": [
-        {
-          "if": {
-            "type": "string",
-            "minLength": 1
-          },
-          "then": {
-            "type": "string",
-            "pattern": "^\\d{3}$",
-            "errorMessage": "ERR_INVALID"
-          },
-          "else": {
-            "$ref": "definitions.json#/definitions/populatedString"
-          }
-        },
-        {
-          "validateSurveyId": true
-        }
-      ]
+      "validateSurveyId": true
     },
     "formType": {
       "if": {


### PR DESCRIPTION
### What is the context of this PR?

In both Author V1 and Author V2, when a questionnaire is linked to a supplementary data schema, an empty or incorrectly formatted survey ID results in duplicated error messages. This issue is especially prominent in Author V2.

Ticket:  https://jira.ons.gov.uk/browse/EAR-2494

Credit goes to @farres1 and @Paul-Joel  for making a significant contribution to resolving this bug

### How to review
1) In Author v1, create a new questionnaire or select an existing one, and link it to a supplementary data schema.

2) In Author v2, check in the settings that if the survey ID field is empty, incorrectly formatted, or does not match the survey ID in the supplementary data schema, an error message displays: "The survey ID does not match the linked supplementary data schema."

3) In the questionnaire, unlink the supplementary data schema, then go to settings and verify that when the survey ID field is empty or incorrectly formatted, the following error messages appear: "Enter a survey ID" or "Enter a survey ID in the correct format."
### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
