### PR TITLE
EAR-2609: Publish only valid questionnaires

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
-      - DATABASE=firestore
+      - DATABASE=mongodb
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api

--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
-      - DATABASE=mongodb
+      - DATABASE=firestore
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -16,6 +16,8 @@ import Button from "components-themed/buttons";
 import PUBLISH_SCHEMA from "graphql/publishSchema.graphql";
 
 import PublishHistory from "./GetPublishHistory";
+import { useQuestionnaire } from "components/QuestionnaireContext";
+import { useQCodeContext } from "components/QCodeContext";
 
 const Container = styled.div`
   display: flex;
@@ -49,9 +51,12 @@ const StyledButton = styled(Button)`
 `;
 
 const PublishPage = () => {
+  const { questionnaire } = useQuestionnaire();
   const [publishSchema] = useMutation(PUBLISH_SCHEMA, {
     refetchQueries: ["GetPublishHistory"],
   });
+  const totalErrorCount = questionnaire?.totalErrorCount || 0;
+  const { hasQCodeError } = useQCodeContext();
   return (
     <Theme themeName="onsLegacyFont">
       <Container data-test="publish-page-container">
@@ -77,6 +82,7 @@ const PublishPage = () => {
               variant="primary"
               onClick={() => publishSchema()}
               data-test="btn-publish-schema"
+              disabled={totalErrorCount > 0 || hasQCodeError} // Disabled if there are any errors
             >
               Publish questionnaire
             </StyledButton>

--- a/eq-author/src/App/publish/PublishPage.test.js
+++ b/eq-author/src/App/publish/PublishPage.test.js
@@ -2,6 +2,8 @@ import React from "react";
 import { render, fireEvent } from "tests/utils/rtl";
 
 import PublishPage from "./PublishPage";
+import QuestionnaireContext from "components/QuestionnaireContext";
+import { QCodeContext } from "components/QCodeContext";
 
 const mockUseSubscription = jest.fn();
 const mockUseMutation = jest.fn();
@@ -13,15 +15,57 @@ jest.mock("@apollo/react-hooks", () => ({
   useQuery: () => [mockUseQuery],
 }));
 
+const renderPublishPage = (questionnaire, hasQCodeError, props) => {
+  return render(
+    <QuestionnaireContext.Provider value={{ questionnaire }}>
+      <QCodeContext.Provider value={{ hasQCodeError }}>
+        <PublishPage {...props} />
+      </QCodeContext.Provider>
+    </QuestionnaireContext.Provider>
+  );
+};
+
 describe("Publish page", () => {
-  const renderPublishPage = (props) => {
-    return render(<PublishPage {...props} />);
-  };
+  let questionnaire, hasQCodeError;
+  beforeEach(() => {
+    questionnaire = {
+      id: "1",
+      isPublic: true,
+    };
+    hasQCodeError = false;
+  });
 
   it("should render publish page", () => {
     const { getByTestId } = renderPublishPage();
 
     expect(getByTestId("publish-page-container")).toBeInTheDocument();
+  });
+
+  it("should enable publish button when totalErrorCount is 0 and no QCode errors", () => {
+    questionnaire.totalErrorCount = 0;
+
+    const { getByTestId } = renderPublishPage(questionnaire);
+
+    const publishButton = getByTestId("btn-publish-schema");
+    expect(publishButton).toBeEnabled();
+  });
+
+  it("should disable publish button when totalErrorCount is greater than 0", () => {
+    questionnaire.totalErrorCount = 1;
+
+    const { getByTestId } = renderPublishPage(questionnaire);
+
+    const publishButton = getByTestId("btn-publish-schema");
+    expect(publishButton).toBeDisabled();
+  });
+
+  it("should disable publish button when there are QCode errors", () => {
+    questionnaire.totalErrorCount = 0;
+    hasQCodeError = true;
+    const { getByTestId } = renderPublishPage(questionnaire, { hasQCodeError });
+
+    const publishButton = getByTestId("btn-publish-schema");
+    expect(publishButton).toBeDisabled();
   });
 
   it("should publish questionnaire on button click", () => {


### PR DESCRIPTION
### What is the context of this PR?

Changes add a 'valid' trap to the 'Publish' button, only enabling the button to trigger the publish process when the Questionnaire has no errors, and no QCodeErrors

### How to review

Launch Author
Within a questionnaire, ensure that the publish button (on the Publish page) is disabled and not clickable when there are errors with the questionnaire and/or q codes. Only when no errors from both sources should the publish button be enabled.
