### PR TITLE
Fix skip logic page when content is after a list collector folder

### DIFF
--- a/eq-author/src/utils/getContentBeforeEntity.js
+++ b/eq-author/src/utils/getContentBeforeEntity.js
@@ -43,9 +43,9 @@ const getContentBeforeEntity = (
           return sections;
         }
 
-        let answers =
-          !isListCollectorPageType(page.pageType) &&
-          (page?.answers?.flatMap(preprocessAnswers) || []);
+        let answers = !isListCollectorPageType(page.pageType)
+          ? page?.answers?.flatMap(preprocessAnswers) || []
+          : [];
 
         /*
           When expression group's condition is "And":


### PR DESCRIPTION
> ### BEFORE MAKING YOUR PR
>
> Please ensure:
>
> - There are no linting errors, all tests must pass
> - PR is named after JIRA ticket number e.g. EAR-###
> - **Accesibility** checks are completed:
>   - Elements have discernible and consistent focus states
>   - Elements can be navigated to and used by just a keyboard
>   - Elements and text can be read out by a screen reader, and the descriptions are understandable
> - Your feature / bug fix works across **GCP** and **AWS** (where appropriate)
>   - Are modifications to eq-publisher-v3 required?
>   - Are modifications to the Firestore data source required?

---

### What is the context of this PR?

Fixes skip logic page not loading for content that appears after a list collector folder

### How to review

1 - Create a questionnaire with two question pages
2 - Apply skip logic to the second page, based on the answer from the first page
3 - Add a list collector folder before the second page
4 - Open the skip logic page for the question page described in **Step 2**
5 - Check that the skip logic page loads correctly

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
