### PR TITLE
Migration to remove confirmation qcodes

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -55,6 +55,7 @@ const migrations = [
   require("./updateHealthThemeToPandemicMonitoring"),
   require("./addAllowableDataVersions"),
   require("./convertEmTagsToStrongTags"),
+  require("./removeConfirmationPageQCodes"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/removeConfirmationPageQCodes.js
+++ b/eq-author-api/migrations/removeConfirmationPageQCodes.js
@@ -1,0 +1,13 @@
+module.exports = (questionnaire) => {
+  questionnaire.sections.forEach((section) => {
+    section.folders.forEach((folder) => {
+      folder.pages.forEach((page) => {
+        if (page.confirmation && page.confirmation.qCode) {
+          delete page.confirmation.qCode;
+        }
+      });
+    });
+  });
+
+  return questionnaire;
+};

--- a/eq-author-api/migrations/removeConfirmationPageQCodes.test.js
+++ b/eq-author-api/migrations/removeConfirmationPageQCodes.test.js
@@ -1,0 +1,133 @@
+const removeConfirmationPageQCodes = require("./removeConfirmationPageQCodes");
+
+describe("removeConfirmationPageQCodes", () => {
+  it("should remove qCode from confirmation pages", () => {
+    const questionnaire = {
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              pages: [
+                {
+                  id: "page-1",
+                  confirmation: {
+                    id: "confirmation-page-1",
+                    qCode: "123",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = removeConfirmationPageQCodes(questionnaire);
+
+    expect(
+      result.sections[0].folders[0].pages[0].confirmation.qCode
+    ).toBeUndefined();
+  });
+
+  it("should not remove qCode from answers", () => {
+    const questionnaire = {
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              pages: [
+                {
+                  id: "page-1",
+                  answers: [
+                    {
+                      id: "answer-1",
+                      qCode: "123",
+                    },
+                  ],
+                  confirmation: {
+                    id: "confirmation-page-1",
+                    qCode: "123",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = removeConfirmationPageQCodes(questionnaire);
+
+    expect(
+      result.sections[0].folders[0].pages[0].confirmation.qCode
+    ).toBeUndefined();
+    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe("123");
+  });
+
+  it("should not amend questionnaire data if the questionnaire does not contain any confirmation pages", () => {
+    const questionnaire = {
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              pages: [
+                {
+                  id: "page-1",
+                  answers: [
+                    {
+                      id: "answer-1",
+                      qCode: "123",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = removeConfirmationPageQCodes(questionnaire);
+
+    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe("123");
+    expect(result).toEqual(questionnaire);
+  });
+
+  it("should not amend questionnaire data if the questionnaire does not contain any qCodes", () => {
+    const questionnaire = {
+      sections: [
+        {
+          id: "section-1",
+          folders: [
+            {
+              id: "folder-1",
+              pages: [
+                {
+                  id: "page-1",
+                  answers: [
+                    {
+                      id: "answer-1",
+                    },
+                  ],
+                  confirmation: {
+                    id: "confirmation-page-1",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = removeConfirmationPageQCodes(questionnaire);
+
+    expect(result).toEqual(questionnaire);
+  });
+});

--- a/eq-author-api/migrations/removeConfirmationPageQCodes.test.js
+++ b/eq-author-api/migrations/removeConfirmationPageQCodes.test.js
@@ -14,7 +14,7 @@ describe("removeConfirmationPageQCodes", () => {
                   id: "page-1",
                   confirmation: {
                     id: "confirmation-page-1",
-                    qCode: "123",
+                    qCode: "confirmation-page-1-qcode",
                   },
                 },
               ],
@@ -45,12 +45,12 @@ describe("removeConfirmationPageQCodes", () => {
                   answers: [
                     {
                       id: "answer-1",
-                      qCode: "123",
+                      qCode: "answer-1-qCode",
                     },
                   ],
                   confirmation: {
                     id: "confirmation-page-1",
-                    qCode: "123",
+                    qCode: "confirmation-page-1-qCode",
                   },
                 },
               ],
@@ -65,7 +65,9 @@ describe("removeConfirmationPageQCodes", () => {
     expect(
       result.sections[0].folders[0].pages[0].confirmation.qCode
     ).toBeUndefined();
-    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe("123");
+    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe(
+      "answer-1-qCode"
+    );
   });
 
   it("should not amend questionnaire data if the questionnaire does not contain any confirmation pages", () => {
@@ -82,7 +84,7 @@ describe("removeConfirmationPageQCodes", () => {
                   answers: [
                     {
                       id: "answer-1",
-                      qCode: "123",
+                      qCode: "answer-1-qCode",
                     },
                   ],
                 },
@@ -95,7 +97,9 @@ describe("removeConfirmationPageQCodes", () => {
 
     const result = removeConfirmationPageQCodes(questionnaire);
 
-    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe("123");
+    expect(result.sections[0].folders[0].pages[0].answers[0].qCode).toBe(
+      "answer-1-qCode"
+    );
     expect(result).toEqual(questionnaire);
   });
 


### PR DESCRIPTION
### What is the context of this PR?

Currently, some confirmation pages include a `qCode`, which is no longer a valid condition.

Adds a migration to remove `qCode` values from confirmation pages, required for the release of LCREE questionnaires. 

### How to review

Import `LCREE 0009` questionnaire.
View the questionnaire's Author schema.

An example of a confirmation page with a `qCode` value in this questionnaire prior to running the migration - the confirmation page with `pageDescription` "Confirmation of full-time equivalent employees in the onshore wind sector" has `qCode` "0261", which should be removed after the migration has been run.

**Check:**
- [ ] `qCode` values are removed from confirmation pages after the migration has been run, and no confirmation pages include a `qCode` value
- [ ] `qCode` values are not removed from any other content (e.g. answers) after the migration has been run
