### PR TITLE
EAR 2529 remove leading and trailing spaces in Qcodes and value

### DIFF
--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -226,7 +226,7 @@ const Row = memo((props) => {
               }${listAnswerType === ANOTHER ? "-another" : ""}-test-input`}
               value={qCode || ""} // Ensure the input always has a value (empty string if qCode is null or undefined)
               onChange={(e) => setQcode(e.value)}
-              onBlur={() => handleBlur(qCode)}
+              onBlur={() => handleBlur(qCode.trim())}
               hasError={Boolean(errorMessage)}
               aria-label="QCode input field"
             />
@@ -249,7 +249,7 @@ const Row = memo((props) => {
             data-test={`${id}${secondary ? "-secondary" : ""}-test-input`}
             value={qCode}
             onChange={(e) => setQcode(e.value)}
-            onBlur={() => handleBlur(qCode)}
+            onBlur={() => handleBlur(qCode.trim())}
             hasError={Boolean(errorMessage)}
             aria-label="QCode input field"
           />
@@ -272,7 +272,7 @@ const Row = memo((props) => {
             data-test={`${id}-value-test-input`}
             value={value}
             onChange={(e) => setValue(e.value)}
-            onBlur={() => handleBlurOptionValue(value)}
+            onBlur={() => handleBlurOptionValue(value.trim())}
             hasError={Boolean(valueErrorMessage)}
             aria-label="Option Value input field"
           />

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -193,7 +193,7 @@ const Row = memo((props) => {
 
   const handleBlurOptionValue = useCallback(
     (value) => {
-      const trimmedValue = value.trim().replace(/\s+/g, " ");
+      const trimmedValue = value?.trim().replace(/\s+/g, " ");
       setValue(trimmedValue);
       updateValue(mutationVariables({ id, value: trimmedValue }));
     },

--- a/eq-author/src/App/qcodes/QCodesTable/index.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.js
@@ -155,19 +155,25 @@ const Row = memo((props) => {
 
   const handleBlur = useCallback(
     (qCode) => {
+      const trimmedQcode = qCode.trim().replace(/\s+/g, " ");
+      setQcode(trimmedQcode);
       if (qCode !== initialQcode) {
         if (option) {
-          updateOption(mutationVariables({ id, qCode }));
+          updateOption(mutationVariables({ id, qCode: trimmedQcode }));
         } else if (listAnswerType === DRIVING) {
           // id represents the list collector page ID
-          updateListCollector(mutationVariables({ id, drivingQCode: qCode }));
+          updateListCollector(
+            mutationVariables({ id, drivingQCode: trimmedQcode })
+          );
         } else if (listAnswerType === ANOTHER) {
-          updateListCollector(mutationVariables({ id, anotherQCode: qCode }));
+          updateListCollector(
+            mutationVariables({ id, anotherQCode: trimmedQcode })
+          );
         } else {
           updateAnswer(
             mutationVariables({
               id,
-              [secondary ? "secondaryQCode" : "qCode"]: qCode,
+              [secondary ? "secondaryQCode" : "qCode"]: trimmedQcode,
             })
           );
         }
@@ -187,7 +193,9 @@ const Row = memo((props) => {
 
   const handleBlurOptionValue = useCallback(
     (value) => {
-      updateValue(mutationVariables({ id, value }));
+      const trimmedValue = value.trim().replace(/\s+/g, " ");
+      setValue(trimmedValue);
+      updateValue(mutationVariables({ id, value: trimmedValue }));
     },
     [id, updateValue]
   );
@@ -226,7 +234,7 @@ const Row = memo((props) => {
               }${listAnswerType === ANOTHER ? "-another" : ""}-test-input`}
               value={qCode || ""} // Ensure the input always has a value (empty string if qCode is null or undefined)
               onChange={(e) => setQcode(e.value)}
-              onBlur={() => handleBlur(qCode.trim())}
+              onBlur={() => handleBlur(qCode)}
               hasError={Boolean(errorMessage)}
               aria-label="QCode input field"
             />
@@ -249,7 +257,7 @@ const Row = memo((props) => {
             data-test={`${id}${secondary ? "-secondary" : ""}-test-input`}
             value={qCode}
             onChange={(e) => setQcode(e.value)}
-            onBlur={() => handleBlur(qCode.trim())}
+            onBlur={() => handleBlur(qCode)}
             hasError={Boolean(errorMessage)}
             aria-label="QCode input field"
           />
@@ -272,7 +280,7 @@ const Row = memo((props) => {
             data-test={`${id}-value-test-input`}
             value={value}
             onChange={(e) => setValue(e.value)}
-            onBlur={() => handleBlurOptionValue(value.trim())}
+            onBlur={() => handleBlurOptionValue(value)}
             hasError={Boolean(valueErrorMessage)}
             aria-label="Option Value input field"
           />

--- a/eq-author/src/App/qcodes/QCodesTable/index.test.js
+++ b/eq-author/src/App/qcodes/QCodesTable/index.test.js
@@ -724,14 +724,33 @@ describe("Qcode Table", () => {
 
       it("should save qCode for checkbox answer", () => {
         fireEvent.change(utils.getByTestId("checkbox-answer-id-test-input"), {
-          target: { value: "123" },
+          target: { value: " test  qcode " },
         });
 
         fireEvent.blur(utils.getByTestId("checkbox-answer-id-test-input"));
 
         expect(mock).toHaveBeenCalledWith({
           variables: {
-            input: { id: "checkbox-answer-id", qCode: "123" },
+            input: { id: "checkbox-answer-id", qCode: "test qcode" },
+          },
+        });
+      });
+
+      it("should save option value for checkbox answer", () => {
+        fireEvent.change(
+          utils.getByTestId("checkbox-option-1-id-value-test-input"),
+          {
+            target: { value: " test  option value " },
+          }
+        );
+
+        fireEvent.blur(
+          utils.getByTestId("checkbox-option-1-id-value-test-input")
+        );
+
+        expect(mock).toHaveBeenCalledWith({
+          variables: {
+            input: { id: "checkbox-option-1-id", value: "test option value" },
           },
         });
       });


### PR DESCRIPTION
### What is the context of this PR?

In the q-codes/option value page, there’s a bug where the validation error message doesn’t appear if the same qcode or value is entered with leading or trailing spaces.

ticket:  https://jira.ons.gov.uk/browse/EAR-2529

### How to review

1) In the q-Codes/Values page in Author, add an option value for answer value of a question
2) Then, add the same value with a trailing/leading space to another answer 
3) Verify that a validation error message appears to inform users that qcodes and value entries must be unique.
4) Repeat steps 1 to 3 for qCodes.
5) Verify that validation error messages are displayed in both data version 1 and data version 3.

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
