### PR TITLE
EAR 2582 remove extra spaces

### DIFF
--- a/eq-author-api/migrations/index.js
+++ b/eq-author-api/migrations/index.js
@@ -55,6 +55,7 @@ const migrations = [
   require("./updateHealthThemeToPandemicMonitoring"),
   require("./addAllowableDataVersions"),
   require("./convertEmTagsToStrongTags"),
+  require("./removeExtraSpaces"),
 ];
 
 const currentVersion = migrations.length;

--- a/eq-author-api/migrations/removeExtraSpaces.js
+++ b/eq-author-api/migrations/removeExtraSpaces.js
@@ -1,0 +1,27 @@
+// Removes extra spaces from title, description, guidance, additionalInfoContent, and (answer) label fields
+const removeExtraSpaces = (questionnaire) => {
+  questionnaire.title = questionnaire.title.replace(/\s+/g, " ").trim();
+  questionnaire?.sections?.forEach((section) => {
+    section.title = section.title?.replace(/\s+/g, " ").trim();
+    section?.folders?.forEach((folder) => {
+      folder.title = folder.title?.replace(/\s+/g, " ").trim();
+      folder?.pages?.forEach((page) => {
+        page.title = page.title?.replace(/\s+/g, " ").trim();
+        page.guidance = page.guidance?.replace(/\s+/g, " ").trim();
+        page.description = page.description?.replace(/\s+/g, " ").trim();
+        page.additionalInfoContent = page.additionalInfoContent
+          ?.replace(/\s+/g, " ")
+          .trim();
+        page?.answers?.forEach((answer) => {
+          answer.label = answer.label?.replace(/\s+/g, " ").trim();
+          answer.guidance = answer.guidance?.replace(/\s+/g, " ").trim();
+          answer.description = answer.description?.replace(/\s+/g, " ").trim();
+        });
+      });
+    });
+  });
+
+  return questionnaire;
+};
+
+module.exports = (questionnaire) => removeExtraSpaces(questionnaire);

--- a/eq-author-api/migrations/removeExtraSpaces.test.js
+++ b/eq-author-api/migrations/removeExtraSpaces.test.js
@@ -1,0 +1,254 @@
+const removeExtraSpaces = require("./removeExtraSpaces");
+
+describe("removeExtraSpaces", () => {
+  describe("Questionnaire", () => {
+    it("should remove extra spaces from questionnaire title", () => {
+      const questionnaire = { title: "  Test  questionnaire  title  " };
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+
+      expect(questionnaireWithoutExtraSpaces.title).toBe(
+        "Test questionnaire title"
+      );
+    });
+  });
+
+  describe("Section", () => {
+    it("should remove extra spaces from section title", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [{ title: "  Test  section  title  " }],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(questionnaireWithoutExtraSpaces.sections[0].title).toBe(
+        "Test section title"
+      );
+    });
+  });
+
+  describe("Folder", () => {
+    it("should remove extra spaces from folder title", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            listId: "list-1",
+            title: "Section title",
+            folders: [{ title: "  Test  folder  title  " }],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(questionnaireWithoutExtraSpaces.sections[0].folders[0].title).toBe(
+        "Test folder title"
+      );
+    });
+  });
+
+  describe("Page", () => {
+    it("should remove extra spaces from page title", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    title: "  Test  page  title  ",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0].title
+      ).toBe("Test page title");
+    });
+
+    it("should remove extra spaces from page guidance", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    guidance: "  Test  page  guidance  ",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0].guidance
+      ).toBe("Test page guidance");
+    });
+
+    it("should remove extra spaces from page description", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    description: "  Test  description  ",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0]
+          .description
+      ).toBe("Test description");
+    });
+
+    it("should remove extra spaces from page additionalInfoContent", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    additionalInfoContent: "  Test  page  additional info  ",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0]
+          .additionalInfoContent
+      ).toBe("Test page additional info");
+    });
+  });
+
+  describe("Answer", () => {
+    it("should remove extra spaces from answer label", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    title: "Page title",
+                    answers: [
+                      {
+                        label: "  Test  answer  label  ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0]
+          .answers[0].label
+      ).toBe("Test answer label");
+    });
+
+    it("should remove extra spaces from answer guidance", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    title: "Page title",
+                    answers: [
+                      {
+                        guidance: "  Test  answer  guidance  ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0]
+          .answers[0].guidance
+      ).toBe("Test answer guidance");
+    });
+
+    it("should remove extra spaces from answer description", () => {
+      const questionnaire = {
+        title: "Questionnaire title",
+        sections: [
+          {
+            title: "Section title",
+            folders: [
+              {
+                title: "Folder title",
+                pages: [
+                  {
+                    title: "Page title",
+                    answers: [
+                      {
+                        description: "  Test  answer  description  ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const questionnaireWithoutExtraSpaces = removeExtraSpaces(questionnaire);
+      expect(
+        questionnaireWithoutExtraSpaces.sections[0].folders[0].pages[0]
+          .answers[0].description
+      ).toBe("Test answer description");
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

Remove extra spaces that have been identified as a requirement for the release of ABS questionnaires

### How to review

- Import an ABS schema that was identified as including extra spaces (e.g. ABS 1806)
- Open the imported ABS questionnaire
- Check that the questionnaire does not include any extra spaces that would prevent the questionnaire's release