### PR TITLE
EQS 30 Publish branch multiple clicks

### DIFF
--- a/eq-author-api/src/validation/customKeywords/validatePipingAnswerInLabel.js
+++ b/eq-author-api/src/validation/customKeywords/validatePipingAnswerInLabel.js
@@ -3,7 +3,6 @@ const {
   PIPING_TITLE_MOVED,
 } = require("../../../constants/validationErrorCodes");
 const createValidationError = require("../createValidationError");
-const { logger } = require("../../../utils/logger");
 
 const {
   getAbsolutePositionById,
@@ -34,12 +33,13 @@ module.exports = (ajv) =>
         rootData: questionnaire,
       }
     ) {
-      const folder = getFolderByAnswerId({ questionnaire }, parentData.id) || {};
+      const folder =
+        getFolderByAnswerId({ questionnaire }, parentData.id) || {};
       let section = {};
       if (folder.id) {
         section = getSectionByFolderId({ questionnaire }, folder.id);
       }
-    
+
       isValid.errors = [];
       const pipedIdList = [];
 
@@ -73,7 +73,6 @@ module.exports = (ajv) =>
       };
 
       for (const [pipedId, dataPiped] of pipedIdList) {
-
         if (!idExists({ questionnaire }, pipedId)) {
           return hasError(PIPING_TITLE_DELETED);
         }
@@ -87,17 +86,23 @@ module.exports = (ajv) =>
 
         if (list) {
           if (!(dataPiped === "supplementary" && list.listName === "")) {
-            if (!parentData.repeatingLabelAndInput && !section.repeatingSection  && !folder.listId ) {
-              return hasError(PIPING_TITLE_DELETED);
-            }  
-
             if (
-              (parentData.repeatingLabelAndInput && list.id !== parentData.repeatingLabelAndInputListId) ||
-              (folder.listId  &&  list.id !== folder.listId) ||
-              (section.repeatingSection  && list.id !== section.repeatingSectionListId)
+              !parentData.repeatingLabelAndInput &&
+              !section.repeatingSection &&
+              !folder.listId
             ) {
               return hasError(PIPING_TITLE_DELETED);
-            }    
+            }
+
+            if (
+              (parentData.repeatingLabelAndInput &&
+                list.id !== parentData.repeatingLabelAndInputListId) ||
+              (folder.listId && list.id !== folder.listId) ||
+              (section.repeatingSection &&
+                list.id !== section.repeatingSectionListId)
+            ) {
+              return hasError(PIPING_TITLE_DELETED);
+            }
           }
         }
 

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { withRouter } from "react-router-dom";
 import styled from "styled-components";
 import { useMutation } from "@apollo/react-hooks";
@@ -55,8 +55,20 @@ const PublishPage = () => {
   const [publishSchema] = useMutation(PUBLISH_SCHEMA, {
     refetchQueries: ["GetPublishHistory"],
   });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handlePublishButtonClick = async () => {
+    setIsLoading(true);
+    try {
+      await publishSchema();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const totalErrorCount = questionnaire?.totalErrorCount || 0;
   const { hasQCodeError } = useQCodeContext();
+
   return (
     <Theme themeName="onsLegacyFont">
       <Container data-test="publish-page-container">
@@ -80,9 +92,9 @@ const PublishPage = () => {
             </Panel>
             <StyledButton
               variant="primary"
-              onClick={() => publishSchema()}
+              onClick={handlePublishButtonClick}
               data-test="btn-publish-schema"
-              disabled={totalErrorCount > 0 || hasQCodeError} // Disabled if there are any errors
+              disabled={totalErrorCount > 0 || hasQCodeError || isLoading} // Disabled if there are any errors or if the publishSchema mutation is loading
             >
               Publish questionnaire
             </StyledButton>

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -55,14 +55,14 @@ const PublishPage = () => {
   const [publishSchema] = useMutation(PUBLISH_SCHEMA, {
     refetchQueries: ["GetPublishHistory"],
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
 
   const handlePublishButtonClick = async () => {
-    setIsLoading(true);
+    setIsPublishing(true);
     try {
       await publishSchema();
     } finally {
-      setIsLoading(false);
+      setIsPublishing(false);
     }
   };
 
@@ -94,7 +94,7 @@ const PublishPage = () => {
               variant="primary"
               onClick={handlePublishButtonClick}
               data-test="btn-publish-schema"
-              disabled={totalErrorCount > 0 || hasQCodeError || isLoading} // Disabled if there are any errors or if the publishSchema mutation is loading
+              disabled={totalErrorCount > 0 || hasQCodeError || isPublishing} // Disabled if there are any errors or if the publishSchema mutation is running
             >
               Publish questionnaire
             </StyledButton>

--- a/eq-author/src/App/publish/PublishPage.test.js
+++ b/eq-author/src/App/publish/PublishPage.test.js
@@ -35,6 +35,10 @@ describe("Publish page", () => {
     hasQCodeError = false;
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should render publish page", () => {
     const { getByTestId } = renderPublishPage();
 
@@ -75,5 +79,38 @@ describe("Publish page", () => {
     fireEvent.click(publishButton);
 
     expect(mockUseMutation).toHaveBeenCalledTimes(1);
+  });
+
+  describe("Button state", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should disable the publish button while publishing", () => {
+      const { getByTestId } = renderPublishPage();
+
+      const publishButton = getByTestId("btn-publish-schema");
+      expect(publishButton).not.toBeDisabled();
+
+      fireEvent.click(publishButton);
+
+      expect(mockUseMutation).toHaveBeenCalledTimes(1);
+      expect(publishButton).toBeDisabled();
+    });
+
+    it("should re-enable the publish button after publishing is complete", async () => {
+      const { getByTestId } = renderPublishPage();
+
+      const publishButton = getByTestId("btn-publish-schema");
+      fireEvent.click(publishButton);
+
+      expect(mockUseMutation).toHaveBeenCalledTimes(1);
+      expect(publishButton).toBeDisabled();
+
+      // Mocks the completion of the mutation
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(publishButton).not.toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?

Disables the publish button while the publish process is running - this prevents users triggering multiple publishes before the initial publish is completed.

https://jira.ons.gov.uk/browse/EQS-30

### How to review

- Create a questionnaire and fix all errors
- Open the "Publish" page
- Set throttling to 3G (Chrome console -> Network -> Change the "No throttling" dropdown to "3G")
- Check that the button is disabled once it is clicked, and automatically re-enabled once the publish process has finished