### PR TITLE
add check for GIUD

### DIFF
--- a/eq-author-api/schema/resolvers/utils/publishSchema.js
+++ b/eq-author-api/schema/resolvers/utils/publishSchema.js
@@ -150,10 +150,19 @@ const publishSchema = async (ctx) => {
       `guid=${ctx.questionnaire.questionnaireVersionId}&validator_version=0.0.0`,
       publishResult
     );
+
+    //check CIR id matches the versionId to ensure the correct GUID has been used in CIR
+    if(publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
+            publishResult.success = false;
+            publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
+            publishResult.displayErrorMessage = "Contact eQ services team";
+    };
+
     logger.info(
       publishResult,
       `publish questionnaire with version id ${ctx.questionnaire.questionnaireVersionId}  - posted to first CIR gateway`
     );
+
 
     // post to second gateway if enabled and first gateway publish was successful
     // The ci_vserion is added to the second post to ensure the CI in both environments can be referenced by the same ci version number
@@ -168,18 +177,21 @@ const publishSchema = async (ctx) => {
         `guid=${ctx.questionnaire.questionnaireVersionId}&validator_version=0.0.0&&ci_version=${publishResult.cirVersion}`,
         publishResult
       );
-    }
-    logger.info(
-      publishResult,
-      `publish questionnaire with version id ${ctx.questionnaire.questionnaireVersionId}  - posted to second CIR gateway`
-    );
 
-    //check CIR id matches the versionId to ensure the correct GUID has been used in CIR, commented out until CIR complete thier work to return the GUID
-    /* if(publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
-            publishResult.success = false;
-            publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
-            publishResult.displayErrorMessage = "Contact eQ services team";
-        } */
+      //check CIR id matches the versionId to ensure the correct GUID has been used in CIR
+      if(publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
+              publishResult.success = false;
+              publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
+              publishResult.displayErrorMessage = "Contact eQ services team";
+      };
+
+      logger.info(
+        publishResult,
+        `publish questionnaire with version id ${ctx.questionnaire.questionnaireVersionId}  - posted to second CIR gateway`
+      );
+    }
+
+
   } finally {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Publish failed");

--- a/eq-author-api/schema/resolvers/utils/publishSchema.js
+++ b/eq-author-api/schema/resolvers/utils/publishSchema.js
@@ -193,9 +193,9 @@ const publishSchema = async (ctx) => {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Publish failed");
     }
-    await saveMetadata(questionnaireMetadata);
-    return questionnaireMetadata.publishHistory;
   }
+  await saveMetadata(questionnaireMetadata);
+  return questionnaireMetadata.publishHistory;
 };
 
 const republishSchema = async (questionnaireVersionId, cirVersion) => {
@@ -284,9 +284,9 @@ const republishSchema = async (questionnaireVersionId, cirVersion) => {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Republish failed");
     }
-    await saveMetadata(questionnaireMetadata);
-    return publishResult;
   }
+  await saveMetadata(questionnaireMetadata);
+  return publishResult;
 };
 
 module.exports = {

--- a/eq-author-api/schema/resolvers/utils/publishSchema.js
+++ b/eq-author-api/schema/resolvers/utils/publishSchema.js
@@ -152,17 +152,16 @@ const publishSchema = async (ctx) => {
     );
 
     //check CIR id matches the versionId to ensure the correct GUID has been used in CIR
-    if(publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
-            publishResult.success = false;
-            publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
-            publishResult.displayErrorMessage = "Contact eQ services team";
-    };
+    if (publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
+      publishResult.success = false;
+      publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
+      publishResult.displayErrorMessage = "Contact eQ services team";
+    }
 
     logger.info(
       publishResult,
       `publish questionnaire with version id ${ctx.questionnaire.questionnaireVersionId}  - posted to first CIR gateway`
     );
-
 
     // post to second gateway if enabled and first gateway publish was successful
     // The ci_vserion is added to the second post to ensure the CI in both environments can be referenced by the same ci version number
@@ -179,19 +178,17 @@ const publishSchema = async (ctx) => {
       );
 
       //check CIR id matches the versionId to ensure the correct GUID has been used in CIR
-      if(publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
-              publishResult.success = false;
-              publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
-              publishResult.displayErrorMessage = "Contact eQ services team";
-      };
+      if (publishResult.cirId !== ctx.questionnaire.questionnaireVersionId) {
+        publishResult.success = false;
+        publishResult.errorMessage = `CIR gateway did not return expected guid - expected ${ctx.questionnaire.questionnaireVersionId} but got ${publishResult.cirId}`;
+        publishResult.displayErrorMessage = "Contact eQ services team";
+      }
 
       logger.info(
         publishResult,
         `publish questionnaire with version id ${ctx.questionnaire.questionnaireVersionId}  - posted to second CIR gateway`
       );
     }
-
-
   } finally {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Publish failed");

--- a/eq-author-api/schema/resolvers/utils/publishSchema.js
+++ b/eq-author-api/schema/resolvers/utils/publishSchema.js
@@ -193,9 +193,9 @@ const publishSchema = async (ctx) => {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Publish failed");
     }
+    await saveMetadata(questionnaireMetadata);
+    return questionnaireMetadata.publishHistory;
   }
-  await saveMetadata(questionnaireMetadata);
-  return questionnaireMetadata.publishHistory;
 };
 
 const republishSchema = async (questionnaireVersionId, cirVersion) => {
@@ -284,9 +284,9 @@ const republishSchema = async (questionnaireVersionId, cirVersion) => {
     if (!publishResult.success) {
       logger.error(publishResult.errorMessage, "Republish failed");
     }
+    await saveMetadata(questionnaireMetadata);
+    return publishResult;
   }
-  await saveMetadata(questionnaireMetadata);
-  return publishResult;
 };
 
 module.exports = {

--- a/eq-author-api/schema/tests/publishSchema.test.js
+++ b/eq-author-api/schema/tests/publishSchema.test.js
@@ -34,6 +34,7 @@ describe("publish schema", () => {
   });
 
   it("should return a successful publish result", async () => {
+    ctx.questionnaire.questionnaireVersionId = "cir-id-1";
     expect(await publishSchema(ctx)).toEqual([
       {
         id: expect.any(String),
@@ -50,6 +51,7 @@ describe("publish schema", () => {
   });
 
   it("should add to publishHistory if publishHistory is defined", async () => {
+    ctx.questionnaire.questionnaireVersionId = "cir-id-1";
     await publishSchema(ctx);
     ctx.questionnaire.questionnaireVersionId = "cir-id-1";
     expect(await publishSchema(ctx)).toEqual([


### PR DESCRIPTION
This PR adds checks to ensure the right GUID is returned from CIR.
When publishing to CIR we provide a GUID, this check ensures the GUID that is returned for CIR is the same as the one we provided. 
