### PR TITLE
updated cloudbuild

### DIFF
--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -5,7 +5,7 @@ steps:
       - "-feq-author-api/docker-compose-ci.yml"
       - up
       - "-d"
-  - name: "node:17"
+  - name: "node:14"
     env:
       - BABEL_ENV=test
       - NODE_ENV=test
@@ -21,16 +21,6 @@ steps:
         yarn --frozen-lockfile
         yarn lint
         yarn test:ci --coverage
-        [ $? -eq 0 ]  || exit 1
-        export percent=$(jq .total.lines.pct coverage/coverage-summary.json)
-        echo "************************"
-        echo "Target coverage: $_COVERAGE_LEVEL%"
-        echo "************************"
-        echo "************************"
-        echo "Coverage: $percent%"
-        echo "************************"
-        export result=$(echo "$percent > $_COVERAGE_LEVEL" | bc)
-        exit $(( 1 - $result ))
     id: unit_tests
     entrypoint: /bin/bash
 timeout: 1200s

--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -1,6 +1,7 @@
 steps:
-  - name: gcr.io/$PROJECT_ID/docker-compose
+  - name: gcr.io/cloud-builders/docker
     args:
+      - "compose"
       - "-feq-author-api/docker-compose-ci.yml"
       - up
       - "-d"

--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -5,7 +5,7 @@ steps:
       - "-feq-author-api/docker-compose-ci.yml"
       - up
       - "-d"
-  - name: "node:18"
+  - name: "node:17"
     env:
       - BABEL_ENV=test
       - NODE_ENV=test

--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -5,7 +5,7 @@ steps:
       - "-feq-author-api/docker-compose-ci.yml"
       - up
       - "-d"
-  - name: "node:14"
+  - name: "node:16"
     env:
       - BABEL_ENV=test
       - NODE_ENV=test
@@ -14,8 +14,8 @@ steps:
     args:
       - "-c"
       - |
-        apt-get update
-        apt-get install -y jq bc
+        apt update
+        apt install -y jq bc
         yarn --frozen-lockfile
         cd eq-author-api
         yarn --frozen-lockfile

--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -5,7 +5,7 @@ steps:
       - "-feq-author-api/docker-compose-ci.yml"
       - up
       - "-d"
-  - name: "node:16"
+  - name: "node:18"
     env:
       - BABEL_ENV=test
       - NODE_ENV=test

--- a/cloudbuild-author-api-tests.yaml
+++ b/cloudbuild-author-api-tests.yaml
@@ -14,8 +14,8 @@ steps:
     args:
       - "-c"
       - |
-        apt update
-        apt install -y jq bc
+        apt-get update
+        apt-get install -y jq bc
         yarn --frozen-lockfile
         cd eq-author-api
         yarn --frozen-lockfile


### PR DESCRIPTION
Fix for broken API tests
Since the removal of the container registry in GCP, the API test have not been able to run due to missing docker compose image.
Cloud builders have since added docker compose support to the docker cloud builder. 
The cloud build script has been updated to use this
Removed coverage result output as JQ is no longer supported in node 14. This can be reintroduced at a later date.