### PR TITLE
EAR-2584 Present publish pass/fail

### DIFF
--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
-      - DATABASE=firestore
+      - DATABASE=mongodb
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api

--- a/eq-author-api/docker-compose.yml
+++ b/eq-author-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - REDIS_DOMAIN_NAME=redis
       - REDIS_PORT=6379
-      - DATABASE=mongodb
+      - DATABASE=firestore
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8070
       - FIRESTORE_PROJECT_ID=eq-author-api
       - GOOGLE_AUTH_PROJECT_ID=eq-author-api

--- a/eq-author-api/schema/resolvers/base.js
+++ b/eq-author-api/schema/resolvers/base.js
@@ -1611,6 +1611,7 @@ const Resolvers = {
       ).catch((e) => {
         publishResult.success = false;
         publishResult.errorMessage = `Failed to fetch questionnaire - ${e.message}`;
+        publishResult.displayErrorMessage = "Publish error, please try later";
       });
 
       if (publishResult.success === false) {
@@ -1620,6 +1621,7 @@ const Resolvers = {
       if (convertedResponse.status !== 200) {
         publishResult.success = false;
         publishResult.errorMessage = `Publisher failed to convert questionnaire - ${convertedResponse.statusText}`;
+        publishResult.displayErrorMessage = "Contact eQ services team";
         return ctx.questionnaire;
       }
 
@@ -1643,11 +1645,13 @@ const Resolvers = {
           } else {
             publishResult.success = false;
             publishResult.errorMessage = `Invalid response - failed with error code ${res.status}`;
+            publishResult.displayErrorMessage = "Contact eQ services team";
           }
         })
         .catch((e) => {
           publishResult.success = false;
           publishResult.errorMessage = `Failed to publish questionnaire - ${e.message}`;
+          publishResult.displayErrorMessage = "Publish error, please try later";
         });
 
       return ctx.questionnaire;

--- a/eq-author-api/schema/tests/publishSchema.test.js
+++ b/eq-author-api/schema/tests/publishSchema.test.js
@@ -102,6 +102,7 @@ describe("publish schema", () => {
         publishDate: expect.any(Date),
         success: false,
         errorMessage: "Failed to fetch questionnaire - Test error",
+        displayErrorMessage: "Publish error, please try later",
       },
     ]);
   });
@@ -133,6 +134,7 @@ describe("publish schema", () => {
         success: false,
         errorMessage:
           "Publisher failed to convert questionnaire - Server error",
+        displayErrorMessage: "Contact eQ services team",
       },
     ]);
   });
@@ -158,6 +160,7 @@ describe("publish schema", () => {
         publishDate: expect.any(Date),
         success: false,
         errorMessage: "Failed to publish questionnaire - Test error",
+        displayErrorMessage: "Publish error, please try later",
       },
     ]);
   });

--- a/eq-author-api/schema/typeDefs.js
+++ b/eq-author-api/schema/typeDefs.js
@@ -912,6 +912,7 @@ type PublishHistoryEvent {
   publishDate: DateTime
   success: Boolean
   errorMessage: String
+  displayErrorMessage: String
 }
 
 type Query {

--- a/eq-author-api/tests/utils/contextBuilder/publishSchema/publishSchema.js
+++ b/eq-author-api/tests/utils/contextBuilder/publishSchema/publishSchema.js
@@ -53,6 +53,7 @@ const publishSchemaMutation = `
             cirId
             cirVersion
             errorMessage
+            displayErrorMessage
             formType
             publishDate
             success

--- a/eq-author/src/App/publish/GetPublishHistory.graphql
+++ b/eq-author/src/App/publish/GetPublishHistory.graphql
@@ -8,5 +8,6 @@ query GetPublishHistory {
     publishDate
     success
     errorMessage
+    displayErrorMessage
   }
 }

--- a/eq-author/src/App/publish/GetPublishHistory.js
+++ b/eq-author/src/App/publish/GetPublishHistory.js
@@ -119,7 +119,7 @@ const PublishHistory = () => {
                     <td>
                       {historyItem.success
                         ? "Success"
-                        : "Failed: " + historyItem.displayErrorMessage}
+                        : `Failed: ${historyItem.displayErrorMessage}`}
                     </td>
                   </tr>
                 );

--- a/eq-author/src/App/publish/GetPublishHistory.js
+++ b/eq-author/src/App/publish/GetPublishHistory.js
@@ -75,7 +75,6 @@ const PublishHistory = () => {
   if (data) {
     if (data.publishHistory) {
       historyItems = data.publishHistory
-        .filter((event) => event.success)
         .map((obj) => {
           return { ...obj, publishDate: new Date(obj.publishDate) };
         })
@@ -105,6 +104,7 @@ const PublishHistory = () => {
                 <th>Form type</th>
                 <th>CIR ID</th>
                 <th>CIR version</th>
+                <th>Publish result</th>
               </tr>
             </thead>
             <tbody>
@@ -116,6 +116,11 @@ const PublishHistory = () => {
                     <td>{historyItem.formType}</td>
                     <td>{historyItem.cirId}</td>
                     <td>{historyItem.cirVersion}</td>
+                    <td>
+                      {historyItem.success
+                        ? "Success"
+                        : "Failed: " + historyItem.displayErrorMessage}
+                    </td>
                   </tr>
                 );
               })}

--- a/eq-author/src/App/publish/GetPublishHistory.test.js
+++ b/eq-author/src/App/publish/GetPublishHistory.test.js
@@ -65,6 +65,8 @@ describe("Test valid return", () => {
           formType: "0005",
           publishDate: "2023-05-18T13:33:16.465Z",
           success: false,
+          errorMessage: "Error message",
+          displayErrorMessage: "Publish error, please try later",
         },
         {
           id: "459f73a5-5522-454f-8bda-dfa97ad65376",
@@ -106,17 +108,27 @@ describe("Test valid return", () => {
     expect(text).not.toBeInTheDocument();
   });
 
-  it("Should return history table and have 3 rows", async () => {
+  it("Should return history table and have 4 rows", async () => {
     render(<PublishHistory />);
-    // Row count of 4, to include header, but remove entry with 'success: false'
     const trElements = screen.getAllByRole("row");
-    expect(trElements).toHaveLength(4);
+    expect(trElements).toHaveLength(5);
   });
 
   it("Should return history table and be in date order, most recent first", async () => {
     render(<PublishHistory />);
     expect(screen.getAllByRole("row")[1]).toHaveTextContent("22/05/2023");
     expect(screen.getAllByRole("row")[2]).toHaveTextContent("19/05/2023");
-    expect(screen.getAllByRole("row")[3]).toHaveTextContent("17/05/2023");
+    expect(screen.getAllByRole("row")[3]).toHaveTextContent("18/05/2023");
+    expect(screen.getAllByRole("row")[4]).toHaveTextContent("17/05/2023");
+  });
+
+  it("Should return history table with success or failure message", async () => {
+    render(<PublishHistory />);
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("Success");
+    expect(screen.getAllByRole("row")[2]).toHaveTextContent("Success");
+    expect(screen.getAllByRole("row")[3]).toHaveTextContent(
+      "Failed: Publish error, please try later"
+    );
+    expect(screen.getAllByRole("row")[4]).toHaveTextContent("Success");
   });
 });

--- a/eq-author/src/App/publish/PublishPage.js
+++ b/eq-author/src/App/publish/PublishPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { withRouter } from "react-router-dom";
 import styled from "styled-components";
 import { useMutation } from "@apollo/react-hooks";
@@ -18,6 +18,8 @@ import PUBLISH_SCHEMA from "graphql/publishSchema.graphql";
 import PublishHistory from "./GetPublishHistory";
 import { useQuestionnaire } from "components/QuestionnaireContext";
 import { useQCodeContext } from "components/QCodeContext";
+
+import { ToastContext } from "components/Toasts";
 
 const Container = styled.div`
   display: flex;
@@ -52,8 +54,19 @@ const StyledButton = styled(Button)`
 
 const PublishPage = () => {
   const { questionnaire } = useQuestionnaire();
+  const { showToast } = useContext(ToastContext);
+
   const [publishSchema] = useMutation(PUBLISH_SCHEMA, {
     refetchQueries: ["GetPublishHistory"],
+    onCompleted: (data) => {
+      const history = data?.publishSchema?.publishHistory;
+      const latestEntry = history && history[history.length - 1];
+      if (latestEntry && !latestEntry.success) {
+        showToast("Publish failed");
+      } else {
+        showToast("Publish successful");
+      }
+    },
   });
   const totalErrorCount = questionnaire?.totalErrorCount || 0;
   const { hasQCodeError } = useQCodeContext();

--- a/eq-author/src/App/publish/PublishPage.test.js
+++ b/eq-author/src/App/publish/PublishPage.test.js
@@ -4,6 +4,7 @@ import { render, fireEvent } from "tests/utils/rtl";
 import PublishPage from "./PublishPage";
 import QuestionnaireContext from "components/QuestionnaireContext";
 import { QCodeContext } from "components/QCodeContext";
+import { ToastContext } from "components/Toasts";
 
 const mockUseSubscription = jest.fn();
 const mockUseMutation = jest.fn();
@@ -75,5 +76,91 @@ describe("Publish page", () => {
     fireEvent.click(publishButton);
 
     expect(mockUseMutation).toHaveBeenCalledTimes(1);
+  });
+});
+describe("onCompleted callback in useMutation", () => {
+  let questionnaire, hasQCodeError, showToastMock, onCompletedCallback;
+
+  beforeEach(() => {
+    questionnaire = { id: "1", totalErrorCount: 0 };
+    hasQCodeError = false;
+    showToastMock = jest.fn();
+
+    // Capture the onCompleted callback passed to useMutation
+    jest
+      .spyOn(require("@apollo/react-hooks"), "useMutation")
+      .mockImplementation((_, opts) => {
+        onCompletedCallback = opts.onCompleted;
+        return [jest.fn()];
+      });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderWithToast = () =>
+    render(
+      <QuestionnaireContext.Provider value={{ questionnaire }}>
+        <QCodeContext.Provider value={{ hasQCodeError }}>
+          <ToastContext.Provider value={{ showToast: showToastMock }}>
+            <PublishPage />
+          </ToastContext.Provider>
+        </QCodeContext.Provider>
+      </QuestionnaireContext.Provider>
+    );
+
+  it("should show 'Publish successful' when latest publish entry is successful", () => {
+    renderWithToast();
+    const data = {
+      publishSchema: {
+        publishHistory: [
+          { id: "1", success: false },
+          { id: "2", success: true },
+        ],
+      },
+    };
+    onCompletedCallback(data);
+    expect(showToastMock).toHaveBeenCalledWith("Publish successful");
+  });
+
+  it("should show 'Publish failed' when latest publish entry is not successful", () => {
+    renderWithToast();
+    const data = {
+      publishSchema: {
+        publishHistory: [
+          { id: "1", success: true },
+          { id: "2", success: false },
+        ],
+      },
+    };
+    onCompletedCallback(data);
+    expect(showToastMock).toHaveBeenCalledWith("Publish failed");
+  });
+
+  it("should show 'Publish successful' when publishHistory is empty", () => {
+    renderWithToast();
+    const data = {
+      publishSchema: {
+        publishHistory: [],
+      },
+    };
+    onCompletedCallback(data);
+    expect(showToastMock).toHaveBeenCalledWith("Publish successful");
+  });
+
+  it("should show 'Publish successful' when publishHistory is undefined", () => {
+    renderWithToast();
+    const data = {
+      publishSchema: {},
+    };
+    onCompletedCallback(data);
+    expect(showToastMock).toHaveBeenCalledWith("Publish successful");
+  });
+
+  it("should show 'Publish successful' when data is undefined", () => {
+    renderWithToast();
+    onCompletedCallback(undefined);
+    expect(showToastMock).toHaveBeenCalledWith("Publish successful");
   });
 });

--- a/eq-author/src/components/Toasts/index.js
+++ b/eq-author/src/components/Toasts/index.js
@@ -6,7 +6,7 @@ import ToastContainer from "./ToastContainer";
 
 let id = 0;
 
-const ToastContext = createContext({
+export const ToastContext = createContext({
   showToast: () => {},
 });
 

--- a/eq-author/src/graphql/publishSchema.graphql
+++ b/eq-author/src/graphql/publishSchema.graphql
@@ -5,6 +5,7 @@ mutation publishSchema {
       cirId
       cirVersion
       errorMessage
+      displayErrorMessage
       formType
       publishDate
       success


### PR DESCRIPTION
### What is the context of this PR?

Updates to the Publish page.

- Adds additional column to the Publish History table, to indicate whether the publish was successful or not
- Removes the block on the table showing failed publishes
- Adds a toast to indicate success or fail of the publish

Updates to the API

- Adds new conditional field to the API response, `displayErrorMessage`, to allow for a specific message related to the type of error, to be presented in the Publish History table. If the api call is successful no value is added (as with the errorMessage field)

Note these changes only add the presentation to the existing error responses. Future tickets will add the functionality for other failure points.

### How to review

- Create/use a questionnaire without errors (to enable the Publish button)
- With 'publisher' service off, click the Publish button
- Publish History table should be added, but the entry should have a failure message in the final column, and a toast message of 'Publish failed' should be triggered
- With 'publisher' service enabled, click the Publish button
- Publish History table should be updated, and the entry should have a success message in the final column, and a toast message of 'Publish successful' should be triggered
